### PR TITLE
fix(o365): fix field types

### DIFF
--- a/Office 365/o365/_meta/fields.yml
+++ b/Office 365/o365/_meta/fields.yml
@@ -115,8 +115,8 @@ office365.teams.invitee:
 
 office365.teams.team.members:
   name: office365.teams.team.members
-  description: "The list of uses in a team"
-  type: keyword
+  description: "The list of users in a team"
+  type: object
 
 ###############################################################
 #                                                             #
@@ -127,7 +127,7 @@ office365.teams.team.members:
 action.properties:
   name: action.properties
   description: "A list of objects describing the action"
-  type: text
+  type: object
 
 action.target:
   name: action.target

--- a/Office 365/o365/tests/ad.json
+++ b/Office 365/o365/tests/ad.json
@@ -55,6 +55,7 @@
       ]
     },
     "source": {
+      "address": "1.2.3.4",
       "ip": "1.2.3.4"
     },
     "office365": {
@@ -66,6 +67,10 @@
       "intake": {
         "parsing_status": "success"
       }
+    },
+    "related": {
+      "ip": ["1.2.3.4"],
+      "user": ["user@company.onmicrosoft.com"]
     }
   }
 }

--- a/Office 365/o365/tests/exchange_event1.json
+++ b/Office 365/o365/tests/exchange_event1.json
@@ -29,6 +29,7 @@
       }
     },
     "source": {
+      "address": "d498:796:298e:be16:1b11:29eb:9996:8a36",
       "ip": "d498:796:298e:be16:1b11:29eb:9996:8a36"
     },
     "event": {
@@ -51,6 +52,10 @@
     "user": {
       "email": "email@example.org",
       "name": "email@example.org"
+    },
+    "related": {
+      "ip": ["d498:796:298e:be16:1b11:29eb:9996:8a36"],
+      "user": ["email@example.org"]
     }
   }
 }

--- a/Office 365/o365/tests/file_previewed.json
+++ b/Office 365/o365/tests/file_previewed.json
@@ -38,6 +38,7 @@
       ]
     },
     "source": {
+      "address": "1.2.3.4",
       "ip": "1.2.3.4"
     },
     "file": {
@@ -45,8 +46,15 @@
       "name": "MyDocument.docx"
     },
     "url": {
+      "domain": "company-my.sharepoint.com",
       "full": "https://company-my.sharepoint.com/personal/jane_doe_company_onmicrosoft_com/Documents/MyDocument.docx",
-      "original": "https://company-my.sharepoint.com/personal/jane_doe_company_onmicrosoft_com/Documents/MyDocument.docx"
+      "original": "https://company-my.sharepoint.com/personal/jane_doe_company_onmicrosoft_com/Documents/MyDocument.docx",
+      "path": "/personal/jane_doe_company_onmicrosoft_com/Documents/MyDocument.docx",
+      "port": 443,
+      "registered_domain": "sharepoint.com",
+      "scheme": "https",
+      "subdomain": "company-my",
+      "top_level_domain": "com"
     },
     "user_agent": {
       "original": "OneDriveMpc-Transform_Thumbnail/1.0"
@@ -62,6 +70,10 @@
       "intake": {
         "parsing_status": "success"
       }
+    },
+    "related": {
+      "ip": ["1.2.3.4"],
+      "user": ["jane.doe@company.onmicrosoft.com"]
     }
   }
 }

--- a/Office 365/o365/tests/file_sync_download_full.json
+++ b/Office 365/o365/tests/file_sync_download_full.json
@@ -42,6 +42,7 @@
         }
     },
     "source": {
+      "address": "1.2.3.4",
       "ip": "1.2.3.4"
     },
     "file": {
@@ -49,8 +50,15 @@
       "name": "logo.png"
     },
     "url": {
+      "domain": "company.sharepoint.com",
       "full": "https://company.sharepoint.com/sites/shared/public/assets/website/logo.png",
-      "original": "https://company.sharepoint.com/sites/shared/public/assets/website/logo.png"
+      "original": "https://company.sharepoint.com/sites/shared/public/assets/website/logo.png",
+      "path": "/sites/shared/public/assets/website/logo.png",
+      "port": 443,
+      "registered_domain": "sharepoint.com",
+      "scheme": "https",
+      "subdomain": "company",
+      "top_level_domain": "com"
     },
     "user_agent": {
       "original": "Microsoft SkyDriveSync 22.099.0508.0001 ship; Windows NT 10.0 (19043)"
@@ -66,6 +74,10 @@
       "intake": {
         "parsing_status": "success"
       }
+    },
+    "related": {
+      "ip": ["1.2.3.4"],
+      "user": ["marketing@company.com"]
     }
   }
 }

