### PR TITLE
Azure: fix Azure windows parser with no EventData details

### DIFF
--- a/Azure/azure-windows/ingest/parser.yml
+++ b/Azure/azure-windows/ingest/parser.yml
@@ -19,7 +19,7 @@ pipeline:
 
   - name: extract_user_name
     description: 'Extract the username'
-    filter: '{{parse_json.message.properties.RawXml != null and (parse_windows_event.message.EventData.SubjectUserName != null or parse_windows_event.message.EventData.User != null)}}'
+    filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData != null and (parse_windows_event.message.EventData.SubjectUserName != null or parse_windows_event.message.EventData.User != null)}}'
     external:
       name: grok.match
       properties:
@@ -31,7 +31,7 @@ pipeline:
 
   - name: parse_hashes
     description: 'Extract Hashes'
-    filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData.Hashes != null}}'
+    filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData != null and parse_windows_event.message.EventData.Hashes != null}}'
     external:
       name: kv.parse-kv
       properties:
@@ -64,7 +64,7 @@ stages:
       - set:
           file.name: '{{parse_windows_event.message.EventData.TargetFilename.split("\\") | last | lower}}'
           file.path: '{{parse_windows_event.message.EventData.TargetFilename.split("\\")[0:-1] | join("\\") | lower}}'
-        filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData.TargetFilename != null}}'
+        filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData != null and parse_windows_event.message.EventData.TargetFilename != null}}'
 
 
   set_user_fields:
@@ -89,12 +89,12 @@ stages:
           registry.path: '{{parse_windows_event.message.EventData.TargetObject}}'
           registry.data.type: 'REG_SZ'
           registry.data.strings: '["{{parse_windows_event.message.EventData.Details}}"]'
-        filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData.Details != null and parse_windows_event.message.EventData.Details.startswith("DWORD") == false }}'
+        filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData != null and parse_windows_event.message.EventData.Details != null and parse_windows_event.message.EventData.Details.startswith("DWORD") == false }}'
       - set:
           registry.path: '{{parse_windows_event.message.EventData.TargetObject}}'
           registry.data.type: 'REG_DWORD'
           registry.data.strings: '["{{parse_windows_event.message.EventData.Details.split(" ") | last | replace("(", "") | replace(")", "")}}"]'
-        filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData.Details != null and parse_windows_event.message.EventData.Details.startswith("DWORD") }}'
+        filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData != null and parse_windows_event.message.EventData.Details != null and parse_windows_event.message.EventData.Details.startswith("DWORD") }}'
 
 
   set_network_fields:
@@ -110,12 +110,12 @@ stages:
       - set:
           source.ip: '{{parse_windows_event.message.EventData.IpAddress or parse_windows_event.message.EventData.SourceIp}}'
           source.port: '{{parse_windows_event.message.EventData.IpPort or parse_windows_event.message.EventData.SourcePort}}'
-        filter: '{{parse_json.message.properties.RawXml != null and (parse_windows_event.message.EventData.IpAddress != null or parse_windows_event.message.EventData.SourceIp != null)}}'
+        filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData != null and (parse_windows_event.message.EventData.IpAddress != null or parse_windows_event.message.EventData.SourceIp != null)}}'
       - set:
           dns.question.name: '{{parse_windows_event.message.EventData.QueryName}}'
           dns.size_in_char: '{{parse_windows_event.message.EventData.QueryName | length}}'
           dns.type: 'query'
-        filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData.QueryName != null}}'
+        filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData != null and parse_windows_event.message.EventData.QueryName != null}}'
       - set:
           dns.answers: >
             {%
@@ -172,13 +172,13 @@ stages:
             {% endfor %}
             ]
           dns.type: 'answer'
-        filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData.QueryResults != null}}'
+        filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData != null and parse_windows_event.message.EventData.QueryResults != null}}'
       - set:
           network.type: 'ipv6'
-        filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData.SourceIsIpv6 == "true"}}'
+        filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData != null and parse_windows_event.message.EventData.SourceIsIpv6 == "true"}}'
       - set:
           network.type: 'ipv4'
-        filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData.SourceIsIpv6 == "false"}}'
+        filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData != null and parse_windows_event.message.EventData.SourceIsIpv6 == "false"}}'
 
 
   set_process_fields:
