### PR TITLE
ci: Trigger a documentation rebuild on merged PR

### DIFF
--- a/.github/workflows/trigger-documentation-rebuild.yaml
+++ b/.github/workflows/trigger-documentation-rebuild.yaml
@@ -1,0 +1,24 @@
+name: Trigger a documentation rebuild
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: my-app-install token
+      id: my-app
+      uses: getsentry/action-github-app-token@v1
+      with:
+        app_id: ${{ secrets.DISPATCH_APP_ID }}
+        private_key: ${{ secrets.DISPATCH_APP_SECRET_KEY }}
+
+    - name: Repository Dispatch
+      uses: peter-evans/repository-dispatch@v1
+      with:
+        token: ${{ steps.my-app.outputs.token }}
+        event-type: rebuild-intake-documentation


### PR DESCRIPTION
Use [`getsentry/action-github-app-token@v1`](https://github.com/getsentry/action-github-app-token) action with a dedicated GitHub App to push a `repository_dispatch` event to the documentation repository when a the `master` branch is updated.

Dedicated application has limited rights to the https://github.com/SEKOIA-IO/documentation repository.

To work as expected, this requires https://github.com/SEKOIA-IO/documentation/pull/202 to be merged.