### PR TITLE
FortiProxy: fix the identifier

### DIFF
--- a/Fortinet/fortiproxy/_meta/manifest.yml
+++ b/Fortinet/fortiproxy/_meta/manifest.yml
@@ -1,4 +1,4 @@
-uuid: 270777d7-0c5a-42fb-b901-b7fadfb00000
+uuid: 270777d7-0c5a-42fb-b901-b7fadfb0ba48
 name: FortiProxy
 slug: fortiproxy
 description: >-


### PR DESCRIPTION
The identifier of this format doesn't match the expected one. Fix it