### PR TITLE
fix(squid): Fill `destination.ip` if we are facing an IP

### DIFF
--- a/Squid/squid/ingest/parser.yml
+++ b/Squid/squid/ingest/parser.yml
@@ -49,7 +49,7 @@ pipeline:
       properties:
         input_field: parsed_event.message.url
         output_field: message
-        pattern: '%{NOTSPACE:domain}:%{NUMBER:port}'
+        pattern: '(%{IP:ip}|%{NOTSPACE:domain}):%{NUMBER:port}'
     filter: '{{parsed_event.message.method == "CONNECT"}}'
   - name: set_base_fields
 
@@ -141,13 +141,14 @@ stages:
 
       - set:
           destination.ip: '{{parsed_event.message.peerhostip}}'
-        filter: '{{parsed_event.message.method != "CONNECT" and parsed_event.message.peerhost != "-"}}'
+        filter: '{{parsed_event.message.method != "CONNECT" and parsed_event.message.peerhostip != "-"}}'
 
       - set:
           url.full: '{{parsed_event.message.url}}'
         filter: '{{parsed_event.message.method != "CONNECT" and parsed_event.message.url.startswith("http")}}'
 
       - set:
+          destination.ip: '{{url.message.ip}}'
           destination.domain: '{{url.message.domain}}'
           destination.port: '{{url.message.port}}'
         filter: '{{parsed_event.message.method == "CONNECT"}}'

--- a/Squid/squid/tests/connect_ip.json
+++ b/Squid/squid/tests/connect_ip.json
@@ -1,0 +1,65 @@
+{
+  "input": {
+    "message": "1642667037.129      0 10.0.4.4 TCP_DENIED/403 3868 CONNECT 45.138.98.34:80 - HIER_NONE/- text/html \"-\" \"-\"",
+    "sekoiaio": {
+      "intake": {
+        "dialect": "squid",
+        "dialect_uuid": "a0dbb8f3-ca1c-4c6b-aafa-595bd430c0cb"
+      }
+    }
+  },
+  "expected": {
+    "message": "1564655684.277   3387 192.168.0.1 TCP_TUNNEL/200 19131 CONNECT example.org:443 - HIER_DIRECT/example.org -",
+    "event": {
+      "category": [
+        "web",
+        "network"
+      ],
+      "kind": "event",
+      "duration": 0,
+      "start": "2022-01-20T08:23:57.129000+00:00",
+      "type": [
+        "connection",
+        "denied",
+        "error"
+      ]
+    },
+    "source": {
+      "address": "10.0.4.4",
+      "ip": "10.0.4.4"
+    },
+    "destination": {
+      "address": "45.138.98.34",
+      "ip": "45.138.98.34",
+      "port": 80
+    },
+    "http": {
+      "request": {
+        "method": "CONNECT"
+      },
+      "response": {
+        "bytes": 3868,
+        "status_code": 403,
+        "mime_type": "text/html"
+      }
+    },
+    "network": {
+      "transport": "tcp",
+      "direction": "egress"
+    },
+    "related": {
+      "ip": [
+        "10.0.4.4"
+      ]
+    },
+    "squid": {
+      "hierarchy_code": "HIER_NONE",
+      "cache_status": "denied"
+    },
+    "observer": {
+      "product": "Squid",
+      "type": "proxy",
+      "vendor": "Squid"
+    }
+  }
+}


### PR DESCRIPTION
In the previous implementation, in some situations we pushed IPs in the `destination.domain` field.