@@ -226,7 +226,7 @@ stages:
         filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData != null and parse_windows_event.message.EventData.ParentProcessName == null and parse_windows_event.message.EventData.ParentImage != null}}'
       - set:
           process.parent.command_line: '{{parse_windows_event.message.EventData.ParentCommandLine | replace ("\"", "") | lower}}'
-        filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData.ParentCommandLine != null}}'
+        filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData != null and parse_windows_event.message.EventData.ParentCommandLine != null}}'
       - set:
           process.parent.pid: '{{parse_windows_event.message.EventData.ProcessId | int(base=16)}}'
         filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData != null and parse_windows_event.message.EventData.ProcessId != null and parse_json.message.properties.ProviderName != "Microsoft-Windows-Sysmon"}}'
@@ -255,13 +255,13 @@ stages:
       - set:
           azure_windows.user.identifier: '{{parse_windows_event.message.EventData.TargetUserSid}}'
           azure_windows.user.type: 'targetedUser'
-        filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData.TargetUserSid != null and parse_windows_event.message.EventData.TargetUserSid != "-" and parse_windows_event.message.EventData.TargetUserSid != "S-1-0-0"}}'
+        filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData != null and parse_windows_event.message.EventData.TargetUserSid != null and parse_windows_event.message.EventData.TargetUserSid != "-" and parse_windows_event.message.EventData.TargetUserSid != "S-1-0-0"}}'
       - set:
           azure_windows.user.name: '{{parse_windows_event.message.EventData.TargetUserName}}'
-        filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData.TargetUserSid != null and parse_windows_event.message.EventData.TargetUserName != "-"}}'
+        filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData != null and parse_windows_event.message.EventData.TargetUserSid != null and parse_windows_event.message.EventData.TargetUserName != "-"}}'
       - set:
           azure_windows.user.domain.name: '{{parse_windows_event.message.EventData.TargetDomainName}}'
-        filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData.TargetUserSid != null and parse_windows_event.message.EventData.TargetUserName != "-"}}'
+        filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData != null and parse_windows_event.message.EventData.TargetUserSid != null and parse_windows_event.message.EventData.TargetUserName != "-"}}'
 
 
   backward_compatibility:
@@ -285,19 +285,19 @@ stages:
           registry.hive: '{{parse_windows_event.message.EventData.TargetObject.split("\\") | first}}'
           registry.key: '{{parse_windows_event.message.EventData.TargetObject.split("\\")[1:-1] | join("\\")}}'
           registry.value: '{{parse_windows_event.message.EventData.TargetObject.split("\\") | last}}'
-        filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData.TargetObject != null and parse_windows_event.message.EventData.TargetObject.split("\\")|length > 2}}'
+        filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData != null and parse_windows_event.message.EventData.TargetObject != null and parse_windows_event.message.EventData.TargetObject.split("\\")|length > 2}}'
       - set:
           destination.size_in_char: '{{parse_windows_event.message.EventData.DestinationHostname | length}}'
-        filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData.DestinationHostname != null}}'
+        filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData != null and parse_windows_event.message.EventData.DestinationHostname != null}}'
       - set:
           source.size_in_char: '{{parse_windows_event.message.EventData.SourceHostname | length}}'
-        filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData.SourceHostname != null}}'
+        filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData != null and parse_windows_event.message.EventData.SourceHostname != null}}'
       - set:
           action.target: 'user'
         filter: '{{parse_json.message.properties.RawXml != null and set_custom_fields.azure_windows.user != null and set_custom_fields.azure_windows.user.type == "targetedUser"}}'
       - set:
           action.target: 'network-traffic'
-        filter: '{{parse_json.message.properties.RawXml != null and (parse_windows_event.message.EventData.IpAddress != null or parse_windows_event.message.EventData.SourceIp != null) and parse_windows_event.message.EventData.DestinationIp != null}}'
+        filter: '{{parse_json.message.properties.RawXml != null and parse_windows_event.message.EventData != null and (parse_windows_event.message.EventData.IpAddress != null or parse_windows_event.message.EventData.SourceIp != null) and parse_windows_event.message.EventData.DestinationIp != null}}'
       - translate:
         dictionary:
           1: 'Process creation'

