### PR TITLE
fix(audibeat): user group field is an object

### DIFF
--- a/Beats/auditbeat/_meta/fields.yml
+++ b/Beats/auditbeat/_meta/fields.yml
@@ -2412,7 +2412,7 @@ system.audit.user.user_information:
 system.audit.user.group: 
   description: group contains information about any groups the user is part of (beyond the user's primary group). 
   name: system.audit.user.group
-  type: keyword
+  type: object
 
 system.audit.user.password.type: 
   description: A user's password type. Possible values are `shadow_password` (the password hash is in the shadow file), `password_disabled`, `no_password` (this is dangerous as anyone can log in), and `crypt_password` (when the password field in /etc/passwd seems to contain an encrypted password). 


### PR DESCRIPTION
Fix the `system.audit.user.group` field type that is [actually an object](https://www.elastic.co/guide/en/beats/auditbeat/current/exported-fields-system.html)