### PR TITLE
Utils: Make generation template compliant with cookiecutter

### DIFF
--- a/utils/new_intake/cookiecutter.json
+++ b/utils/new_intake/cookiecutter.json
@@ -1,0 +1,5 @@
+{
+    "intake_name": "The name of the intake",
+    "intake_slug": "{{cookiecutter.intake_name.lower().replace(' ', '-')}}",
+    "intake_description": "The description of the intake"
+}

--- a/utils/new_intake/{{cookiecutter.intake_slug}}/_meta/manifest.yaml
+++ b/utils/new_intake/{{cookiecutter.intake_slug}}/_meta/manifest.yaml
@@ -1,0 +1,8 @@
+uuid: {{ uuid4() }}
+name: {{ cookiecutter.intake_name }}
+slug: {{ cookiecutter.intake_slug }}
+
+description: >-
+  {{ cookiecutter.intake_description }}
+
+data_sources:

--- a/utils/new_intake/{{cookiecutter.intake_slug}}/ingest/parser.yml
+++ b/utils/new_intake/{{cookiecutter.intake_slug}}/ingest/parser.yml
@@ -1,0 +1,4 @@
+name: {{ cookiecutter.intake_slug }}
+pipeline:
+
+stages:

--- a/utils/new_intake/{{intake_slug}}/_meta/manifest.yaml
+++ b/utils/new_intake/{{intake_slug}}/_meta/manifest.yaml
@@ -1,8 +1,0 @@
-uuid: 
-name: {{intake_name}}
-slug: {{intake_slug}}
-
-description: >-
-
-
-data_sources:

--- a/utils/new_intake/{{intake_slug}}/ingest/parser.yml
+++ b/utils/new_intake/{{intake_slug}}/ingest/parser.yml
@@ -1,4 +1,0 @@
-name: {{intake_slug}}
-pipeline:
-
-stages:

--- a/utils/new_module/cookiecutter.json
+++ b/utils/new_module/cookiecutter.json
@@ -1,0 +1,5 @@
+{
+    "module_name": "SEKOIAIO",
+    "module_description": "The description of the module",
+    "module_dir": "{{ cookiecutter.module_name }}"
+}

--- a/utils/new_module/{{cookiecutter.module_dir}}/README.md
+++ b/utils/new_module/{{cookiecutter.module_dir}}/README.md
@@ -1,4 +1,4 @@
-# {{cookiecutter.module}}
+# {{cookiecutter.module_name}}
 
 ## Description
 {{cookiecutter.module_description}}

--- a/utils/new_module/{{cookiecutter.module_dir}}/_meta/manifest.yaml
+++ b/utils/new_module/{{cookiecutter.module_dir}}/_meta/manifest.yaml
@@ -1,0 +1,5 @@
+uuid: {{ uuid4() }}
+name: {{ cookiecutter.module_name }}
+slug: {{ cookiecutter.module_name.lower().replace(" ", "-") }}
+description: >-
+  {{ cookiecutter.module_description }}


### PR DESCRIPTION
Update `utils/new_module` and `utils/new_intake` to be compliant with cookie cutter