### PR TITLE
fix(azure-linux): fix failing when Msg field missing

### DIFF
--- a/Azure/azure-linux/ingest/parser.yml
+++ b/Azure/azure-linux/ingest/parser.yml
@@ -112,6 +112,7 @@ pipeline:
     filter: '{{json_event.message.properties.ident == "sudo"}}'
     external: null
   - name: grok_omsagent
+    filter: '{{json_event.message.properties.Msg is defined }}'
     external:
       name: grok.match
       properties:
@@ -120,7 +121,7 @@ pipeline:
         pattern: 'omsagent : %{GREEDYDATA:omsagent_message}'
         custom_patterns: {}
   - name: omsagent
-    filter: '{{ grok_omsagent.result.omsagent_message != null }}'
+    filter: '{{ grok_omsagent and grok_omsagent.result.omsagent_message != null }}'
     external:
       name: kv.parse-kv
       properties:
@@ -129,7 +130,7 @@ pipeline:
         value_sep: '='
         item_sep: \s;\s
   - name: grok2_omsagent
-    filter: '{{ grok_omsagent.result.omsagent_message != null }}'
+    filter: '{{ grok_omsagent and grok_omsagent.result.omsagent_message != null }}'
     external:
       name: grok.match
       properties:
@@ -138,7 +139,7 @@ pipeline:
         pattern: '%{UNIXPATH:process_executable}( %{GREEDYDATA:process_args})?'
         custom_patterns: {}
   - name: omsagent2
-    filter: '{{ grok_omsagent.result.omsagent_message != null }}'
+    filter: '{{ grok_omsagent and grok_omsagent.result.omsagent_message != null }}'
     external: null
   - name: action-outcome
     filter: >-


### PR DESCRIPTION
Do not fail parsing if `properties.Msg` is missing