### PR TITLE
McAfee: fix action defined for block_id=2

### DIFF
--- a/McAfee/mcafee_web_gateway/ingest/parser.yml
+++ b/McAfee/mcafee_web_gateway/ingest/parser.yml
@@ -63,7 +63,7 @@ stages:
         dictionary:
           '0': 'allowed'
           '1': 'error'
-          '2': 'change'
+          '2': 'denied'
           '3': 'error'
         mapping:
           event.code: event.action


### PR DESCRIPTION
Change the value of `event.action` to `denied` when block_id=2 (the request wad blocked and a template was applied to the response)