### PR TITLE
fix(sekoiaio_endpoints): consider action.properties as an opaque object

### DIFF
--- a/SekoiaIO/endpoint/_meta/fields.yml
+++ b/SekoiaIO/endpoint/_meta/fields.yml
@@ -68,6 +68,11 @@ source.size_in_char:
 
 # Action Properties field (directly from the events)
 
+action.properties:
+  name: action.properties
+  type: object
+  description: ""
+
 action.properties.AccessGranted:
   name: action.properties.AccessGranted
   type: keyword

--- a/SekoiaIO/endpoint/tests/windows_defender.json
+++ b/SekoiaIO/endpoint/tests/windows_defender.json
@@ -1,0 +1,69 @@
+{
+    "input": {
+        "@timestamp": "2022-06-02T12:18:37.6722336Z",
+        "message": "{\"@timestamp\": \"2022-06-23T13:10:31.7691464Z\",\"agent\": {\"id\": \"3598e70397f8931e6288d7aa4075d336bee33fa6224627218e7b67587c3a62e9\",\"version\": \"0.1.0\"},\"action\": {\"id\": 1151,\"properties\": {\"AS security intelligence creation time\": \"23/06/2022 03:14:37\",\"AS security intelligence version\": \"1.369.112.0\",\"AV security intelligence creation time\": \"23/06/2022 03:14:37\",\"AV security intelligence version\": \"1.369.112.0\",\"BM state\": \"Activé\",\"Engine up-to-date\": \"0\",\"Engine version\": \"1.1.19300.2\",\"IOAV state\": \"Activé\",\"Keywords\": \"0x8000000000000000\",\"Last AS security intelligence age\": \"0\",\"Last AV security intelligence age\": \"0\",\"Last full scan age\": \"4294967295\",\"Last full scan end time\": \"01/01/1601 00:00:00\",\"Last full scan source\": \"0\",\"Last full scan start time\": \"01/01/1601 00:00:00\",\"Last quick scan age\": \"1\",\"Last quick scan end time\": \"22/06/2022 10:01:43\",\"Last quick scan source\": \"2\",\"Last quick scan start time\": \"22/06/2022 10:00:16\",\"Latest engine version\": \"1.1.19300.2\",\"Latest platform version\": \"4.18.2205.7\",\"NRI engine version\": \"1.1.19300.2\",\"NRI security intelligence version\": \"1.369.112.0\",\"OA state\": \"Activé\",\"Platform up-to-date\": \"1\",\"Platform version\": \"4.18.2205.7\",\"Product Name\": \"Antivirus Microsoft Defender\",\"Product status\": \"0x00080000\",\"ProviderGuid\": \"{11CD958A-C507-4EF3-B3F2-5FD9DFBD2C78}\",\"RTP state\": \"Activé\",\"Severity\": \"INFO\",\"SourceName\": \"Microsoft-Windows-Windows Defender\",\"Unused\": \"\"}},\"event\": {\"code\": 1151,\"provider\": \"Microsoft-Windows-Windows Defender\"},\"host\": {\"hostname\": \"test-PC\"}}",
+        "sekoiaio": {
+            "intake": {
+                "dialect": "sekoiaio-endpoint",
+                "dialect_uuid": "250e4095-fa08-4101-bb02-e72f870fcbd1"
+            }
+        }
+    },
+    "expected": {
+        "@timestamp": "2022-06-23T13:10:31.7691464Z",
+        "agent": {
+            "id": "3598e70397f8931e6288d7aa4075d336bee33fa6224627218e7b67587c3a62e9",
+            "version": "0.1.0"
+        },
+        "action": {
+            "id": 1151,
+            "properties": {
+                "AS security intelligence creation time": "23/06/2022 03:14:37",
+                "AS security intelligence version": "1.369.112.0",
+                "AV security intelligence creation time": "23/06/2022 03:14:37",
+                "AV security intelligence version": "1.369.112.0",
+                "BM state": "Activé",
+                "Engine up-to-date": "0",
+                "Engine version": "1.1.19300.2",
+                "IOAV state": "Activé",
+                "Keywords": "0x8000000000000000",
+                "Last AS security intelligence age": "0",
+                "Last AV security intelligence age": "0",
+                "Last full scan age": "4294967295",
+                "Last full scan end time": "01/01/1601 00:00:00",
+                "Last full scan source": "0",
+                "Last full scan start time": "01/01/1601 00:00:00",
+                "Last quick scan age": "1",
+                "Last quick scan end time": "22/06/2022 10:01:43",
+                "Last quick scan source": "2",
+                "Last quick scan start time": "22/06/2022 10:00:16",
+                "Latest engine version": "1.1.19300.2",
+                "Latest platform version": "4.18.2205.7",
+                "NRI engine version": "1.1.19300.2",
+                "NRI security intelligence version": "1.369.112.0",
+                "OA state": "Activé",
+                "Platform up-to-date": "1",
+                "Platform version": "4.18.2205.7",
+                "Product Name": "Antivirus Microsoft Defender",
+                "Product status": "0x00080000",
+                "ProviderGuid": "{11CD958A-C507-4EF3-B3F2-5FD9DFBD2C78}",
+                "RTP state": "Activé",
+                "Severity": "INFO",
+                "SourceName": "Microsoft-Windows-Windows Defender",
+                "Unused": ""
+            }
+        },
+        "event": {
+            "code": "1151",
+            "provider": "Microsoft-Windows-Windows Defender"
+        },
+        "host": {
+            "hostname": "test-PC"
+        },
+        "related": {
+            "hosts": [
+                "test-PC"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Make sure that any field that is inside `action.properties` and not listed in the fields is still added to the event, without errors.

Unfortunately, this also means that declared fields inside `action.properties` no longer have their type enforced.