--- a/Office 365/o365/tests/teams_message_has_link.json
+++ b/Office 365/o365/tests/teams_message_has_link.json
@@ -10,6 +10,7 @@
   },
   "expected": {
     "source": {
+      "address": "1.2.3.4",
       "ip": "1.2.3.4"
     },
     "organization": {
@@ -36,7 +37,15 @@
         }
     },
     "url": {
-        "original": "https://www.amazon.fr/s?i=merchant-items&amp;me=A1TLEYKQIC7812&amp;marketplaceID=A13V1IB3VIYZZH&amp;qid=1649187214&amp;ref=sr_pg_1"
+        "domain": "www.amazon.fr",
+        "original": "https://www.amazon.fr/s?i=merchant-items&amp;me=A1TLEYKQIC7812&amp;marketplaceID=A13V1IB3VIYZZH&amp;qid=1649187214&amp;ref=sr_pg_1",
+        "path": "/s",
+        "port": 443,
+        "query": "i=merchant-items&amp;me=A1TLEYKQIC7812&amp;marketplaceID=A13V1IB3VIYZZH&amp;qid=1649187214&amp;ref=sr_pg_1",
+        "registered_domain": "amazon.fr",
+        "scheme": "https",
+        "subdomain": "www",
+        "top_level_domain": "fr"
     },
     "user": {
       "email": "email@example.org",
@@ -62,6 +71,10 @@
       "id": 25,
       "outcome": "success",
       "name": "MessageCreatedHasLink"
+    },
+    "related": {
+      "ip": ["1.2.3.4"],
+      "user": ["email@example.org"]
     }
   }
 }

--- a/Office 365/o365/tests/update_group.json
+++ b/Office 365/o365/tests/update_group.json
@@ -41,6 +41,9 @@
       "intake": {
         "parsing_status": "success"
       }
+    },
+    "related": {
+      "user": ["Sync_V-WATT_83d3b7098669@acme.onmicrosoft.com"]
     }
   }
 }

--- a/Office 365/o365/tests/update_user.json
+++ b/Office 365/o365/tests/update_user.json
@@ -42,6 +42,9 @@
       "intake": {
         "parsing_status": "success"
       }
+    },
+    "related": {
+      "user": ["Sync_V-WATT_83d3b7098669@acme.onmicrosoft.com"]
     }
   }
 }

--- a/Office 365/o365/tests/update_user_empty_source_ip.json
+++ b/Office 365/o365/tests/update_user_empty_source_ip.json
@@ -55,6 +55,9 @@
       "intake": {
         "parsing_status": "success"
       }
+    },
+    "related": {
+      "user": ["user@domain.onmicrosoft.com"]
     }
   }
 }

--- a/Office 365/o365/tests/user_logged_in.json
+++ b/Office 365/o365/tests/user_logged_in.json
@@ -60,6 +60,7 @@
       ]
     },
     "source": {
+      "address": "1.2.3.4",
       "ip": "1.2.3.4",
       "port": 8085
     },
@@ -67,6 +68,10 @@
       "intake": {
         "parsing_status": "success"
       }
+    },
+    "related": {
+      "ip": ["1.2.3.4"],
+      "user": ["REDACTED@company.onmicrosoft.com"]
     }
   }
 }


### PR DESCRIPTION
Fix Office365 field types. Some object fields were previously declared as text fields, which was incompatible with the future version of ingest.

Tests will not pass until the new version of ingest is deployed, but we need this update to deploy the new version 😅 