### PR TITLE
SentinelOne: only parse defined dates

### DIFF
--- a/SentinelOne/sentinelone/ingest/parser.yml
+++ b/SentinelOne/sentinelone/ingest/parser.yml
@@ -12,7 +12,7 @@ pipeline:
         input_field: "{{json_event.message.data.sourceprocessstarttime | float / 1000}}"
         output_field: datetime
         format: "timestamp"
-    filter: "{{json_event.message.get('data', {}).get('sourceprocessstarttime') != None}}"
+    filter: "{{json_event.message.get('data', {}).get('sourceprocessstarttime', 0) != 0}}"
   - name: parsed_process_parent_start
     external:
       name: date.parse
@@ -20,7 +20,7 @@ pipeline:
         input_field: "{{json_event.message.data.sourceparentprocessstarttime | float / 1000}}"
         output_field: datetime
         format: "timestamp"
-    filter: "{{json_event.message.get('data', {}).get('sourceparentprocessstarttime') != None}}"
+    filter: "{{json_event.message.get('data', {}).get('sourceparentprocessstarttime', 0) != 0}}"
   - name: read_threat_info
     filter: '{{json_event.message.threatInfo != null }}'
   - name: read_agent_info


### PR DESCRIPTION
Avoid to parse timestamp 0.