### PR TITLE
Cisco: handle syslog prefixed payload

### DIFF
--- a/Cisco/cisco-wsa/ingest/parser.yml
+++ b/Cisco/cisco-wsa/ingest/parser.yml
@@ -6,7 +6,9 @@ pipeline:
       properties:
         input_field: original.message
         output_field: message
-        pattern: '^%{NUMBER:timestamp}\s+%{NUMBER:elapsed}\s+%{IP:source_ip}\s+%{WORD:code}/%{NUMBER:status}\s+%{NUMBER:http_response_bytes}\s+%{WORD:method}\s+%{NOTSPACE:url}\s+%{NOTSPACE:username}\s+%{NOTSPACE:hierarchy_code}/(%{IP:peerhostip}|%{NOTSPACE:peerhost})\s+%{NOTSPACE:mime_type}\s+%{WORD:decision_tag}-%{WORD:policy_group_name}-%{WORD:policy_identity}-%{WORD:outbound_malware_scanning_policy}-%{WORD:data_security_policy}-%{WORD:external_dlp_policy}-%{WORD:routing_policy}\s+<%{NOTSPACE:scanning_verdict_information}>\s+%{DATA:user_agent}$'
+        pattern: '%{PREFIX}%{NUMBER:timestamp}\s+%{NUMBER:elapsed}\s+%{IP:source_ip}\s+%{WORD:code}/%{NUMBER:status}\s+%{NUMBER:http_response_bytes}\s+%{WORD:method}\s+%{NOTSPACE:url}\s+%{NOTSPACE:username}\s+%{NOTSPACE:hierarchy_code}/(%{IP:peerhostip}|%{NOTSPACE:peerhost})\s+%{NOTSPACE:mime_type}\s+%{WORD:decision_tag}-%{WORD:policy_group_name}-%{WORD:policy_identity}-%{WORD:outbound_malware_scanning_policy}-%{WORD:data_security_policy}-%{WORD:external_dlp_policy}-%{WORD:routing_policy}\s+<%{NOTSPACE:scanning_verdict_information}>\s+%{DATA:user_agent}$'
+        custom_patterns:
+          PREFIX: '(?:Info:\s+)*'
   - name: parsed_timestamp
     external:
       name: date.parse
@@ -15,6 +17,7 @@ pipeline:
         output_field: start_date
         format: timestamp
   - name: parsed_scanning_verdict
+    filter: '{{ parsed_event.message != null }}'
     external:
       name: dsv.parse-dsv
       properties:

--- a/Cisco/cisco-wsa/ingest/parser.yml
+++ b/Cisco/cisco-wsa/ingest/parser.yml
@@ -6,9 +6,10 @@ pipeline:
       properties:
         input_field: original.message
         output_field: message
-        pattern: '%{PREFIX}%{NUMBER:timestamp}\s+%{NUMBER:elapsed}\s+%{IP:source_ip}\s+%{WORD:code}/%{NUMBER:status}\s+%{NUMBER:http_response_bytes}\s+%{WORD:method}\s+%{NOTSPACE:url}\s+%{NOTSPACE:username}\s+%{NOTSPACE:hierarchy_code}/(%{IP:peerhostip}|%{NOTSPACE:peerhost})\s+%{NOTSPACE:mime_type}\s+%{WORD:decision_tag}-%{WORD:policy_group_name}-%{WORD:policy_identity}-%{WORD:outbound_malware_scanning_policy}-%{WORD:data_security_policy}-%{WORD:external_dlp_policy}-%{WORD:routing_policy}\s+<%{NOTSPACE:scanning_verdict_information}>\s+%{DATA:user_agent}$'
+        pattern: '%{PREFIX}%{NUMBER:timestamp}\s+%{NUMBER:elapsed}\s+%{IP:source_ip}\s+%{WORD:code}/%{NUMBER:status}\s+%{NUMBER:http_response_bytes}\s+%{WORD:method}\s+%{NOTSPACE:url}\s+%{NOTSPACE:username}\s+%{NOTSPACE:hierarchy_code}/(%{IP:peerhostip}|%{NOTSPACE:peerhost})\s+%{NOTSPACE:mime_type}\s+%{NOTSPACE:acl_decision}\s+<%{VERDICT:scanning_verdict_information}>\s+%{DATA:user_agent}.*'
         custom_patterns:
           PREFIX: '(?:Info:\s+)*'
+          VERDICT: '(?:[^>]+)'
   - name: parsed_timestamp
     external:
       name: date.parse
