### PR TITLE
feat: intake format validation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,21 +26,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
-      id: setup-python
-      with:
-        python-version: '3.10'
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
+        id: setup-python
+        with:
+          python-version: '3.10'
 
-    - name: Install Poetry
-      run: |
-        pip install poetry
-        poetry config virtualenvs.in-project true
+      - name: Install Poetry
+        run: |
+          pip install poetry
+          poetry config virtualenvs.in-project true
 
-    - name: Install dependencies
-      run: |
-        poetry install
-  
-    - name: Execute tests
-      run: |
-        poetry run pytest test_formats.py -vv --changes
+      - name: Install dependencies
+        run: |
+          poetry install
+    
+      - name: Execute tests
+        run: |
+          poetry run pytest test_formats.py -vv --changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: Validate Intake Formats
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+defaults:
+  run:
+    working-directory: utils
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  test:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - uses: actions/checkout@v2
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      id: setup-python
+      with:
+        python-version: '3.10'
+
+    - name: Install Poetry
+      run: |
+        pip install poetry
+        poetry config virtualenvs.in-project true
+
+    - name: Install dependencies
+      run: |
+        poetry install
+  
+    - name: Execute tests
+      run: |
+        poetry run pytest test_formats.py -vv --changes

--- a/utils/conftest.py
+++ b/utils/conftest.py
@@ -1,0 +1,197 @@
+import glob
+import json
+import os
+import subprocess
+from collections import defaultdict
+from typing import Tuple
+
+import pytest
+import requests
+import yaml
+
+VALIDATION_URL = "https://app.sekoia.io/api/v1/ingest/formats/validate"
+INTAKES_PATH = os.path.dirname(os.path.dirname(__file__))
+
+
+class IntakeTestManager:
+    def __init__(self):
+        self._intakes = {}
+        self._results = defaultdict(dict)
+
+    def load(self, modules: list[str], intake_formats: list[str]):
+        """Load the hierarchy of modules, parsers and tests"""
+        filtered_elements = {".git", ".github", "doc", "utils"}
+
+        for subdir in os.listdir(INTAKES_PATH):
+            if subdir not in filtered_elements and (not modules or subdir in modules):
+                module_path = os.path.join(INTAKES_PATH, subdir)
+                if os.path.isdir(module_path):
+                    self._intakes[subdir] = self._get_formats(
+                        module_path, intake_formats
+                    )
+
+    def _get_formats(self, module_path: str, intake_formats: list[str]) -> list[str]:
+        formats = {}
+
+        filtered_elements = {"_meta"}
+
+        for subdir in os.listdir(module_path):
+            if subdir not in filtered_elements and (
+                not intake_formats or subdir in intake_formats
+            ):
+                format_path = os.path.join(module_path, subdir)
+                if os.path.isdir(format_path) and os.path.isfile(
+                    os.path.join(format_path, "ingest", "parser.yml")
+                ):
+                    formats[subdir] = self._get_tests(format_path)
+
+        return formats
+
+    def _get_tests(self, format_path: str) -> list[str]:
+        tests = []
+
+        for test_file in glob.glob(f"{format_path}/tests/*.json"):
+            tests.append(os.path.relpath(test_file, INTAKES_PATH))
+
+        return tests
+
+    def testcases(self) -> list[str]:
+        results = []
+
+        for _, module in self._intakes.items():
+            for _, tests in module.items():
+                results += tests
+
+        return results
+
+    def formats(self) -> list[Tuple[str, str]]:
+        results = []
+
+        for module, module_dict in self._intakes.items():
+            for intake_format in module_dict:
+                results.append((module, intake_format))
+
+        return results
+
+    def _get_format_results(self, module: str, intake_format: str) -> dict:
+        if module not in self._results or intake_format not in self._results[module]:
+            format_path = os.path.join(INTAKES_PATH, module, intake_format)
+
+            with open(os.path.join(format_path, "ingest", "parser.yml")) as f:
+                parser = yaml.safe_load(f)
+
+            fields_path = os.path.join(format_path, "_meta", "fields.yml")
+            if os.path.isfile(fields_path):
+                with open(fields_path) as f:
+                    fields = list(yaml.safe_load(f).values())
+            else:
+                fields = []
+
+            messages = []
+            for test in self._intakes[module][intake_format]:
+                with open(os.path.join(INTAKES_PATH, test)) as f:
+                    message = json.load(f)
+                    messages.append(message["input"]["message"])
+
+            response = requests.post(
+                VALIDATION_URL,
+                json={"parser": parser, "taxonomy": fields, "messages": messages},
+            )
+            response.raise_for_status()
+            self._results[module][intake_format] = response.json()
+            self._results[module][intake_format]["parsed_messages"] = {
+                test: self._results[module][intake_format]["parsed_messages"][i]
+                for i, test in enumerate(self._intakes[module][intake_format])
+            }
+
+        return self._results[module][intake_format]
+
+    def get_parsed_message(self, test_path: str) -> dict:
+        parts = test_path.split("/")
+        results = self._get_format_results(parts[0], parts[1])
+        return results["parsed_messages"].pop(test_path, {})
+
+    def get_coverage(self, module: str, intake_format: str) -> dict:
+        results = self._get_format_results(module, intake_format)
+        return results["coverage"]
+
+    def get_taxonomy(self, module: str, intake_format: str) -> dict:
+        results = self._get_format_results(module, intake_format)
+        return results["taxonomy"]
+
+
+_manager = IntakeTestManager()
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--module",
+        action="append",
+        default=[],
+        help="name of the module to test",
+    )
+
+    parser.addoption(
+        "--format",
+        action="append",
+        default=[],
+        help="name of the format to test",
+    )
+
+    parser.addoption(
+        "--changes",
+        action="store_true",
+        default=False,
+        help="only check formats that were modified",
+    )
+
+
+def pytest_configure(config):
+    modules = config.getoption("module")
+    intake_formats = config.getoption("format")
+
+    if config.getoption("changes"):
+        check_all = False
+        changed_modules = set()
+        changed_formats = set()
+
+        result = subprocess.run(
+            ["git", "diff", "--name-only", "main"], capture_output=True
+        )
+        for changed_file in result.stdout.splitlines():
+            changed_file = changed_file.decode()
+            parts = changed_file.split("/")
+
+            if parts[-1] in ["conftest.py", "test_formats.py"]:
+                check_all = True
+                break
+
+            if len(parts) > 2:
+                changed_modules.add(parts[0])
+                changed_formats.add(parts[1])
+
+        if check_all:
+            modules = []
+            intake_formats = []
+        else:
+            modules = list(changed_modules)
+            intake_formats = list(changed_formats)
+
+    _manager.load(modules=modules, intake_formats=intake_formats)
+
+
+def pytest_generate_tests(metafunc):
+    if "test_path" in metafunc.fixturenames:
+        metafunc.parametrize("test_path", _manager.testcases())
+    elif "intake_format" in metafunc.fixturenames:
+        metafunc.parametrize("module,intake_format", _manager.formats())
+
+
+@pytest.fixture
+def manager():
+    return _manager
+
+
+@pytest.fixture
+def intakes_root():
+    return INTAKES_PATH

