### PR TITLE
fix(azure-linux): fix missing properties check

### DIFF
--- a/Azure/azure-linux/ingest/parser.yml
+++ b/Azure/azure-linux/ingest/parser.yml
@@ -8,8 +8,9 @@ pipeline:
         output_field: message
   - name: stage2
     external: null
+    filter: '{{"properties" in json_event.message}}'
   - name: grok_sshd
-    filter: '{{json_event.message.properties.ident == "sshd"}}'
+    filter: '{{"properties" in json_event.message and json_event.message.properties.ident == "sshd"}}'
     external:
       name: grok.match
       properties:
@@ -60,10 +61,10 @@ pipeline:
             %{SSHD_CLIENT_ADDRESS} port %{NUMBER:source_port}
           SSHD_MESSAGE_IDENTIFICATION_NOT_RECEIVED: Did not receive identification
   - name: sshd
-    filter: '{{json_event.message.properties.ident == "sshd"}}'
+    filter: '{{"properties" in json_event.message and json_event.message.properties.ident == "sshd"}}'
     external: null
   - name: grok_systemd
-    filter: '{{json_event.message.properties.ident == "systemd"}}'
+    filter: '{{"properties" in json_event.message and json_event.message.properties.ident == "systemd"}}'
     external:
       name: grok.match
       properties:
@@ -74,10 +75,10 @@ pipeline:
           %{USERNAME:user_name}.
         custom_patterns: {}
   - name: systemd
-    filter: '{{json_event.message.properties.ident == "systemd"}}'
+    filter: '{{"properties" in json_event.message and json_event.message.properties.ident == "systemd"}}'
     external: null
   - name: grok_crond
-    filter: '{{json_event.message.properties.ident == "CROND"}}'
+    filter: '{{"properties" in json_event.message and json_event.message.properties.ident == "CROND"}}'
     external:
       name: grok.match
       properties:
@@ -89,10 +90,10 @@ pipeline:
         custom_patterns:
           CMD_WITH_PATH: '%{UNIXPATH:process_executable} %{GREEDYDATA:process_args}'
   - name: crond
-    filter: '{{json_event.message.properties.ident == "CROND"}}'
+    filter: '{{"properties" in json_event.message and json_event.message.properties.ident == "CROND"}}'
     external: null
   - name: grok_sudo
-    filter: '{{json_event.message.properties.ident == "sudo"}}'
+    filter: '{{"properties" in json_event.message and json_event.message.properties.ident == "sudo"}}'
     external:
       name: grok.match
       properties:
@@ -109,10 +110,10 @@ pipeline:
             pam_%{GREEDYDATA}\(%{GREEDYDATA:action_name}\): auth could not
             identify password for \[%{USERNAME:user_name}\]
   - name: sudo
-    filter: '{{json_event.message.properties.ident == "sudo"}}'
+    filter: '{{"properties" in json_event.message and json_event.message.properties.ident == "sudo"}}'
     external: null
   - name: grok_omsagent
-    filter: '{{json_event.message.properties.Msg is defined }}'
+    filter: '{{"properties" in json_event.message and json_event.message.properties.Msg is defined }}'
     external:
       name: grok.match
       properties:
@@ -121,7 +122,7 @@ pipeline:
         pattern: 'omsagent : %{GREEDYDATA:omsagent_message}'
         custom_patterns: {}
   - name: omsagent
-    filter: '{{ grok_omsagent and grok_omsagent.result.omsagent_message != null }}'
+    filter: '{{"properties" in json_event.message and grok_omsagent and grok_omsagent.result.omsagent_message != null }}'
     external:
       name: kv.parse-kv
       properties:
@@ -130,7 +131,7 @@ pipeline:
         value_sep: '='
         item_sep: \s;\s
   - name: grok2_omsagent
-    filter: '{{ grok_omsagent and grok_omsagent.result.omsagent_message != null }}'
+    filter: '{{"properties" in json_event.message and grok_omsagent and grok_omsagent.result.omsagent_message != null }}'
     external:
       name: grok.match
       properties:
@@ -139,11 +140,12 @@ pipeline:
         pattern: '%{UNIXPATH:process_executable}( %{GREEDYDATA:process_args})?'
         custom_patterns: {}
   - name: omsagent2
-    filter: '{{ grok_omsagent and grok_omsagent.result.omsagent_message != null }}'
+    filter: '{{"properties" in json_event.message and grok_omsagent and grok_omsagent.result.omsagent_message != null }}'
     external: null
   - name: action-outcome
     filter: >-
-      {{json_event.message.properties.ident == "systemd" or
+      {{"properties" in json_event.message and
+      json_event.message.properties.ident == "systemd" or
       json_event.message.properties.ident == "sudo"}}
     external: null
 stages:


### PR DESCRIPTION
Add some checks to not fail parsing when message doesn't contain `properties`