### PR TITLE
feat(Stormshield): Verify that startime is not empty before parsing.

### DIFF
--- a/Stormshield/stormshield_network_security/ingest/parser.yml
+++ b/Stormshield/stormshield_network_security/ingest/parser.yml
@@ -21,6 +21,7 @@ pipeline:
         # Time difference between the Firewall’s time and GMT. This depends on the time zone used.
         # String in “+HHMM” or “-HHMM” format.
         format: "%Y-%m-%d %H:%M:%S%z"
+    filter: '{{kv.result.time != "" }}'
 
   - name: parsed_startime
     external:
@@ -29,6 +30,8 @@ pipeline:
         input_field: "{{kv.result.startime}}{{kv.result.tz}}" #startime="2022-03-03 14:21:10"
         output_field: date
         format: "%Y-%m-%d %H:%M:%S%z"
+    filter: '{{kv.result.startime != "" }}'
+
 
   - name: stage2
 

--- a/Stormshield/stormshield_network_security/tests/filter.json
+++ b/Stormshield/stormshield_network_security/tests/filter.json
@@ -6,7 +6,7 @@
         "dialect_uuid": "79029ef9-e5d3-44f3-b70f-fd3b54ba1fe4"
       }
     },
-    "message": "time=\"2022-03-03 14:21:10\" fw=\"SN12345678912345\" tz=+0100 startime=\"2022-03-03 14:21:10\" pri=5 confid=01 slotlevel=2 ruleid=100 srcif=\"Ethernet3\" srcifname=\"in\" ipproto=tcp dstif=\"Ethernet2\" dstifname=\"out\" proto=https src=42.123.123.123 srcport=60355 srcportname=ad2009-dyn_tcp srcname=DLEM-AMPD02 srcmac=00:5e:6f:3q:78:30 dst=424.321.123.42 dstport=443 dstportname=https dstname=example_dest dstcontinent=\"na\" dstcountry=\"us\" ipv=4 sent=0 rcvd=0 duration=2.00 action=pass logtype=\"filter\""
+    "message": "time=\"2022-03-03 14:21:10\" fw=\"SN12345678912345\" tz=+0100 startime=\"2022-03-03 14:21:10\" pri=5 confid=01 slotlevel=2 ruleid=100 srcif=\"Ethernet3\" srcifname=\"in\" ipproto=tcp dstif=\"Ethernet2\" dstifname=\"out\" proto=https src=42.123.123.123 srcport=60355 srcportname=ad2009-dyn_tcp srcname=DLEM-AMPD02 srcmac=00:5e:6f:3q:78:30 dst=24.32.123.42 dstport=443 dstportname=https dstname=example_dest dstcontinent=\"na\" dstcountry=\"us\" ipv=4 sent=0 rcvd=0 duration=2.00 action=pass logtype=\"filter\""
   },
   "expected": {
     "source": {
@@ -16,8 +16,8 @@
       "port": 60355
     },
     "destination": {
-      "address": "424.321.123.42",
-      "ip": "424.321.123.42",
+      "address": "24.32.123.42",
+      "ip": "24.32.123.42",
       "port": 443,
       "geo": {
         "continent_name": "na",

--- a/Stormshield/stormshield_network_security/tests/filter2.json
+++ b/Stormshield/stormshield_network_security/tests/filter2.json
@@ -1,0 +1,124 @@
+{
+  "input": {
+    "sekoiaio": {
+      "intake": {
+        "dialect": "sns",
+        "dialect_uuid": "79029ef9-e5d3-44f3-b70f-fd3b54ba1fe4"
+      }
+    },
+    "message": "time=\"2022-03-16 19:36:03\" fw=\"SN12345678912345\" tz=+0100 startime=\"\" pri=5 confid=01 slotlevel=2 ruleid=103 srcif=\"Ethernet3\" srcifname=\"in\" ipproto=tcp dstif=\"Ethernet2\" dstifname=\"out\" proto=https src=11.11.11.11 srcport=49586 srcportname=ephemeral_fw_tcp srcname=Passerelle_SITA srcmac=00:1c:7f:8c:45:04 srccontinent=\"na\" srccountry=\"us\" dst=22 dstport=443 dstportname=https dstcontinent=\"eu\" dstcountry=\"be\" modsrc=92.175.10.97 modsrcport=49586 origdst=22.22.22.22 origdstport=443 ipv=4 sent=2827291 rcvd=2728401 duration=107331.18 action=pass logtype=\"connection\""
+  },
+  "expected": {
+    "@timestamp": "2022-03-16T18:36:03+00:00",
+    "destination": {
+      "address": "22",
+      "geo": {
+        "continent_name": "eu",
+        "country_iso_code": "be"
+      },
+      "ip": "22",
+      "port": 443
+    },
+    "ecs": {
+      "version": "1.10.0"
+    },
+    "event": {
+      "category": "network",
+      "duration": 107331180000000.0,
+      "kind": "event",
+      "outcome": "success",
+      "risk_score": 5,
+      "start": "2022-03-03T13:21:10+00:00",
+      "timezone": "+0100",
+      "type": "connection"
+    },
+    "host": {
+      "network": {
+        "egress": {
+          "bytes": 2827291
+        },
+        "ingress": {
+          "bytes": 2728401
+        }
+      }
+    },
+    "message": "time=\"2022-03-16 19:36:03\" fw=\"SN12345678912345\" tz=+0100 startime=\"\" pri=5 confid=01 slotlevel=2 ruleid=103 srcif=\"Ethernet3\" srcifname=\"in\" ipproto=tcp dstif=\"Ethernet2\" dstifname=\"out\" proto=https src=11.11.11.11 srcport=49586 srcportname=ephemeral_fw_tcp srcname=Passerelle_SITA srcmac=00:1c:7f:8c:45:04 srccontinent=\"na\" srccountry=\"us\" dst=22 dstport=443 dstportname=https dstcontinent=\"eu\" dstcountry=\"be\" modsrc=92.175.10.97 modsrcport=49586 origdst=22.22.22.22 origdstport=443 ipv=4 sent=2827291 rcvd=2728401 duration=107331.18 action=pass logtype=\"connection\"",
+    "network": {
+      "bytes": 28272912728401,
+      "protocol": "https",
+      "transport": "tcp",
+      "type": "4"
+    },
+    "observer": {
+      "egress": {
+        "interface": {
+          "alias": "out",
+          "name": "Ethernet2"
+        }
+      },
+      "ingress": {
+        "interface": {
+          "alias": "in",
+          "name": "Ethernet3"
+        }
+      },
+      "serial_number": "SN12345678912345"
+    },
+    "related": {
+      "ip": [
+        "11.11.11.11",
+        "22"
+      ]
+    },
+    "rule": {
+      "category": "2",
+      "id": "103"
+    },
+    "sekoiaio": {
+      "entity": {
+        "id": "jNZ0wDmv",
+        "name": "w5gjMeE2rgO7n0CI",
+        "uuid": "9a42db14-0072-4c5a-bd51-92f4cd060d96"
+      },
+      "intake": {
+        "created": "2021-04-23T20:02:05.017771Z",
+        "dialect": "sns",
+        "dialect_uuid": "79029ef9-e5d3-44f3-b70f-fd3b54ba1fe4",
+        "id": "10f0afe9-98a1-4226-a6bd-8f70d461d430",
+        "parsing_status": "success"
+      },
+      "log": {
+        "syslog": {
+          "facility": {
+            "code": "21",
+            "name": "local5"
+          },
+          "priority": "3",
+          "severity": {
+            "code": "3",
+            "name": "err"
+          }
+        }
+      }
+    },
+    "source": {
+      "address": "11.11.11.11",
+      "geo": {
+        "continent_name": "na",
+        "country_iso_code": "us"
+      },
+      "ip": "11.11.11.11",
+      "mac": "00:1c:7f:8c:45:04",
+      "port": 49586
+    },
+    "stormshield": {
+      "confid": 1,
+      "dstportname": "https",
+      "filter": {
+        "action": "pass"
+      },
+      "slotlevel": 2,
+      "srcportname": "ephemeral_fw_tcp"
+    }
+  }
+}


### PR DESCRIPTION
- Fix `parsed_startime - execution failure` when `startime` is empty
- Replace invalid IP addresses in previous test case