### PR TITLE
fix(Harfang Lab): Alert status field not parsed

### DIFF
--- a/HarfangLab/harfanglab/_meta/fields.yml
+++ b/HarfangLab/harfanglab/_meta/fields.yml
@@ -7,7 +7,7 @@ harfanglab.alert_time:
 
 harfanglab.alert_unique_id:
   name: harfanglab.alert_unique_id
-  type: long
+  type: keyword
   description: ""
 
 harfanglab.alert_subtype:
@@ -25,4 +25,7 @@ harfanglab.level:
   type: keyword
   description: ""
   
-  
+harfanglab.status:
+  name: harfanglab.status
+  type: keyword
+  description: ""

--- a/HarfangLab/harfanglab/ingest/parser.yml
+++ b/HarfangLab/harfanglab/ingest/parser.yml
@@ -99,6 +99,7 @@ stages:
           harfanglab.alert_unique_id: "{{json_event.message.alert_unique_id}}"
           harfanglab.alert_subtype: "{{json_event.message.alert_subtype}}"
           harfanglab.execution: "{{json_event.message.execution}}"
+          harfanglab.status: "{{json_event.message.status}}"
 
   investigation_info:
     actions:

--- a/HarfangLab/harfanglab/tests/process2.json
+++ b/HarfangLab/harfanglab/tests/process2.json
@@ -1,0 +1,51 @@
+{
+  "input": {
+    "sekoiaio": {
+      "intake": {
+        "dialect": "harfanglab",
+        "dialect_uuid": "3c7057d3-4689-4fae-8033-6f1f887a70f2"
+      }
+    },
+    "message": "{\n  \"@version\": \"1\",\n  \"agent\": {\n    \"agentid\": \"00000000-0000-0000-0000-000000000000\",\n    \"distroid\": null,\n    \"domainname\": \"domain123\",\n    \"ostype\": \"windows\",\n    \"hostname\": \"pc123\",\n    \"osversion\": \"10.0.19041\",\n    \"osproducttype\": \"Windows 10 Pro\",\n    \"domain\": null,\n    \"version\": \"2.12.6\"\n  },\n  \"type\": \"rtlogs\",\n  \"alert_subtype\": \"process\",\n  \"log_type\": \"alert\",\n  \"detection_origin\": \"agent\",\n  \"tenant\": \"\",\n  \"alert_time\": \"2022-03-15T07:26:01.276+00:00\",\n  \"alert_type\": \"sigma\",\n  \"status\": \"false_positive\",\n  \"rule_id\": \"00000000-0000-0000-0000-000000000000\",\n  \"@event_create_date\": \"2022-03-15T07:26:01.276Z\",\n  \"alert_unique_id\": \"00000000-0000-0000-0000-000000000000\",\n  \"level\": \"low\",\n  \"aggregation_key\": \"123456\",\n  \"@timestamp\": \"2022-03-15T07:26:01.311Z\",\n  \"tags\": [\n    \"attack.discovery\",\n    \"attack.t1057\",\n    \"attack.s0057\"\n  ],\n  \"process\": {\n    \"detection_timestamp\": \"2022/03/15 07:24:54.438105\",\n    \"process_unique_id\": \"00000000-0000-0000-0000-000000000000\",\n    \"parent_integrity_level\": \"Medium\",\n    \"log_platform_flag\": 0,\n    \"fake_parent_image\": null,\n    \"pid\": 11320,\n    \"image_name\": \"C:\\\\Windows\\\\SysWOW64\\\\tasklist.exe\",\n    \"username\": \"XXX\\\\XXX\",\n    \"logonid\": 151210562,\n    \"signature_info\": {\n      \"signed_authenticode\": false,\n      \"signed_catalog\": true,\n      \"root_info\": {\n        \"thumbprint\": \"3b1efd3a66ea28b16697394703a72ca340a05bd5\",\n        \"display_name\": \"Microsoft Root Certificate Authority 2010\",\n        \"serial_number\": \"28cc3a25bfba44ac449a9b586b4339aa\",\n        \"issuer_name\": \"Microsoft Root Certificate Authority 2010\"\n      },\n      \"signer_info\": {\n        \"thumbprint\": \"f7c2f2c96a328c13cda8cdb57b715bdea2cbd1d9\",\n        \"display_name\": \"Microsoft Windows\",\n        \"serial_number\": \"33000002ec6579ad1e670890130000000002ec\",\n        \"issuer_name\": \"Microsoft Windows Production PCA 2011\"\n      }\n    },\n    \"current_directory\": \"C:\\\\Program Files (x86)\\\\EPOS\\\\EPOS Connect\",\n    \"error_msg\": \"\",\n    \"status_msg\": \"sigma match detected this process but not configured to block it\",\n    \"ppid\": 17808,\n    \"fake_parent_commandline\": null,\n    \"commandline\": \"tasklist\",\n    \"signed\": true,\n    \"grandparent_integrity_level\": \"Medium\",\n    \"log_type\": \"process\",\n    \"pe_imphash\": \"19BBD9C4E73C288A3645E163F4B82682\",\n    \"create_time\": \"2022-03-15T07:24:54.260Z\",\n    \"status\": 0,\n    \"parent_image\": \"C:\\\\Windows\\\\SysWOW64\\\\cmd.exe\",\n    \"integrity_level\": \"Medium\",\n    \"usersid\": \"S-1-5-21-299502267-725345543-82448378-2366\",\n    \"pe_info\": {\n      \"product_version\": \"10.0.19041.1\",\n      \"legal_copyright\": \"© Microsoft Corporation. All rights reserved.\",\n      \"original_filename\": \"tasklist.exe\",\n      \"company_name\": \"Microsoft Corporation\",\n      \"file_description\": \"Lists the current running tasks\",\n      \"file_version\": \"10.0.19041.1 (WinBuild.160101.0800)\",\n      \"internal_name\": \"tasklist.exe\",\n      \"product_name\": \"Microsoft® Windows® Operating System\"\n    },\n    \"session\": 3,\n    \"pe_timestamp\": \"1994-09-11T16:43:21.000Z\",\n    \"parent_unique_id\": \"2332edf8-70c0-43c2-4590-00f912ab3d18\",\n    \"process_name\": \"tasklist.exe\",\n    \"grandparent_commandline\": \"C:\\\\Program Files (x86)\\\\EPOS\\\\EPOS Connect\\\\EPOSConnect.exe 1\",\n    \"pe_timestamp_int\": 779301801,\n    \"grandparent_image\": \"C:\\\\Program Files (x86)\\\\EPOS\\\\EPOS Connect\\\\EPOSConnect.exe\",\n    \"parent_commandline\": \"C:\\\\WINDOWS\\\\system32\\\\cmd.exe /d /s /c tasklist\",\n    \"fake_parent_unique_id\": null,\n    \"size\": 79360,\n    \"fake_ppid\": null,\n    \"hashes\": {\n      \"sha1\": \"7f50d8c3cf3ec79122a876e969bdb65d939becd0\",\n      \"sha256\": \"76eac7b5f53e0d58a98d5a6ddf9c97e19d1462ef65c0035d7798f89988b15ab4\",\n      \"md5\": \"0a4448b31ce7f83cb7691a2657f330f1\"\n    }\n  },\n  \"execution\": 0,\n  \"rule_name\": \"Discovery: Process list\",\n  \"maturity\": \"stable\",\n  \"msg\": \"Detects the execution of tasklist.exe, a tool used to gather detailed information about a computer's active processes.\"\n}\n"
+  },
+  "expected": {
+    "message": "{\n  \"@version\": \"1\",\n  \"agent\": {\n    \"agentid\": \"00000000-0000-0000-0000-000000000000\",\n    \"distroid\": null,\n    \"domainname\": \"domain123\",\n    \"ostype\": \"windows\",\n    \"hostname\": \"pc123\",\n    \"osversion\": \"10.0.19041\",\n    \"osproducttype\": \"Windows 10 Pro\",\n    \"domain\": null,\n    \"version\": \"2.12.6\"\n  },\n  \"type\": \"rtlogs\",\n  \"alert_subtype\": \"process\",\n  \"log_type\": \"alert\",\n  \"detection_origin\": \"agent\",\n  \"tenant\": \"\",\n  \"alert_time\": \"2022-03-15T07:26:01.276+00:00\",\n  \"alert_type\": \"sigma\",\n  \"status\": \"false_positive\",\n  \"rule_id\": \"00000000-0000-0000-0000-000000000000\",\n  \"@event_create_date\": \"2022-03-15T07:26:01.276Z\",\n  \"alert_unique_id\": \"00000000-0000-0000-0000-000000000000\",\n  \"level\": \"low\",\n  \"aggregation_key\": \"123456\",\n  \"@timestamp\": \"2022-03-15T07:26:01.311Z\",\n  \"tags\": [\n    \"attack.discovery\",\n    \"attack.t1057\",\n    \"attack.s0057\"\n  ],\n  \"process\": {\n    \"detection_timestamp\": \"2022/03/15 07:24:54.438105\",\n    \"process_unique_id\": \"00000000-0000-0000-0000-000000000000\",\n    \"parent_integrity_level\": \"Medium\",\n    \"log_platform_flag\": 0,\n    \"fake_parent_image\": null,\n    \"pid\": 11320,\n    \"image_name\": \"C:\\\\Windows\\\\SysWOW64\\\\tasklist.exe\",\n    \"username\": \"XXX\\\\XXX\",\n    \"logonid\": 151210562,\n    \"signature_info\": {\n      \"signed_authenticode\": false,\n      \"signed_catalog\": true,\n      \"root_info\": {\n        \"thumbprint\": \"3b1efd3a66ea28b16697394703a72ca340a05bd5\",\n        \"display_name\": \"Microsoft Root Certificate Authority 2010\",\n        \"serial_number\": \"28cc3a25bfba44ac449a9b586b4339aa\",\n        \"issuer_name\": \"Microsoft Root Certificate Authority 2010\"\n      },\n      \"signer_info\": {\n        \"thumbprint\": \"f7c2f2c96a328c13cda8cdb57b715bdea2cbd1d9\",\n        \"display_name\": \"Microsoft Windows\",\n        \"serial_number\": \"33000002ec6579ad1e670890130000000002ec\",\n        \"issuer_name\": \"Microsoft Windows Production PCA 2011\"\n      }\n    },\n    \"current_directory\": \"C:\\\\Program Files (x86)\\\\EPOS\\\\EPOS Connect\",\n    \"error_msg\": \"\",\n    \"status_msg\": \"sigma match detected this process but not configured to block it\",\n    \"ppid\": 17808,\n    \"fake_parent_commandline\": null,\n    \"commandline\": \"tasklist\",\n    \"signed\": true,\n    \"grandparent_integrity_level\": \"Medium\",\n    \"log_type\": \"process\",\n    \"pe_imphash\": \"19BBD9C4E73C288A3645E163F4B82682\",\n    \"create_time\": \"2022-03-15T07:24:54.260Z\",\n    \"status\": 0,\n    \"parent_image\": \"C:\\\\Windows\\\\SysWOW64\\\\cmd.exe\",\n    \"integrity_level\": \"Medium\",\n    \"usersid\": \"S-1-5-21-299502267-725345543-82448378-2366\",\n    \"pe_info\": {\n      \"product_version\": \"10.0.19041.1\",\n      \"legal_copyright\": \"© Microsoft Corporation. All rights reserved.\",\n      \"original_filename\": \"tasklist.exe\",\n      \"company_name\": \"Microsoft Corporation\",\n      \"file_description\": \"Lists the current running tasks\",\n      \"file_version\": \"10.0.19041.1 (WinBuild.160101.0800)\",\n      \"internal_name\": \"tasklist.exe\",\n      \"product_name\": \"Microsoft® Windows® Operating System\"\n    },\n    \"session\": 3,\n    \"pe_timestamp\": \"1994-09-11T16:43:21.000Z\",\n    \"parent_unique_id\": \"2332edf8-70c0-43c2-4590-00f912ab3d18\",\n    \"process_name\": \"tasklist.exe\",\n    \"grandparent_commandline\": \"C:\\\\Program Files (x86)\\\\EPOS\\\\EPOS Connect\\\\EPOSConnect.exe 1\",\n    \"pe_timestamp_int\": 779301801,\n    \"grandparent_image\": \"C:\\\\Program Files (x86)\\\\EPOS\\\\EPOS Connect\\\\EPOSConnect.exe\",\n    \"parent_commandline\": \"C:\\\\WINDOWS\\\\system32\\\\cmd.exe /d /s /c tasklist\",\n    \"fake_parent_unique_id\": null,\n    \"size\": 79360,\n    \"fake_ppid\": null,\n    \"hashes\": {\n      \"sha1\": \"7f50d8c3cf3ec79122a876e969bdb65d939becd0\",\n      \"sha256\": \"76eac7b5f53e0d58a98d5a6ddf9c97e19d1462ef65c0035d7798f89988b15ab4\",\n      \"md5\": \"0a4448b31ce7f83cb7691a2657f330f1\"\n    }\n  },\n  \"execution\": 0,\n  \"rule_name\": \"Discovery: Process list\",\n  \"maturity\": \"stable\",\n  \"msg\": \"Detects the execution of tasklist.exe, a tool used to gather detailed information about a computer's active processes.\"\n}\n",
+    "agent": {"id": "00000000-0000-0000-0000-000000000000"},
+    "event": {
+      "category": "process",
+      "event": {
+        "outcome": "success"
+      },
+      "kind": "alert",
+      "outcome": "success",
+      "type": "start"
+    },
+    "harfanglab": {
+      "alert_unique_id": "00000000-0000-0000-0000-000000000000",
+      "alert_subtype": "process",
+      "alert_time": "2022-03-15T07:26:01.276+00:00",
+      "execution": 0,
+      "level": "low",
+      "status": "false_positive"
+    },
+    "host": {
+      "domain": "domain123",
+      "hostname": "pc123",
+      "os": {
+        "full": "Windows 10 Pro",
+        "version": "10.0.19041"
+      }
+    },
+    "related": {
+      "hosts": [
+        "pc123"
+      ]
+    },
+    "rule": {
+      "category": "sigma",
+      "description": "Detects the execution of tasklist.exe, a tool used to gather detailed information about a computer's active processes.",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "name": "Discovery: Process list"
+    }
+  }
+}


### PR DESCRIPTION
fix :
- alert status not parsed
- alert uniq id wrong type:

```json 
{
  "field": "harfanglab.alert_unique_id",
  "value_error": "ValueError(\"invalid literal for int() with base 10: '00000000-0000-0000-0000-000000000000'\")",
  "event": "Cannot set a field as no value was computed",
  "logger": "ActionExecutor",
  "level": "info",
  "timestamp": "2022-03-21T11:23:15.822544Z"
}
 ```