@@ -16,6 +17,14 @@ pipeline:
         input_field: parsed_event.message.timestamp
         output_field: start_date
         format: timestamp
+  - name: parsed_acl_decision
+    filter: '{{ parsed_event.message != null and parsed_event.message.acl_decision != null}}'
+    external:
+      name: grok.match
+      properties:
+        input_field: parsed_event.message.acl_decision
+        output_field: result
+        pattern: '%{WORD:decision_tag}-%{WORD:policy_group_name}-%{WORD:policy_identity}-%{WORD:outbound_malware_scanning_policy}-%{WORD:data_security_policy}-%{WORD:external_dlp_policy}-%{WORD:routing_policy}'
   - name: parsed_scanning_verdict
     filter: '{{ parsed_event.message != null }}'
     external:
@@ -86,8 +95,14 @@ stages:
           http.response.status_code: '{{parsed_event.message.status}}'
           http.response.bytes: '{{parsed_event.message.http_response_bytes}}'
           url.original: '{{parsed_event.message.url}}'
-          rule.ruleset: '{{parsed_event.message.policy_identity | replace("_", " ")}}'
-          rule.id: '{{parsed_event.message.decision_tag}}'
+
+      - set:
+          rule.ruleset: '{{parsed_acl_decision.result.policy_identity | replace("_", " ")}}'
+        filter: '{{parsed_acl_decision.result != None and parsed_acl_decision.result.policy_identity != None}}'
+
+      - set:
+          rule.id: '{{parsed_acl_decision.result.decision_tag}}'
+        filter: '{{parsed_acl_decision.result != None and parsed_acl_decision.result.decision_tag != None}}'
 
       - set:
           user_agent.original: '{{parsed_event.message.useragent}}'
@@ -141,11 +156,12 @@ stages:
           cisco_wsa.hierarchy_code: '{{parsed_event.message.hierarchy_code}}'
 
       - set:
-          cisco_wsa.rule.policy.name: '{{parsed_event.message.policy_group_name}}'
-          cisco_wsa.rule.policy.outbound_malware_scanning: '{{parsed_event.message.outbound_malware_scanning_policy}}'
-          cisco_wsa.rule.policy.data_security: '{{parsed_event.message.data_security_policy}}'
-          cisco_wsa.rule.policy.external_dlp: '{{parsed_event.message.external_dlp_policy}}'
-          cisco_wsa.rule.policy.routing: '{{parsed_event.message.routing_policy}}'
+          cisco_wsa.rule.policy.name: '{{parsed_acl_decision.result.policy_group_name}}'
+          cisco_wsa.rule.policy.outbound_malware_scanning: '{{parsed_acl_decision.result.outbound_malware_scanning_policy}}'
+          cisco_wsa.rule.policy.data_security: '{{parsed_acl_decision.result.data_security_policy}}'
+          cisco_wsa.rule.policy.external_dlp: '{{parsed_acl_decision.result.external_dlp_policy}}'
+          cisco_wsa.rule.policy.routing: '{{parsed_acl_decision.result.routing_policy}}'
+        filter: '{{parsed_acl_decision.result != None}}'
 
       - set:
           cisco_wsa.cache_status: hit
@@ -246,7 +262,7 @@ stages:
         mapping:
           cisco_wsa.url.category_code: cisco_wsa.url.category
         fallback: 'Unclassified'
-        filter: '{{parsed_scanning_verdict.results.url_category != nc}}'
+        filter: '{{parsed_scanning_verdict.results.url_category != "nc"}}'
 
       - set:
           cisco_wsa.threat.name: '{{parsed_scanning_verdict.results.threat_name}}'
@@ -254,7 +270,11 @@ stages:
 
       - set:
           cisco_wsa.threat.category_code: '{{parsed_scanning_verdict.results.threat_category_code}}'
+        filter: '{{parsed_scanning_verdict.results.threat_category_code != "-"}}'
+
+      - set:
           cisco_wsa.threat.reputation_score: '{{parsed_scanning_verdict.results.threat_score}}'
+        filter: '{{parsed_scanning_verdict.results.threat_score != "-"}}'
 
       - translate:
         dictionary:

--- a/Cisco/cisco-wsa/tests/event1.json
+++ b/Cisco/cisco-wsa/tests/event1.json
@@ -1,0 +1,79 @@
+{
+  "input": {
+    "sekoiaio": {
+      "intake": {
+        "dialect": "cisco-wsa",
+        "dialect_uuid": "23b75d0c-2026-4d3e-b916-636c27ba4931"
+      }
+    },
+    "message": "Info: 1649097617.352 7 1.2.3.4 TCP_MISS/302 779 HEAD http://example.g1.com/release2/chrome_component/ncl4aq5sui3jzdal274hizxkxe_102.0.4984.0/jamhcnnkihinmdlkakkaopbjbbcngflc_102.0.4984.0_all_kqe423m2ktlxwrfccq656tbhhi.crx3 - DIRECT/example.g1.com text/html DEFAULT_CASE_12-DefaultGroup-Internal_network-NONE-NONE-NONE-DefaultGroup-NONE <\"IW_infr\",6.8,1,\"-\",-,-,-,-,\"-\",-,-,-,\"-\",-,-,\"-\",\"-\",-,-,\"IW_infr\",-,\"-\",\"Infrastructure and Content Delivery Networks\",\"-\",\"Unknown\",\"Unknown\",\"-\",\"-\",890.29,0,-,\"-\",\"-\",-,\"-\",-,-,\"-\",\"-\",-,-,\"-\",-> - -"
+  },
+  "expected": {
+    "message": "Info: 1649097617.352 7 1.2.3.4 TCP_MISS/302 779 HEAD http://example.g1.com/release2/chrome_component/ncl4aq5sui3jzdal274hizxkxe_102.0.4984.0/jamhcnnkihinmdlkakkaopbjbbcngflc_102.0.4984.0_all_kqe423m2ktlxwrfccq656tbhhi.crx3 - DIRECT/example.g1.com text/html DEFAULT_CASE_12-DefaultGroup-Internal_network-NONE-NONE-NONE-DefaultGroup-NONE <\"IW_infr\",6.8,1,\"-\",-,-,-,-,\"-\",-,-,-,\"-\",-,-,\"-\",\"-\",-,-,\"IW_infr\",-,\"-\",\"Infrastructure and Content Delivery Networks\",\"-\",\"Unknown\",\"Unknown\",\"-\",\"-\",890.29,0,-,\"-\",\"-\",-,\"-\",-,-,\"-\",\"-\",-,-,\"-\",-> - -",
+    "cisco_wsa": {
+      "cache_status": "miss",
+      "hierarchy_code": "DIRECT",
+      "threat": {
+        "category": "Not Set",
+        "name": "-"
+      },
+      "url": {
+        "category": "Infrastructure and Content Delivery Networks",
+        "category_code": "IW_infr"
+      }
+    },
+    "destination": {
+      "address": "example.g1.com",
+      "domain": "example.g1.com",
+      "registered_domain": "g1.com",
+      "subdomain": "example",
+      "top_level_domain": "com"
+    },
+    "ecs": {
+      "version": "1.10.0"
+    },
+    "event": {
+      "category": [
+        "web",
+        "network"
+      ],
+      "duration": 7,
+      "kind": "event",
+      "outcome": "success",
+      "start": "2022-04-04T18:40:17.352000Z"
+    },
+    "http": {
+      "request": {
+        "method": "HEAD"
+      },
+      "response": {
+        "bytes": 779,
+        "mime_type": "text/html",
+        "status_code": 302
+      }
+    },
+    "network": {
+      "direction": "egress",
+      "transport": "tcp"
+    },
+    "observer": {
+      "product": "Cisco Web Security Appliances",
+      "type": "proxy",
+      "vendor": "Cisco"
+    },
+    "source": {
+      "address": "1.2.3.4",
+      "ip": "1.2.3.4"
+    },
+    "url": {
+      "domain": "example.g1.com",
+      "original": "http://example.g1.com/release2/chrome_component/ncl4aq5sui3jzdal274hizxkxe_102.0.4984.0/jamhcnnkihinmdlkakkaopbjbbcngflc_102.0.4984.0_all_kqe423m2ktlxwrfccq656tbhhi.crx3",
+      "path": "/release2/chrome_component/ncl4aq5sui3jzdal274hizxkxe_102.0.4984.0/jamhcnnkihinmdlkakkaopbjbbcngflc_102.0.4984.0_all_kqe423m2ktlxwrfccq656tbhhi.crx3",
+      "port": 80,
+      "registered_domain": "g1.com",
+      "scheme": "http",
+      "subdomain": "example",
+      "top_level_domain": "com"
+    }
+  }
+}

