### PR TITLE
fix(fortigate): add smart description for webfilter blocked event

### DIFF
--- a/Fortinet/fortigate/_meta/smart-descriptions.json
+++ b/Fortinet/fortigate/_meta/smart-descriptions.json
@@ -139,6 +139,36 @@
         ]
     },
     {
+        "value": "{source.ip} was denied a connection to {url.original} (category {rule.category})",
+        "conditions": [
+            {
+                "field": "action.type",
+                "value": "webfilter"
+            },
+            {
+                "field": "action.name",
+                "value": "blocked"
+            }
+        ],
+        "relationships": [
+            {
+                "source": "source.ip",
+                "target": "url.original",
+                "type": "was denied a connection to"
+            },
+            {
+                "source": "url.original",
+                "target": "destination.domain",
+                "type": "hosted on"
+            },
+            {
+                "source": "destination.domain",
+                "target": "destination.ip",
+                "type": "resolves to"
+            }
+        ]
+    },
+    {
         "value": "{source.ip} connected to {url.domain}{url.path} on {customer.zone_name} (category {application.category})",
         "conditions": [
             {


### PR DESCRIPTION
Add a missing Smart Description when webfilter blocks access to an URL