--- a/utils/poetry.lock
+++ b/utils/poetry.lock
@@ -1,0 +1,276 @@
+[[package]]
+name = "atomicwrites"
+version = "1.4.0"
+description = "Atomic file writes."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "attrs"
+version = "21.4.0"
+description = "Classes Without Boilerplate"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.extras]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
+
+[[package]]
+name = "certifi"
+version = "2022.5.18.1"
+description = "Python package for providing Mozilla's CA Bundle."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "charset-normalizer"
+version = "2.0.12"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+category = "main"
+optional = false
+python-versions = ">=3.5.0"
+
+[package.extras]
+unicode_backport = ["unicodedata2"]
+
+[[package]]
+name = "colorama"
+version = "0.4.4"
+description = "Cross-platform colored terminal text."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "idna"
+version = "3.3"
+description = "Internationalized Domain Names in Applications (IDNA)"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
+name = "iniconfig"
+version = "1.1.1"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "packaging"
+version = "21.3"
+description = "Core utilities for Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
+
+[[package]]
+name = "pluggy"
+version = "1.0.0"
+description = "plugin and hook calling mechanisms for python"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "py"
+version = "1.11.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "pyparsing"
+version = "3.0.9"
+description = "pyparsing module - Classes and methods to define and execute parsing grammars"
+category = "main"
+optional = false
+python-versions = ">=3.6.8"
+
+[package.extras]
+diagrams = ["railroad-diagrams", "jinja2"]
+
+[[package]]
+name = "pytest"
+version = "7.1.2"
+description = "pytest: simple powerful testing with Python"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
+attrs = ">=19.2.0"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<2.0"
+py = ">=1.8.2"
+tomli = ">=1.0.0"
+
+[package.extras]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+
+[[package]]
+name = "pyyaml"
+version = "6.0"
+description = "YAML parser and emitter for Python"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "requests"
+version = "2.28.0"
+description = "Python HTTP for Humans."
+category = "main"
+optional = false
+python-versions = ">=3.7, <4"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+charset-normalizer = ">=2.0.0,<2.1.0"
+idna = ">=2.5,<4"
+urllib3 = ">=1.21.1,<1.27"
+
+[package.extras]
+socks = ["PySocks (>=1.5.6,!=1.5.7)"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
+
+[[package]]
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "urllib3"
+version = "1.26.9"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+
+[package.extras]
+brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.10"
+content-hash = "a0d9221e18ef72cdb436db86f26ba6b66872ed17e8cb28777a1f200789b60517"
+
+[metadata.files]
+atomicwrites = [
+    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
+    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
+]
+attrs = [
+    {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
+    {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
+]
+certifi = [
+    {file = "certifi-2022.5.18.1-py3-none-any.whl", hash = "sha256:f1d53542ee8cbedbe2118b5686372fb33c297fcd6379b050cca0ef13a597382a"},
+    {file = "certifi-2022.5.18.1.tar.gz", hash = "sha256:9c5705e395cd70084351dd8ad5c41e65655e08ce46f2ec9cf6c2c08390f71eb7"},
+]
+charset-normalizer = [
+    {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
+    {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
+]
+colorama = [
+    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
+    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+]
+idna = [
+    {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
+    {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
+]
+iniconfig = [
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
+    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+]
+packaging = [
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
+]
+pluggy = [
+    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
+py = [
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
+]
+pyparsing = [
+    {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
+    {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
+]
+pytest = [
+    {file = "pytest-7.1.2-py3-none-any.whl", hash = "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c"},
+    {file = "pytest-7.1.2.tar.gz", hash = "sha256:a06a0425453864a270bc45e71f783330a7428defb4230fb5e6a731fde06ecd45"},
+]
+pyyaml = [
+    {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
+    {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
+    {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
+    {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
+    {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4"},
+    {file = "PyYAML-6.0-cp36-cp36m-win32.whl", hash = "sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293"},
+    {file = "PyYAML-6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57"},
+    {file = "PyYAML-6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9"},
+    {file = "PyYAML-6.0-cp37-cp37m-win32.whl", hash = "sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737"},
+    {file = "PyYAML-6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d"},
+    {file = "PyYAML-6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287"},
+    {file = "PyYAML-6.0-cp38-cp38-win32.whl", hash = "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78"},
+    {file = "PyYAML-6.0-cp38-cp38-win_amd64.whl", hash = "sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0"},
+    {file = "PyYAML-6.0-cp39-cp39-win32.whl", hash = "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb"},
+    {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
+    {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
+]
+requests = [
+    {file = "requests-2.28.0-py3-none-any.whl", hash = "sha256:bc7861137fbce630f17b03d3ad02ad0bf978c844f3536d0edda6499dafce2b6f"},
+    {file = "requests-2.28.0.tar.gz", hash = "sha256:d568723a7ebd25875d8d1eaf5dfa068cd2fc8194b2e483d7b1f7c81918dbec6b"},
+]
+tomli = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+urllib3 = [
+    {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},
+    {file = "urllib3-1.26.9.tar.gz", hash = "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"},
+]

--- a/utils/pyproject.toml
+++ b/utils/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.poetry]
+name = "intake-formats"
+version = "0.1.0"
+description = "SEKOIA.IO Intake Formats"
+authors = []
+
+[tool.poetry.dependencies]
+python = "^3.10"
+pytest = "^7.1.2"
+requests = "^2.28.0"
+PyYAML = "^6.0"
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/utils/test_formats.py
+++ b/utils/test_formats.py
@@ -1,0 +1,95 @@
+import json
+import os
+
+constant_fields = {
+    "sekoiaio": {
+        "intake": {
+            "coverage": None,
+            "parsing_status": "success",
+            "dialect": "test",
+            "dialect_uuid": "00000000-0000-0000-0000-000000000000",
+        }
+    },
+    "event": {"id": "00000000-0000-0000-0000-000000000000", "outcome": "success"},
+    "ecs": {"version": "1.10.0"},
+}
+
+# Tests inside this file are actually parametrized depending on arguments
+# See `pytest_generate_tests` in conftest.py for details
+
+
+def test_intakes_produce_expected_messages(manager, intakes_root, test_path):
+    with open(os.path.join(intakes_root, test_path)) as f:
+        testcase = json.load(f)
+
+    parsed = manager.get_parsed_message(test_path)
+
+    # Make tests simpler to write by removing some default values
+    merge_dict(testcase["expected"], constant_fields)
+
+    if testcase["expected"].get("event"):
+        merge_dict(parsed, {"event": testcase["expected"]["event"]})
+
+    parsed.pop("message")
+
+    # The order inside `related` is not guaranteed, sort it to make it consistent
+    if "related" in parsed:
+        for related_field in ["hosts", "ip", "user", "hash"]:
+            if related_field in parsed["related"]:
+                parsed["related"][related_field] = sorted(
+                    parsed["related"][related_field]
+                )
+                print(parsed["related"][related_field])
+
+    assert parsed == testcase["expected"]
+
+
+def test_intake_format_coverage(manager, module, intake_format):
+    coverage = manager.get_coverage(module, intake_format)
+
+    print(f"Coverage: {coverage['percent']}")
+    print("Steps missing coverage:\n")
+
+    for missing in coverage.get("missing", []):
+        print(missing)
+
+    assert coverage["percent"] > 75
+
+
+def test_intake_format_unused_fields(manager, module, intake_format):
+    taxonomy = manager.get_taxonomy(module, intake_format)
+
+    number_of_unused_fields = len(taxonomy["unused"])
+
+    print(f"Unused fields ({number_of_unused_fields}):\n")
+
+    for unused in taxonomy["unused"]:
+        print(unused)
+
+    assert number_of_unused_fields == 0
+
+
+def test_intake_format_missing_fields(manager, module, intake_format):
+    taxonomy = manager.get_taxonomy(module, intake_format)
+
+    number_of_missing_fields = len(taxonomy["missing"])
+
+    print(f"Missing fields ({number_of_missing_fields}):\n")
+
+    for missing in taxonomy["missing"]:
+        print(missing)
+
+    assert number_of_missing_fields == 0
+
+
+def merge_dict(dst, src):
+    """
+    Merge two dict without erasing intermediate nodes from `dst`
+    """
+    for key, value in src.items():
+        if isinstance(value, dict):
+            if key not in dst:
+                dst[key] = {}
+            merge_dict(dst[key], value)
+        else:
+            dst[key] = value


### PR DESCRIPTION
This PR introduces a script that can be used to validate intake formats:

* Verify expected outputs
* Compute test coverage
* Detect unused or missing fields

The script is automatically run on Pull Requests.

It requires a validation endpoint on ingestapi that is not yet deployed, so all tests will fail for now.