--- a/Cisco/cisco-wsa/tests/prefixed.json
+++ b/Cisco/cisco-wsa/tests/prefixed.json
@@ -1,0 +1,91 @@
+{
+  "input": {
+    "sekoiaio": {
+      "intake": {
+        "dialect": "cisco-wsa",
+        "dialect_uuid": "23b75d0c-2026-4d3e-b916-636c27ba4931"
+      }
+    },
+    "message": "Info: 1278096903.150 97 172.10.11.22 TCP_MISS/200 8187 GET http://my.site.com/ - DIRECT/my.site.com text/plain DEFAULT_CASE_11-PolicyGroupName-Identity-OutboundMalwareScanningPolicy-DataSecurityPolicy-ExternalDLPPolicy-RoutingPolicy <IW_comp,6.9,-,\"-\",-,-,-,-,\"-\",-,-,-,\"-\",-,-,\"-\",\"-\",-,-,IW_comp,-,\"-\",\"-\",\"Unknown\",\"Unknown\",\"-\",\"-\",198.34,0,-,[Local],\"-\",37,\"W32.CiscoTestVector\",33,0,\"WSA-INFECTED-FILE.pdf\",\"fd5ef49d4213e05f448f11ed9c98253d85829614fba368a421d14e64c426da5e\"> -"
+  },
+  "expected": {
+    "message": "Info: 1278096903.150 97 172.10.11.22 TCP_MISS/200 8187 GET http://my.site.com/ - DIRECT/my.site.com text/plain DEFAULT_CASE_11-PolicyGroupName-Identity-OutboundMalwareScanningPolicy-DataSecurityPolicy-ExternalDLPPolicy-RoutingPolicy <IW_comp,6.9,-,\"-\",-,-,-,-,\"-\",-,-,-,\"-\",-,-,\"-\",\"-\",-,-,IW_comp,-,\"-\",\"-\",\"Unknown\",\"Unknown\",\"-\",\"-\",198.34,0,-,[Local],\"-\",37,\"W32.CiscoTestVector\",33,0,\"WSA-INFECTED-FILE.pdf\",\"fd5ef49d4213e05f448f11ed9c98253d85829614fba368a421d14e64c426da5e\"> -",
+    "event": {
+      "start": "2010-07-02T18:55:03.150000Z",
+      "duration": 97,
+      "category": ["web", "network"],
+      "kind": "event"
+    },
+    "source": {
+      "ip": "172.10.11.22",
+      "address": "172.10.11.22"
+    },
+    "destination": {
+      "domain": "my.site.com",
+      "address": "my.site.com",
+      "registered_domain": "site.com",
+      "subdomain": "my",
+      "top_level_domain": "com"
+    },
+    "network": {
+        "transport": "tcp",
+        "direction": "egress"
+    },
+    "url": {
+      "original": "http://my.site.com/",
+      "path": "/",
+      "domain": "my.site.com",
+      "top_level_domain": "com",
+      "subdomain": "my",
+      "scheme": "http"
+    },
+    "http": {
+      "response": {
+        "status_code": 200,
+        "bytes": 8187,
+        "mime_type": "text/plain"
+      },
+      "request": {
+        "method": "GET"
+      }
+    },
+    "observer": {
+        "product": "Cisco Web Security Appliances",
+        "type": "proxy",
+        "vendor": "Cisco"
+    },
+    "rule": {
+        "ruleset": "Identity",
+        "id": "DEFAULT_CASE_11"
+    },
+    "file": {
+      "name": "WSA-INFECTED-FILE.pdf",
+      "hash": {
+        "sha256": "fd5ef49d4213e05f448f11ed9c98253d85829614fba368a421d14e64c426da5e"
+      }
+    },
+    "cisco_wsa": {
+      "hierarchy_code": "DIRECT",
+      "cache_status": "miss",
+      "rule": {
+        "policy": {
+          "name": "PolicyGroupName",
+          "outbound_malware_scanning": "OutboundMalwareScanningPolicy",
+          "data_security": "DataSecurityPolicy",
+          "external_dlp": "ExternalDLPPolicy",
+          "routing": "RoutingPolicy"
+        }
+      },
+      "url": {
+        "category_code": "IW_comp",
+        "category": "Computers and Internet"
+      },
+      "threat": {
+        "name": "W32.CiscoTestVector",
+        "category_code": 37,
+        "category": "Known Malicious and High-Risk Files",
+        "reputation_score": 33
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fix the parser to handle the prefix `Info: ` added in the payload of syslog message