--- a/Azure/azure-windows/tests/restart_manager.json
+++ b/Azure/azure-windows/tests/restart_manager.json
@@ -1,0 +1,41 @@
+{
+  "input": {
+    "sekoiaio": {
+      "intake": {
+        "dialect": "Azure Windows",
+        "dialect_uuid": "2815eaab-2425-4eff-8038-3f7d5a3b8b11"
+      }
+    },
+    "message": "{\"time\":\"2022-01-12T10:33:34.9717584Z\",\"category\":\"WindowsEventLogsTable\",\"level\":\"Informational\",\"properties\":{\"DeploymentId\":\"f329f776-83f1-4c79-95e5-6ad3f77f11e5\",\"Role\":\"IaaS\",\"RoleInstance\":\"_lab-vm\",\"ProviderGuid\":\"{0888e5ef-9b98-4695-979d-e92ce4247224}\",\"ProviderName\":\"Microsoft-Windows-RestartManager\",\"EventId\":10001,\"Level\":4,\"Pid\":3732,\"Tid\":2144,\"Opcode\":0,\"Task\":0,\"Channel\":\"Application\",\"Description\":\"Ending session 0 started ‎2022‎-‎01‎-‎12T10:33:34.805069900Z.\",\"RawXml\":\"<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-RestartManager' Guid='{0888e5ef-9b98-4695-979d-e92ce4247224}'/><EventID>10001</EventID><Version>0</Version><Level>4</Level><Task>0</Task><Opcode>0</Opcode><Keywords>0x8000000000000000</Keywords><TimeCreated SystemTime='2022-01-12T10:33:34.9717584Z'/><EventRecordID>9379</EventRecordID><Correlation/><Execution ProcessID='3732' ThreadID='2144'/><Channel>Application</Channel><Computer>lab-vm</Computer><Security UserID='S-1-5-18'/></System><UserData><RmSessionEvent xmlns='http://www.microsoft.com/2005/08/Windows/Reliability/RestartManager/'><RmSessionId>0</RmSessionId><UTCStartTime>2022-01-12T10:33:34.8050699Z</UTCStartTime></RmSessionEvent></UserData></Event>\"}}"
+  },
+  "expected": {
+    "message": "{\"time\":\"2022-01-12T10:33:34.9717584Z\",\"category\":\"WindowsEventLogsTable\",\"level\":\"Informational\",\"properties\":{\"DeploymentId\":\"f329f776-83f1-4c79-95e5-6ad3f77f11e5\",\"Role\":\"IaaS\",\"RoleInstance\":\"_lab-vm\",\"ProviderGuid\":\"{0888e5ef-9b98-4695-979d-e92ce4247224}\",\"ProviderName\":\"Microsoft-Windows-RestartManager\",\"EventId\":10001,\"Level\":4,\"Pid\":3732,\"Tid\":2144,\"Opcode\":0,\"Task\":0,\"Channel\":\"Application\",\"Description\":\"Ending session 0 started ‎2022‎-‎01‎-‎12T10:33:34.805069900Z.\",\"RawXml\":\"<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-RestartManager' Guid='{0888e5ef-9b98-4695-979d-e92ce4247224}'/><EventID>10001</EventID><Version>0</Version><Level>4</Level><Task>0</Task><Opcode>0</Opcode><Keywords>0x8000000000000000</Keywords><TimeCreated SystemTime='2022-01-12T10:33:34.9717584Z'/><EventRecordID>9379</EventRecordID><Correlation/><Execution ProcessID='3732' ThreadID='2144'/><Channel>Application</Channel><Computer>lab-vm</Computer><Security UserID='S-1-5-18'/></System><UserData><RmSessionEvent xmlns='http://www.microsoft.com/2005/08/Windows/Reliability/RestartManager/'><RmSessionId>0</RmSessionId><UTCStartTime>2022-01-12T10:33:34.8050699Z</UTCStartTime></RmSessionEvent></UserData></Event>\"}}",
+    "action": {
+        "id": 10001,
+        "name": "no match",
+        "outcome": "success",
+        "record_id": 9379,
+        "type": "Application"
+    },
+    "azure_windows": {
+        "opcode": "0",
+        "task": "0",
+        "provider_guid": "0888e5ef-9b98-4695-979d-e92ce4247224",
+        "provider_name": "Microsoft-Windows-RestartManager"
+    },
+    "os": {
+        "family": "windows",
+        "platform": "windows"
+    },
+    "process": {
+        "pid": 3732,
+        "thread": {"id": 2144}
+    },
+    "host": {"hostname": "lab-vm"},
+    "log": {"hostname": "lab-vm"},
+    "event": {
+        "code": "10001",
+        "provider": "Microsoft-Windows-RestartManager"
+    }
+  }
+}


### PR DESCRIPTION
With the parser to not failed when handling windows Event with no EventData part