### PR TITLE
Office365: remove the extract of url.original from teams links

### DIFF
--- a/Office 365/o365/ingest/parser.yml
+++ b/Office 365/o365/ingest/parser.yml
@@ -218,6 +218,3 @@ stages:
               {% endfor %}
             ]
         filter: '{{json_event.message.get("Members", []) != []}}'
-      - set:
-          url.original: '{{json_event.message.MessageURLs[0]}}'
-        filter: '{{json_event.message.get("MessageURLs", []) | length >= 1}}'

--- a/Office 365/o365/tests/teams_message_has_link.json
+++ b/Office 365/o365/tests/teams_message_has_link.json
@@ -36,17 +36,6 @@
             }
         }
     },
-    "url": {
-        "domain": "www.amazon.fr",
-        "original": "https://www.amazon.fr/s?i=merchant-items&amp;me=A1TLEYKQIC7812&amp;marketplaceID=A13V1IB3VIYZZH&amp;qid=1649187214&amp;ref=sr_pg_1",
-        "path": "/s",
-        "port": 443,
-        "query": "i=merchant-items&amp;me=A1TLEYKQIC7812&amp;marketplaceID=A13V1IB3VIYZZH&amp;qid=1649187214&amp;ref=sr_pg_1",
-        "registered_domain": "amazon.fr",
-        "scheme": "https",
-        "subdomain": "www",
-        "top_level_domain": "fr"
-    },
     "user": {
       "email": "email@example.org",
       "name": "email@example.org"


### PR DESCRIPTION
Remove the extraction of url.original for teams links to avoid misinterpretation