### PR TITLE
Add timestamp fields respecting ECS format to event

### DIFF
--- a/Fortinet/fortigate/ingest/parser.yml
+++ b/Fortinet/fortigate/ingest/parser.yml
@@ -22,13 +22,22 @@ pipeline:
     filter: "{{original.message | re_match('^\\s*\\w+=[^\\s]+(?:\\s\\w+=.*)\\s*$')}}"
 
   - name: parsed_date
+    filter: '{{ parsed_event.message.FTNTFGTeventtime | length == 10 }}'
     external:
       name: date.parse
       properties:
         input_field: '{{parsed_event.message.FTNTFGTeventtime}}'
         output_field: date
         format: "timestamp"
-    filter: '{{parsed_event.message.get("FTNTFGTeventtime") != None}}'
+
+  - name: parsed_date
+    filter: '{{ parsed_event.message.FTNTFGTeventtime | length == 19 }}'
+    external:
+      name: date.parse
+      properties:
+        input_field: '{{parsed_event.message.FTNTFGTeventtime | float / 1000000000}}'
+        output_field: date
+        format: "timestamp"
 
   - name: field_extraction
 
@@ -56,7 +65,7 @@ stages:
           event.code: "{{parsed_event.message.logid or parsed_event.message.FTNTFGTlogid or parsed_event.message.FortinetFortiGatelogid}}"
           event.reason: "{{parsed_event.message.msg}}"
           event.severity: "{{parsed_event.message.severity}}"
-          # event.timezone: "{{parsed_event.message.FTNTFGTtz}}" doesn not work for now, related to issue #32239
+          event.timezone: "{{parsed_event.message.FortinetFortiGatetz or parsed_event.message.tz or parsed_event.message.FTNTFGTtz }}"
           file.name: "{{parsed_event.message.fname}}"
           fortinet.apprisk: "{{parsed_event.message.apprisk}}"
           fortinet.event.desc: "{{parsed_event.message.desc}}"

--- a/Fortinet/fortigate/ingest/parser.yml
+++ b/Fortinet/fortigate/ingest/parser.yml
@@ -21,12 +21,22 @@ pipeline:
         item_sep: \s
     filter: "{{original.message | re_match('^\\s*\\w+=[^\\s]+(?:\\s\\w+=.*)\\s*$')}}"
 
+  - name: parsed_date
+    external:
+      name: date.parse
+      properties:
+        input_field: '{{parsed_event.message.FTNTFGTeventtime}}'
+        output_field: date
+        format: "timestamp"
+    filter: '{{parsed_event.message.get("FTNTFGTeventtime") != None}}'
+
   - name: field_extraction
 
 stages:
   field_extraction:
     actions:
       - set:
+          '@timestamp': "{{parsed_date.date}}"
           action.name: "{{parsed_event.message.name or parsed_event.message.FTNTFGTaction or parsed_event.message.FortinetFortiGateaction or parsed_event.message.act or parsed_event.message.action}}"
           action.outcome: "{{parsed_event.message.status or 'success'}}"
           action.type: "{{parsed_event.message.subtype or parsed_event.message.FTNTFGTsubtype or parsed_event.message.FortinetFortiGatesubtype}}"
@@ -44,9 +54,9 @@ stages:
           event.action: "{{parsed_event.message.reason}}"
           event.category: "{{parsed_event.message.type}}"
           event.code: "{{parsed_event.message.logid or parsed_event.message.FTNTFGTlogid or parsed_event.message.FortinetFortiGatelogid}}"
-          event.ingested: "{{parsed_event.message.FTNTFGTeventtime or parsed_event.message.FTNTFGTtz}}"
           event.reason: "{{parsed_event.message.msg}}"
           event.severity: "{{parsed_event.message.severity}}"
+          event.timezone: "{{parsed_event.message.FTNTFGTtz}}"
           file.name: "{{parsed_event.message.fname}}"
           fortinet.apprisk: "{{parsed_event.message.apprisk}}"
           fortinet.event.desc: "{{parsed_event.message.desc}}"

--- a/Fortinet/fortigate/ingest/parser.yml
+++ b/Fortinet/fortigate/ingest/parser.yml
@@ -22,22 +22,40 @@ pipeline:
     filter: "{{original.message | re_match('^\\s*\\w+=[^\\s]+(?:\\s\\w+=.*)\\s*$')}}"
 
   - name: parsed_date
-    filter: '{{ parsed_event.message.FTNTFGTeventtime | length == 10 }}'
+    filter: '{{parsed_event.message.get("FTNTFGTeventtime") != None}}'
     external:
       name: date.parse
       properties:
         input_field: '{{parsed_event.message.FTNTFGTeventtime}}'
         output_field: date
-        format: "timestamp"
+        timezone: '{{parsed_event.message.FTNTFGTtz}}'
 
   - name: parsed_date
-    filter: '{{ parsed_event.message.FTNTFGTeventtime | length == 19 }}'
+    filter: '{{parsed_event.message.get("FortinetFortiGateeventtime") != None}}'
     external:
       name: date.parse
       properties:
-        input_field: '{{parsed_event.message.FTNTFGTeventtime | float / 1000000000}}'
+        input_field: '{{parsed_event.message.FortinetFortiGateeventtime}}'
         output_field: date
-        format: "timestamp"
+        timezone: '{{parsed_event.message.FortinetFortiGatetz}}'
+
+  - name: parsed_date
+    filter: '{{parsed_event.message.get("eventtime") != None}}'
+    external:
+      name: date.parse
+      properties:
+        input_field: '{{parsed_event.message.eventtime }}'
+        output_field: date
+        timezone: '{{parsed_event.message.tz}}'
+
+  - name: parsed_date
+    filter: '{{parsed_event.message.get("timestamp") != None}}'
+    external:
+      name: date.parse
+      properties:
+        input_field: '{{parsed_event.message.timestamp }}'
+        output_field: date
+        timezone: '{{parsed_event.message.tz}}'
 
   - name: field_extraction
 

--- a/Fortinet/fortigate/ingest/parser.yml
+++ b/Fortinet/fortigate/ingest/parser.yml
@@ -44,6 +44,7 @@ stages:
           event.action: "{{parsed_event.message.reason}}"
           event.category: "{{parsed_event.message.type}}"
           event.code: "{{parsed_event.message.logid or parsed_event.message.FTNTFGTlogid or parsed_event.message.FortinetFortiGatelogid}}"
+          event.ingested: "{{parsed_event.message.FTNTFGTeventtime or parsed_event.message.FTNTFGTtz}}"
           event.reason: "{{parsed_event.message.msg}}"
           event.severity: "{{parsed_event.message.severity}}"
           file.name: "{{parsed_event.message.fname}}"

--- a/Fortinet/fortigate/ingest/parser.yml
+++ b/Fortinet/fortigate/ingest/parser.yml
@@ -56,7 +56,7 @@ stages:
           event.code: "{{parsed_event.message.logid or parsed_event.message.FTNTFGTlogid or parsed_event.message.FortinetFortiGatelogid}}"
           event.reason: "{{parsed_event.message.msg}}"
           event.severity: "{{parsed_event.message.severity}}"
-          event.timezone: "{{parsed_event.message.FTNTFGTtz}}"
+          # event.timezone: "{{parsed_event.message.FTNTFGTtz}}" doesn not work for now, related to issue #32239
           file.name: "{{parsed_event.message.fname}}"
           fortinet.apprisk: "{{parsed_event.message.apprisk}}"
           fortinet.event.desc: "{{parsed_event.message.desc}}"

--- a/Fortinet/fortigate/tests/Configuration_changed.CEF.json
+++ b/Fortinet/fortigate/tests/Configuration_changed.CEF.json
@@ -22,6 +22,7 @@
       "dialect_uuid": "1e256ea1-3947-429e-97a6-abaec8702dc4",
       "kind": "event"
     },
+    "@timestamp": "2021-11-23T14:35:08.541882Z",
     "action": {
       "outcome": "success",
       "type": "system"

--- a/Fortinet/fortigate/tests/Configuration_changed.CEF.json
+++ b/Fortinet/fortigate/tests/Configuration_changed.CEF.json
@@ -9,24 +9,18 @@
     "message": "CEF:0|Fortinet|Fortigate|v6.2.9|32102|event:system|7|deviceExternalId=FGVM2V0000171868 FortinetFortiGatelogid=0100032102 cat=event:system FortinetFortiGatesubtype=system FortinetFortiGatelevel=alert FortinetFortiGatevd=root FortinetFortiGateeventtime=1637681708541881380 FortinetFortiGatetz=+0100 FortinetFortiGatelogdesc=Configuration changed duser= sproc=console msg=Configuration is changed in the admin session"
   },
   "expected": {
+    "message": "CEF:0|Fortinet|Fortigate|v6.2.9|32102|event:system|7|deviceExternalId=FGVM2V0000171868 FortinetFortiGatelogid=0100032102 cat=event:system FortinetFortiGatesubtype=system FortinetFortiGatelevel=alert FortinetFortiGatevd=root FortinetFortiGateeventtime=1637681708541881380 FortinetFortiGatetz=+0100 FortinetFortiGatelogdesc=Configuration changed duser= sproc=console msg=Configuration is changed in the admin session",
     "event": {
       "code": "0100032102",
-      "outcome": "success",
+      "reason": "Configuration is changed in the admin session",
+      "timezone": "+0100",
       "dialect": "fortigate",
       "severity": "7",
-      "reason": "Configuration is changed in the admin session",
       "category": "event",
       "created": "2021-04-23T20:02:05.017771Z",
       "original": "1sjze813YtXlmgHp3a1jU4rOAwYpBKMFaWtYCeTQ0QhEtg36Z68bcNi4ahZ2G7Fz",
       "dialect_uuid": "1e256ea1-3947-429e-97a6-abaec8702dc4",
-      "id": "10f0afe9-98a1-4226-a6bd-8f70d461d430",
       "kind": "event"
-    },
-    "message": "CEF:0|Fortinet|Fortigate|v6.2.9|32102|event:system|7|deviceExternalId=FGVM2V0000171868 FortinetFortiGatelogid=0100032102 cat=event:system FortinetFortiGatesubtype=system FortinetFortiGatelevel=alert FortinetFortiGatevd=root FortinetFortiGateeventtime=1637681708541881380 FortinetFortiGatetz=+0100 FortinetFortiGatelogdesc=Configuration changed duser= sproc=console msg=Configuration is changed in the admin session",
-    "observer": {
-      "type": "Fortigate",
-      "vendor": "Fortinet",
-      "version": "v6.2.9"
     },
     "action": {
       "outcome": "success",
@@ -35,10 +29,10 @@
     "log": {
       "level": "alert"
     },
-    "sekoiaio": {
-      "intake": {
-        "parsing_status": "success"
-      }
+    "observer": {
+      "type": "Fortigate",
+      "vendor": "Fortinet",
+      "version": "v6.2.9"
     }
   }
 }

--- a/Fortinet/fortigate/tests/IP_SEC.STANDARD.json
+++ b/Fortinet/fortigate/tests/IP_SEC.STANDARD.json
@@ -9,22 +9,26 @@
     "message": "time=17:24:16 devname=\"abc\" devid=\"1\" logid=\"0101037130\" type=\"event\" subtype=\"vpn\" level=\"error\" vd=\"root\" eventtime=1580142256 logdesc=\"Progress IPsec phase 2\" msg=\"progress IPsec phase 2\" action=\"negotiate\" remip=1.1.1.1 locip=93.187.43.9 remport=500 locport=500 outintf=\"N/A\" cookies=\"07f928d94dd975ea/89b1d990f54f0b82\" user=\"N/A\" group=\"N/A\" xauthuser=\"N/A\" xauthgroup=\"N/A\" assignip=N/A vpntunnel=\"VPN-ACCENTURE\" status=\"failure\" init=\"local\" exch=\"CREATE_CHILD\" dir=\"inbound\" role=\"initiator\" result=\"ERROR\" version=\"IKEv2\""
   },
   "expected": {
+    "message": "time=17:24:16 devname=\"abc\" devid=\"1\" logid=\"0101037130\" type=\"event\" subtype=\"vpn\" level=\"error\" vd=\"root\" eventtime=1580142256 logdesc=\"Progress IPsec phase 2\" msg=\"progress IPsec phase 2\" action=\"negotiate\" remip=1.1.1.1 locip=93.187.43.9 remport=500 locport=500 outintf=\"N/A\" cookies=\"07f928d94dd975ea/89b1d990f54f0b82\" user=\"N/A\" group=\"N/A\" xauthuser=\"N/A\" xauthgroup=\"N/A\" assignip=N/A vpntunnel=\"VPN-ACCENTURE\" status=\"failure\" init=\"local\" exch=\"CREATE_CHILD\" dir=\"inbound\" role=\"initiator\" result=\"ERROR\" version=\"IKEv2\"",
     "event": {
-      "code": "0101037130",
-      "outcome": "success",
-      "dialect": "fortigate",
-      "reason": "progress IPsec phase 2",
       "category": "event",
+      "code": "0101037130",
+      "reason": "progress IPsec phase 2",
+      "dialect": "fortigate",
       "created": "2021-04-23T20:02:05.017771Z",
       "original": "1sjze813YtXlmgHp3a1jU4rOAwYpBKMFaWtYCeTQ0QhEtg36Z68bcNi4ahZ2G7Fz",
       "dialect_uuid": "1e256ea1-3947-429e-97a6-abaec8702dc4",
-      "id": "10f0afe9-98a1-4226-a6bd-8f70d461d430",
       "kind": "event"
+    },
+    "@timestamp": "2020-01-27T16:24:16.000000Z",
+    "action": {
+      "name": "negotiate",
+      "outcome": "failure",
+      "type": "vpn"
     },
     "log": {
       "level": "error"
     },
-    "message": "time=17:24:16 devname=\"abc\" devid=\"1\" logid=\"0101037130\" type=\"event\" subtype=\"vpn\" level=\"error\" vd=\"root\" eventtime=1580142256 logdesc=\"Progress IPsec phase 2\" msg=\"progress IPsec phase 2\" action=\"negotiate\" remip=1.1.1.1 locip=93.187.43.9 remport=500 locport=500 outintf=\"N/A\" cookies=\"07f928d94dd975ea/89b1d990f54f0b82\" user=\"N/A\" group=\"N/A\" xauthuser=\"N/A\" xauthgroup=\"N/A\" assignip=N/A vpntunnel=\"VPN-ACCENTURE\" status=\"failure\" init=\"local\" exch=\"CREATE_CHILD\" dir=\"inbound\" role=\"initiator\" result=\"ERROR\" version=\"IKEv2\"",
     "source": {
       "address": "1.1.1.1",
       "ip": "1.1.1.1",
@@ -32,21 +36,13 @@
         "name": "N/A"
       }
     },
-    "action": {
-      "name": "negotiate",
-      "outcome": "failure",
-      "type": "vpn"
-    },
     "related": {
+      "user": [
+        "N/A"
+      ],
       "ip": [
         "1.1.1.1"
-      ],
-      "user": ["N/A"]
-    },
-    "sekoiaio": {
-      "intake": {
-        "parsing_status": "success"
-      }
+      ]
     }
   }
 }

--- a/Fortinet/fortigate/tests/LOGOUT.STANDARD.json
+++ b/Fortinet/fortigate/tests/LOGOUT.STANDARD.json
@@ -9,6 +9,20 @@
     "message": "time=16:48:00 devname=\"abc\" devid=\"1\" logid=\"0100032003\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" eventtime=1619621280 logdesc=\"Admin logout successful\" sn=\"1619620402\" user=\"test\" ui=\"jsconsole\" method=\"jsconsole\" srcip=1.1.1.1 dstip=2.2.2.2 action=\"logout\" status=\"success\" duration=878 reason=\"exit\" msg=\"Administrator test logged out from jsconsole\""
   },
   "expected": {
+    "message": "time=16:48:00 devname=\"abc\" devid=\"1\" logid=\"0100032003\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" eventtime=1619621280 logdesc=\"Admin logout successful\" sn=\"1619620402\" user=\"test\" ui=\"jsconsole\" method=\"jsconsole\" srcip=1.1.1.1 dstip=2.2.2.2 action=\"logout\" status=\"success\" duration=878 reason=\"exit\" msg=\"Administrator test logged out from jsconsole\"",
+    "event": {
+      "action": "exit",
+      "category": "event",
+      "code": "0100032003",
+      "reason": "Administrator test logged out from jsconsole",
+      "created": "2021-04-26T05:31:28.317798Z",
+      "original": "7SWUWw0hIzFir8RNBlQmV40jtrt8wZG9nE38nymazmLyCGCdfpiNw6JDavRaSt6R",
+      "dialect_uuid": "7f69d51f-c863-4347-8fdb-6201b763ce12",
+      "provider": "jsconsole",
+      "dialect": "fortigate",
+      "kind": "event"
+    },
+    "@timestamp": "2021-04-28T14:48:00.000000Z",
     "action": {
       "name": "logout",
       "outcome": "success",
@@ -18,24 +32,14 @@
       "address": "2.2.2.2",
       "ip": "2.2.2.2"
     },
-    "event": {
-      "category": "event",
-      "code": "0100032003",
-      "reason": "Administrator test logged out from jsconsole",
-      "action": "exit",
-      "created": "2021-04-26T05:31:28.317798Z",
-      "original": "7SWUWw0hIzFir8RNBlQmV40jtrt8wZG9nE38nymazmLyCGCdfpiNw6JDavRaSt6R",
-      "dialect_uuid": "7f69d51f-c863-4347-8fdb-6201b763ce12",
-      "id": "7a0c0ade-d30f-4b10-933b-abf4a7b459ee",
-      "outcome": "success",
-      "provider": "jsconsole",
-      "dialect": "fortigate",
-      "kind": "event"
+    "http": {
+      "request": {
+        "method": "jsconsole"
+      }
     },
     "log": {
       "level": "information"
     },
-    "message": "time=16:48:00 devname=\"abc\" devid=\"1\" logid=\"0100032003\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" eventtime=1619621280 logdesc=\"Admin logout successful\" sn=\"1619620402\" user=\"test\" ui=\"jsconsole\" method=\"jsconsole\" srcip=1.1.1.1 dstip=2.2.2.2 action=\"logout\" status=\"success\" duration=878 reason=\"exit\" msg=\"Administrator test logged out from jsconsole\"",
     "source": {
       "address": "1.1.1.1",
       "ip": "1.1.1.1",
@@ -45,19 +49,12 @@
     },
     "related": {
       "ip": [
-        "1.1.1.1", "2.2.2.2"
+        "1.1.1.1",
+        "2.2.2.2"
       ],
-      "user": ["test"]
-    },
-    "http": {
-      "request": {
-        "method": "jsconsole"
-      }
-    },
-    "sekoiaio": {
-      "intake": {
-        "parsing_status": "success"
-      }
+      "user": [
+        "test"
+      ]
     }
   }
 }

--- a/Fortinet/fortigate/tests/ROLL-LOG.STANDARD.json
+++ b/Fortinet/fortigate/tests/ROLL-LOG.STANDARD.json
@@ -9,32 +9,26 @@
     "message": "time=16:23:50 devname=\"abc\" devid=\"1\" logid=\"0100032011\" type=\"event\" subtype=\"system\" level=\"notice\" vd=\"PRX1-AA\" eventtime=1619619830 logdesc=\"Disk log rolled\" action=\"roll-log\" reason=\"file-size\" log=\"tlog\" msg=\"Disk log has rolled.\""
   },
   "expected": {
+    "message": "time=16:23:50 devname=\"abc\" devid=\"1\" logid=\"0100032011\" type=\"event\" subtype=\"system\" level=\"notice\" vd=\"PRX1-AA\" eventtime=1619619830 logdesc=\"Disk log rolled\" action=\"roll-log\" reason=\"file-size\" log=\"tlog\" msg=\"Disk log has rolled.\"",
+    "event": {
+      "action": "file-size",
+      "category": "event",
+      "code": "0100032011",
+      "reason": "Disk log has rolled.",
+      "created": "2021-04-26T05:03:41.964860Z",
+      "original": "cdb5bxPLGIua7HGZV17aRAr3oU4q8HDxTCcWwbHXjL1xIeiPefRmfZNwDmmblhpM",
+      "dialect_uuid": "d9baa40e-09c4-45d4-83db-d655e99288eb",
+      "dialect": "fortigate",
+      "kind": "event"
+    },
+    "@timestamp": "2021-04-28T14:23:50.000000Z",
     "action": {
       "name": "roll-log",
       "outcome": "success",
       "type": "system"
     },
-    "event": {
-      "category": "event",
-      "code": "0100032011",
-      "reason": "Disk log has rolled.",
-      "action": "file-size",
-      "created": "2021-04-26T05:03:41.964860Z",
-      "original": "cdb5bxPLGIua7HGZV17aRAr3oU4q8HDxTCcWwbHXjL1xIeiPefRmfZNwDmmblhpM",
-      "dialect_uuid": "d9baa40e-09c4-45d4-83db-d655e99288eb",
-      "id": "f6536ec3-038f-4fe4-a252-45aae61257a6",
-      "outcome": "success",
-      "dialect": "fortigate",
-      "kind": "event"
-    },
     "log": {
       "level": "notice"
-    },
-    "message": "time=16:23:50 devname=\"abc\" devid=\"1\" logid=\"0100032011\" type=\"event\" subtype=\"system\" level=\"notice\" vd=\"PRX1-AA\" eventtime=1619619830 logdesc=\"Disk log rolled\" action=\"roll-log\" reason=\"file-size\" log=\"tlog\" msg=\"Disk log has rolled.\"",
-    "sekoiaio": {
-      "intake": {
-        "parsing_status": "success"
-      }
     }
   }
 }

--- a/Fortinet/fortigate/tests/WAD.STANDARD.json
+++ b/Fortinet/fortigate/tests/WAD.STANDARD.json
@@ -9,6 +9,18 @@
     "message": "time=15:29:39 devname=\"abc\" devid=\"1\" logid=\"0105048039\" type=\"event\" subtype=\"wad\" level=\"error\" vd=\"PRX1-AA\" eventtime=1619616579 logdesc=\"SSL fatal alert sent\" session_id=473f963d policyid=0 srcip=2.2.2.2 srcport=47782 dstip=1.1.1.1 dstport=8002 action=\"send\" alert=\"2\" desc=\"illegal parameter\" msg=\"SSL Alert sent\""
   },
   "expected": {
+    "message": "time=15:29:39 devname=\"abc\" devid=\"1\" logid=\"0105048039\" type=\"event\" subtype=\"wad\" level=\"error\" vd=\"PRX1-AA\" eventtime=1619616579 logdesc=\"SSL fatal alert sent\" session_id=473f963d policyid=0 srcip=2.2.2.2 srcport=47782 dstip=1.1.1.1 dstport=8002 action=\"send\" alert=\"2\" desc=\"illegal parameter\" msg=\"SSL Alert sent\"",
+    "event": {
+      "category": "event",
+      "code": "0105048039",
+      "reason": "SSL Alert sent",
+      "created": "2021-04-26T04:17:39.492286Z",
+      "original": "CO0Bc1MbjbOwVYPYTY69yQWWHIKOI8wbccbfhTNgD35U8qHRdBl0E8x0SYR7PAFp",
+      "dialect_uuid": "a948028d-8e9c-48e3-9f3a-193f2c42e9d1",
+      "dialect": "fortigate",
+      "kind": "event"
+    },
+    "@timestamp": "2021-04-28T13:29:39.000000Z",
     "action": {
       "name": "send",
       "outcome": "success",
@@ -19,18 +31,6 @@
       "ip": "1.1.1.1",
       "port": 8002
     },
-    "event": {
-      "category": "event",
-      "code": "0105048039",
-      "reason": "SSL Alert sent",
-      "created": "2021-04-26T04:17:39.492286Z",
-      "original": "CO0Bc1MbjbOwVYPYTY69yQWWHIKOI8wbccbfhTNgD35U8qHRdBl0E8x0SYR7PAFp",
-      "dialect_uuid": "a948028d-8e9c-48e3-9f3a-193f2c42e9d1",
-      "id": "3b43476c-40d8-45de-91a9-4ee0312bec21",
-      "outcome": "success",
-      "dialect": "fortigate",
-      "kind": "event"
-    },
     "fortinet": {
       "event": {
         "desc": "illegal parameter"
@@ -39,7 +39,6 @@
     "log": {
       "level": "error"
     },
-    "message": "time=15:29:39 devname=\"abc\" devid=\"1\" logid=\"0105048039\" type=\"event\" subtype=\"wad\" level=\"error\" vd=\"PRX1-AA\" eventtime=1619616579 logdesc=\"SSL fatal alert sent\" session_id=473f963d policyid=0 srcip=2.2.2.2 srcport=47782 dstip=1.1.1.1 dstport=8002 action=\"send\" alert=\"2\" desc=\"illegal parameter\" msg=\"SSL Alert sent\"",
     "source": {
       "address": "2.2.2.2",
       "ip": "2.2.2.2",
@@ -47,13 +46,9 @@
     },
     "related": {
       "ip": [
-        "1.1.1.1", "2.2.2.2"
+        "1.1.1.1",
+        "2.2.2.2"
       ]
-    },
-    "sekoiaio": {
-      "intake": {
-        "parsing_status": "success"
-      }
     }
   }
 }

--- a/Fortinet/fortigate/tests/dns.CSV.json
+++ b/Fortinet/fortigate/tests/dns.CSV.json
@@ -9,38 +9,27 @@
     "message": "date=2018-12-27,time=14:45:26,logid=\"1501054802\",type=\"dns\",subtype=\"dns-response\",level=\"notice\",vd=\"vdom1\",eventtime=1545950726,policyid=1,sessionid=13355,user=\"bob\",srcip=1.1.1.1,srcport=54621,srcintf=\"port12\",srcintfrole=\"lan\",dstip=2.2.2.2,dstport=53,dstintf=\"port11\",dstintfrole=\"wan\",proto=17,profile=\"default\",srcmac=\"00:00:00:00:00:00\",xid=5137,qname=\"detectportal.firefox.com\",qtype=\"A\",qtypeval=1,qclass=\"IN\",ipaddr=\"104.80.89.26, 104.80.89.24\",msg=\"Domain is monitored\",action=\"pass\",cat=52,catdesc=\"Information Technology\""
   },
   "expected": {
+    "message": "date=2018-12-27,time=14:45:26,logid=\"1501054802\",type=\"dns\",subtype=\"dns-response\",level=\"notice\",vd=\"vdom1\",eventtime=1545950726,policyid=1,sessionid=13355,user=\"bob\",srcip=1.1.1.1,srcport=54621,srcintf=\"port12\",srcintfrole=\"lan\",dstip=2.2.2.2,dstport=53,dstintf=\"port11\",dstintfrole=\"wan\",proto=17,profile=\"default\",srcmac=\"00:00:00:00:00:00\",xid=5137,qname=\"detectportal.firefox.com\",qtype=\"A\",qtypeval=1,qclass=\"IN\",ipaddr=\"104.80.89.26, 104.80.89.24\",msg=\"Domain is monitored\",action=\"pass\",cat=52,catdesc=\"Information Technology\"",
     "event": {
-      "code": "1501054802",
-      "outcome": "success",
-      "dialect": "fortigate",
-      "reason": "Domain is monitored",
       "category": "dns",
+      "code": "1501054802",
+      "reason": "Domain is monitored",
+      "dialect": "fortigate",
       "created": "2021-04-23T20:02:05.017771Z",
       "original": "1sjze813YtXlmgHp3a1jU4rOAwYpBKMFaWtYCeTQ0QhEtg36Z68bcNi4ahZ2G7Fz",
       "dialect_uuid": "1e256ea1-3947-429e-97a6-abaec8702dc4",
-      "id": "10f0afe9-98a1-4226-a6bd-8f70d461d430",
       "kind": "event"
     },
-    "log": {
-      "level": "notice"
-    },
-    "message": "date=2018-12-27,time=14:45:26,logid=\"1501054802\",type=\"dns\",subtype=\"dns-response\",level=\"notice\",vd=\"vdom1\",eventtime=1545950726,policyid=1,sessionid=13355,user=\"bob\",srcip=1.1.1.1,srcport=54621,srcintf=\"port12\",srcintfrole=\"lan\",dstip=2.2.2.2,dstport=53,dstintf=\"port11\",dstintfrole=\"wan\",proto=17,profile=\"default\",srcmac=\"00:00:00:00:00:00\",xid=5137,qname=\"detectportal.firefox.com\",qtype=\"A\",qtypeval=1,qclass=\"IN\",ipaddr=\"104.80.89.26, 104.80.89.24\",msg=\"Domain is monitored\",action=\"pass\",cat=52,catdesc=\"Information Technology\"",
-    "source": {
-      "ip": "1.1.1.1",
-      "address": "1.1.1.1",
-      "port": 54621,
-      "mac": "00:00:00:00:00:00",
-      "user": {
-        "name": "bob"
-      }
+    "@timestamp": "2018-12-27T22:45:26.000000Z",
+    "action": {
+      "name": "pass",
+      "outcome": "success",
+      "type": "dns-response"
     },
     "destination": {
-      "ip": "2.2.2.2",
       "address": "2.2.2.2",
+      "ip": "2.2.2.2",
       "port": 53
-    },
-    "network": {
-      "transport": "udp"
     },
     "dns": {
       "question": {
@@ -48,10 +37,11 @@
         "type": "A"
       }
     },
-    "action": {
-      "name": "pass",
-      "outcome": "success",
-      "type": "dns-response"
+    "log": {
+      "level": "notice"
+    },
+    "network": {
+      "transport": "udp"
     },
     "observer": {
       "egress": {
@@ -68,18 +58,23 @@
     "rule": {
       "category": "Information Technology"
     },
+    "source": {
+      "address": "1.1.1.1",
+      "ip": "1.1.1.1",
+      "mac": "00:00:00:00:00:00",
+      "port": 54621,
+      "user": {
+        "name": "bob"
+      }
+    },
     "related": {
       "ip": [
-        "1.1.1.1", "2.2.2.2"
+        "1.1.1.1",
+        "2.2.2.2"
       ],
       "user": [
         "bob"
       ]
-    },
-    "sekoiaio": {
-      "intake": {
-        "parsing_status": "success"
-      }
     }
   }
 }

--- a/Fortinet/fortigate/tests/hostname.STANDARD.json
+++ b/Fortinet/fortigate/tests/hostname.STANDARD.json
@@ -9,44 +9,39 @@
     "message": "time=11:09:50 devname=\"abc\" devid=\"1\" logid=\"1059028704\" type=\"utm\" subtype=\"app-ctrl\" eventtype=\"app-ctrl-all\" level=\"information\" vd=\"root\" eventtime=1579860590 appid=40568 srcip=1.1.1.1 dstip=2.2.2.2 srcport=33345 dstport=443 srcintf=\"test\" srcintfrole=\"undefined\" dstintf=\"port1\" dstintfrole=\"undefined\" proto=6 service=\"HTTPS\" direction=\"outgoing\" policyid=1 sessionid=1508480438 applist=\"default\" appcat=\"Web.Client\" app=\"HTTPS.BROWSER\" action=\"pass\" hostname=\"abcd\" incidentserialno=455926217 url=\"/\" msg=\"Web.Client: HTTPS.BROWSER,\" apprisk=\"medium\""
   },
   "expected": {
+    "message": "time=11:09:50 devname=\"abc\" devid=\"1\" logid=\"1059028704\" type=\"utm\" subtype=\"app-ctrl\" eventtype=\"app-ctrl-all\" level=\"information\" vd=\"root\" eventtime=1579860590 appid=40568 srcip=1.1.1.1 dstip=2.2.2.2 srcport=33345 dstport=443 srcintf=\"test\" srcintfrole=\"undefined\" dstintf=\"port1\" dstintfrole=\"undefined\" proto=6 service=\"HTTPS\" direction=\"outgoing\" policyid=1 sessionid=1508480438 applist=\"default\" appcat=\"Web.Client\" app=\"HTTPS.BROWSER\" action=\"pass\" hostname=\"abcd\" incidentserialno=455926217 url=\"/\" msg=\"Web.Client: HTTPS.BROWSER,\" apprisk=\"medium\"",
     "event": {
-      "code": "1059028704",
-      "outcome": "success",
-      "dialect": "fortigate",
-      "reason": "Web.Client: HTTPS.BROWSER,",
       "category": "utm",
+      "code": "1059028704",
+      "reason": "Web.Client: HTTPS.BROWSER,",
+      "dialect": "fortigate",
       "created": "2021-04-23T20:02:05.017771Z",
       "original": "1sjze813YtXlmgHp3a1jU4rOAwYpBKMFaWtYCeTQ0QhEtg36Z68bcNi4ahZ2G7Fz",
       "dialect_uuid": "1e256ea1-3947-429e-97a6-abaec8702dc4",
-      "id": "10f0afe9-98a1-4226-a6bd-8f70d461d430",
       "kind": "event"
     },
-    "message": "time=11:09:50 devname=\"abc\" devid=\"1\" logid=\"1059028704\" type=\"utm\" subtype=\"app-ctrl\" eventtype=\"app-ctrl-all\" level=\"information\" vd=\"root\" eventtime=1579860590 appid=40568 srcip=1.1.1.1 dstip=2.2.2.2 srcport=33345 dstport=443 srcintf=\"test\" srcintfrole=\"undefined\" dstintf=\"port1\" dstintfrole=\"undefined\" proto=6 service=\"HTTPS\" direction=\"outgoing\" policyid=1 sessionid=1508480438 applist=\"default\" appcat=\"Web.Client\" app=\"HTTPS.BROWSER\" action=\"pass\" hostname=\"abcd\" incidentserialno=455926217 url=\"/\" msg=\"Web.Client: HTTPS.BROWSER,\" apprisk=\"medium\"",
-    "source": {
-      "address": "1.1.1.1",
-      "port": 33345,
-      "ip": "1.1.1.1"
-    },
-    "destination": {
-      "address": "2.2.2.2",
-      "port": 443,
-      "ip": "2.2.2.2",
-      "domain": "abcd"
-    },
-    "network": {
-      "protocol": "HTTPS",
-      "transport": "tcp",
-      "application": "HTTPS.BROWSER"
-    },
+    "@timestamp": "2020-01-24T10:09:50.000000Z",
     "action": {
       "name": "pass",
       "outcome": "success",
       "type": "app-ctrl"
     },
-    "url": {
-      "original": "/",
-      "full": "/",
-      "path": "/"
+    "destination": {
+      "address": "2.2.2.2",
+      "domain": "abcd",
+      "ip": "2.2.2.2",
+      "port": 443
+    },
+    "fortinet": {
+      "apprisk": "medium"
+    },
+    "log": {
+      "level": "information"
+    },
+    "network": {
+      "application": "HTTPS.BROWSER",
+      "protocol": "HTTPS",
+      "transport": "tcp"
     },
     "observer": {
       "egress": {
@@ -60,28 +55,28 @@
         }
       }
     },
-    "fortinet": {
-      "apprisk": "medium"
-    },
     "rule": {
       "category": "Web.Client",
       "ruleset": "default"
+    },
+    "source": {
+      "address": "1.1.1.1",
+      "ip": "1.1.1.1",
+      "port": 33345
+    },
+    "url": {
+      "full": "/",
+      "original": "/",
+      "path": "/"
     },
     "related": {
       "hosts": [
         "abcd"
       ],
       "ip": [
-        "1.1.1.1", "2.2.2.2"
+        "1.1.1.1",
+        "2.2.2.2"
       ]
-    },
-    "log": {
-      "level": "information"
-    },
-    "sekoiaio": {
-      "intake": {
-        "parsing_status": "success"
-      }
     }
   }
 }

--- a/Fortinet/fortigate/tests/icmp.json
+++ b/Fortinet/fortigate/tests/icmp.json
@@ -20,6 +20,7 @@
       "dialect_uuid": "1e256ea1-3947-429e-97a6-abaec8702dc4",
       "kind": "event"
     },
+    "@timestamp": "2020-10-13T09:22:43.587868Z",
     "action": {
       "name": "ip-conn",
       "outcome": "success",

--- a/Fortinet/fortigate/tests/icmp.json
+++ b/Fortinet/fortigate/tests/icmp.json
@@ -9,37 +9,32 @@
     "message": " time=15:22:43 devname=\"abc\" devid=\"1\" logid=\"0000000011\" type=\"traffic\" subtype=\"forward\" level=\"warning\" vd=\"root\" eventtime=1602591763587868496 tz=\"+0300\" srcip=1.1.1.1 identifier=256 srcintf=\"internal\" srcintfrole=\"lan\" dstip=2.2.2.2 dstintf=\"wan1\" dstintfrole=\"wan\" srcuuid=\"b22e6ef4-2e38-51ea-72c9-53b2da2e20f5\" dstuuid=\"052bdbce-823a-51e9-eb23-7a3e819fea4f\" poluuid=\"1520e1aa-823a-51e9-984f-a55e1f39b3c7\" sessionid=706677975 proto=1 action=\"ip-conn\" policyid=1 policytype=\"policy\" service=\"icmp/0/8\" dstcountry=\"Netherlands\" srccountry=\"Reserved\" appcat=\"unscanned\" crscore=5 craction=262144 crlevel=\"low\""
   },
   "expected": {
+    "message": " time=15:22:43 devname=\"abc\" devid=\"1\" logid=\"0000000011\" type=\"traffic\" subtype=\"forward\" level=\"warning\" vd=\"root\" eventtime=1602591763587868496 tz=\"+0300\" srcip=1.1.1.1 identifier=256 srcintf=\"internal\" srcintfrole=\"lan\" dstip=2.2.2.2 dstintf=\"wan1\" dstintfrole=\"wan\" srcuuid=\"b22e6ef4-2e38-51ea-72c9-53b2da2e20f5\" dstuuid=\"052bdbce-823a-51e9-eb23-7a3e819fea4f\" poluuid=\"1520e1aa-823a-51e9-984f-a55e1f39b3c7\" sessionid=706677975 proto=1 action=\"ip-conn\" policyid=1 policytype=\"policy\" service=\"icmp/0/8\" dstcountry=\"Netherlands\" srccountry=\"Reserved\" appcat=\"unscanned\" crscore=5 craction=262144 crlevel=\"low\"",
     "event": {
-      "code": "0000000011",
-      "outcome": "success",
-      "dialect": "fortigate",
       "category": "traffic",
+      "code": "0000000011",
+      "timezone": "+0300",
+      "dialect": "fortigate",
       "created": "2021-04-23T20:02:05.017771Z",
       "original": "1sjze813YtXlmgHp3a1jU4rOAwYpBKMFaWtYCeTQ0QhEtg36Z68bcNi4ahZ2G7Fz",
       "dialect_uuid": "1e256ea1-3947-429e-97a6-abaec8702dc4",
-      "id": "10f0afe9-98a1-4226-a6bd-8f70d461d430",
       "kind": "event"
-    },
-    "log": {
-      "level": "warning"
-    },
-    "message": " time=15:22:43 devname=\"abc\" devid=\"1\" logid=\"0000000011\" type=\"traffic\" subtype=\"forward\" level=\"warning\" vd=\"root\" eventtime=1602591763587868496 tz=\"+0300\" srcip=1.1.1.1 identifier=256 srcintf=\"internal\" srcintfrole=\"lan\" dstip=2.2.2.2 dstintf=\"wan1\" dstintfrole=\"wan\" srcuuid=\"b22e6ef4-2e38-51ea-72c9-53b2da2e20f5\" dstuuid=\"052bdbce-823a-51e9-eb23-7a3e819fea4f\" poluuid=\"1520e1aa-823a-51e9-984f-a55e1f39b3c7\" sessionid=706677975 proto=1 action=\"ip-conn\" policyid=1 policytype=\"policy\" service=\"icmp/0/8\" dstcountry=\"Netherlands\" srccountry=\"Reserved\" appcat=\"unscanned\" crscore=5 craction=262144 crlevel=\"low\"",
-    "destination": {
-      "address": "2.2.2.2",
-      "ip": "2.2.2.2"
-    },
-    "source": {
-      "address": "1.1.1.1",
-      "ip": "1.1.1.1"
-    },
-    "network": {
-      "transport": "icmp",
-      "protocol": "icmp/0/8"
     },
     "action": {
       "name": "ip-conn",
       "outcome": "success",
       "type": "forward"
+    },
+    "destination": {
+      "address": "2.2.2.2",
+      "ip": "2.2.2.2"
+    },
+    "log": {
+      "level": "warning"
+    },
+    "network": {
+      "protocol": "icmp/0/8",
+      "transport": "icmp"
     },
     "observer": {
       "egress": {
@@ -57,15 +52,15 @@
       "category": "unscanned",
       "ruleset": "policy"
     },
+    "source": {
+      "address": "1.1.1.1",
+      "ip": "1.1.1.1"
+    },
     "related": {
       "ip": [
-        "1.1.1.1", "2.2.2.2"
+        "1.1.1.1",
+        "2.2.2.2"
       ]
-    },
-    "sekoiaio": {
-      "intake": {
-        "parsing_status": "success"
-      }
     }
   }
 }

--- a/Fortinet/fortigate/tests/icmp6.json
+++ b/Fortinet/fortigate/tests/icmp6.json
@@ -20,6 +20,7 @@
       "dialect_uuid": "1e256ea1-3947-429e-97a6-abaec8702dc4",
       "kind": "event"
     },
+    "@timestamp": "2020-10-13T09:02:14.900309Z",
     "action": {
       "name": "accept",
       "outcome": "success",

--- a/Fortinet/fortigate/tests/icmp6.json
+++ b/Fortinet/fortigate/tests/icmp6.json
@@ -9,42 +9,35 @@
     "message": " time=13:02:14 devname=\"abc\" devid=\"1\" logid=\"0001000014\" type=\"traffic\" subtype=\"local\" level=\"notice\" vd=\"root\" eventtime=1602586934900309053 tz=\"+0200\" srcip=00::00:00:00:00 identifier=0 srcintf=\"AVR-GUEST-AP\" srcintfrole=\"lan\" dstip=12::16 dstintf=\"unknown0\" dstintfrole=\"undefined\" sessionid=1395131 proto=58 action=\"accept\" policyid=0 policytype=\"local-in-policy6\" service=\"icmp6/143/0\" trandisp=\"noop\" app=\"icmp6/143/0\" duration=60 sentbyte=76 rcvdbyte=0 sentpkt=1 rcvdpkt=0 appcat=\"unscanned\""
   },
   "expected": {
+    "message": " time=13:02:14 devname=\"abc\" devid=\"1\" logid=\"0001000014\" type=\"traffic\" subtype=\"local\" level=\"notice\" vd=\"root\" eventtime=1602586934900309053 tz=\"+0200\" srcip=00::00:00:00:00 identifier=0 srcintf=\"AVR-GUEST-AP\" srcintfrole=\"lan\" dstip=12::16 dstintf=\"unknown0\" dstintfrole=\"undefined\" sessionid=1395131 proto=58 action=\"accept\" policyid=0 policytype=\"local-in-policy6\" service=\"icmp6/143/0\" trandisp=\"noop\" app=\"icmp6/143/0\" duration=60 sentbyte=76 rcvdbyte=0 sentpkt=1 rcvdpkt=0 appcat=\"unscanned\"",
     "event": {
-      "code": "0001000014",
-      "outcome": "success",
-      "dialect": "fortigate",
       "category": "traffic",
+      "code": "0001000014",
+      "timezone": "+0200",
+      "dialect": "fortigate",
       "created": "2021-04-23T20:02:05.017771Z",
       "original": "1sjze813YtXlmgHp3a1jU4rOAwYpBKMFaWtYCeTQ0QhEtg36Z68bcNi4ahZ2G7Fz",
       "dialect_uuid": "1e256ea1-3947-429e-97a6-abaec8702dc4",
-      "id": "10f0afe9-98a1-4226-a6bd-8f70d461d430",
       "kind": "event"
-    },
-    "log": {
-      "level": "notice"
-    },
-    "message": " time=13:02:14 devname=\"abc\" devid=\"1\" logid=\"0001000014\" type=\"traffic\" subtype=\"local\" level=\"notice\" vd=\"root\" eventtime=1602586934900309053 tz=\"+0200\" srcip=00::00:00:00:00 identifier=0 srcintf=\"AVR-GUEST-AP\" srcintfrole=\"lan\" dstip=12::16 dstintf=\"unknown0\" dstintfrole=\"undefined\" sessionid=1395131 proto=58 action=\"accept\" policyid=0 policytype=\"local-in-policy6\" service=\"icmp6/143/0\" trandisp=\"noop\" app=\"icmp6/143/0\" duration=60 sentbyte=76 rcvdbyte=0 sentpkt=1 rcvdpkt=0 appcat=\"unscanned\"",
-    "source": {
-      "ip": "00::00:00:00:00",
-      "address": "00::00:00:00:00",
-      "bytes": 76,
-      "packets": 1
-    },
-    "destination": {
-      "address": "12::16",
-      "ip": "12::16",
-      "bytes": 0,
-      "packets": 0
-    },
-    "network": {
-      "transport": "ipv6-icmp",
-      "protocol": "icmp6/143/0",
-      "application": "icmp6/143/0"
     },
     "action": {
       "name": "accept",
       "outcome": "success",
       "type": "local"
+    },
+    "destination": {
+      "address": "12::16",
+      "bytes": 0,
+      "ip": "12::16",
+      "packets": 0
+    },
+    "log": {
+      "level": "notice"
+    },
+    "network": {
+      "application": "icmp6/143/0",
+      "protocol": "icmp6/143/0",
+      "transport": "ipv6-icmp"
     },
     "observer": {
       "egress": {
@@ -62,15 +55,17 @@
       "category": "unscanned",
       "ruleset": "local-in-policy6"
     },
+    "source": {
+      "address": "00::00:00:00:00",
+      "bytes": 76,
+      "ip": "00::00:00:00:00",
+      "packets": 1
+    },
     "related": {
       "ip": [
-        "00::00:00:00:00", "12::16"
+        "00::00:00:00:00",
+        "12::16"
       ]
-    },
-    "sekoiaio": {
-      "intake": {
-        "parsing_status": "success"
-      }
     }
   }
 }

--- a/Fortinet/fortigate/tests/icmp_CEF.json
+++ b/Fortinet/fortigate/tests/icmp_CEF.json
@@ -9,57 +9,52 @@
     "message": "CEF:0|Fortinet|Fortigate|v6.0.10|00014|traffic:local accept|3|deviceExternalId=FGVM2V0000171868 FortinetFortiGatelogid=0001000014 cat=traffic:local FortinetFortiGatesubtype=local FortinetFortiGatelevel=notice FortinetFortiGatevd=root FortinetFortiGateeventtime=1602663098 src=1.1.1.1 deviceInboundInterface=port1 FortinetFortiGatesrcintfrole=undefined dst=2.2.2.2 deviceOutboundInterface=root FortinetFortiGatedstintfrole=undefined externalId=4887198 proto=1 FortinetFortiGateaction=accept FortinetFortiGatepolicyid=0 FortinetFortiGatepolicytype=local-in-policy app=icmp/8/0 FortinetFortiGatedstcountry=Reserved FortinetFortiGatesrccountry=China FortinetFortiGatetrandisp=noop FortinetFortiGateapp=icmp/8/0 FortinetFortiGateduration=61 out=84 in=84 FortinetFortiGatesentpkt=1 FortinetFortiGatercvdpkt=1 FortinetFortiGateappcat=unscanned"
   },
   "expected": {
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.10|00014|traffic:local accept|3|deviceExternalId=FGVM2V0000171868 FortinetFortiGatelogid=0001000014 cat=traffic:local FortinetFortiGatesubtype=local FortinetFortiGatelevel=notice FortinetFortiGatevd=root FortinetFortiGateeventtime=1602663098 src=1.1.1.1 deviceInboundInterface=port1 FortinetFortiGatesrcintfrole=undefined dst=2.2.2.2 deviceOutboundInterface=root FortinetFortiGatedstintfrole=undefined externalId=4887198 proto=1 FortinetFortiGateaction=accept FortinetFortiGatepolicyid=0 FortinetFortiGatepolicytype=local-in-policy app=icmp/8/0 FortinetFortiGatedstcountry=Reserved FortinetFortiGatesrccountry=China FortinetFortiGatetrandisp=noop FortinetFortiGateapp=icmp/8/0 FortinetFortiGateduration=61 out=84 in=84 FortinetFortiGatesentpkt=1 FortinetFortiGatercvdpkt=1 FortinetFortiGateappcat=unscanned",
     "event": {
       "code": "0001000014",
-      "outcome": "success",
       "dialect": "fortigate",
       "severity": "3",
       "category": "traffic",
       "created": "2021-04-23T20:02:05.017771Z",
       "original": "1sjze813YtXlmgHp3a1jU4rOAwYpBKMFaWtYCeTQ0QhEtg36Z68bcNi4ahZ2G7Fz",
       "dialect_uuid": "1e256ea1-3947-429e-97a6-abaec8702dc4",
-      "id": "10f0afe9-98a1-4226-a6bd-8f70d461d430",
       "kind": "event"
+    },
+    "@timestamp": "2020-10-14T08:11:38.000000Z",
+    "action": {
+      "name": "accept",
+      "outcome": "success",
+      "type": "local"
+    },
+    "destination": {
+      "address": "2.2.2.2",
+      "bytes": 84,
+      "ip": "2.2.2.2",
+      "packets": 1
     },
     "log": {
       "level": "notice"
     },
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.10|00014|traffic:local accept|3|deviceExternalId=FGVM2V0000171868 FortinetFortiGatelogid=0001000014 cat=traffic:local FortinetFortiGatesubtype=local FortinetFortiGatelevel=notice FortinetFortiGatevd=root FortinetFortiGateeventtime=1602663098 src=1.1.1.1 deviceInboundInterface=port1 FortinetFortiGatesrcintfrole=undefined dst=2.2.2.2 deviceOutboundInterface=root FortinetFortiGatedstintfrole=undefined externalId=4887198 proto=1 FortinetFortiGateaction=accept FortinetFortiGatepolicyid=0 FortinetFortiGatepolicytype=local-in-policy app=icmp/8/0 FortinetFortiGatedstcountry=Reserved FortinetFortiGatesrccountry=China FortinetFortiGatetrandisp=noop FortinetFortiGateapp=icmp/8/0 FortinetFortiGateduration=61 out=84 in=84 FortinetFortiGatesentpkt=1 FortinetFortiGatercvdpkt=1 FortinetFortiGateappcat=unscanned",
-    "source": {
-      "ip": "1.1.1.1",
-      "address": "1.1.1.1",
-      "bytes": 84,
-      "packets": 1
-    },
-    "destination": {
-      "address": "2.2.2.2",
-      "ip": "2.2.2.2",
-      "bytes": 84,
-      "packets": 1
-    },
     "network": {
-      "transport": "icmp",
-      "application": "icmp/8/0"
+      "application": "icmp/8/0",
+      "transport": "icmp"
     },
     "observer": {
       "type": "Fortigate",
       "vendor": "Fortinet",
       "version": "v6.0.10"
     },
-    "action": {
-      "name": "accept",
-      "outcome": "success",
-      "type": "local"
+    "source": {
+      "address": "1.1.1.1",
+      "bytes": 84,
+      "ip": "1.1.1.1",
+      "packets": 1
     },
     "related": {
       "ip": [
-        "1.1.1.1", "2.2.2.2"
+        "1.1.1.1",
+        "2.2.2.2"
       ]
-    },
-    "sekoiaio": {
-      "intake": {
-        "parsing_status": "success"
-      }
     }
   }
 }

--- a/Fortinet/fortigate/tests/ping.json
+++ b/Fortinet/fortigate/tests/ping.json
@@ -20,6 +20,7 @@
       "dialect_uuid": "1e256ea1-3947-429e-97a6-abaec8702dc4",
       "kind": "event"
     },
+    "@timestamp": "2020-10-13T10:22:38.311909Z",
     "action": {
       "name": "accept",
       "outcome": "success",

--- a/Fortinet/fortigate/tests/ping.json
+++ b/Fortinet/fortigate/tests/ping.json
@@ -9,41 +9,34 @@
     "message": " time=14:22:37 devname=\"abc\" devid=\"1\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"ROUTER\" eventtime=1602591758311908837 tz=\"+0200\" srcip=1.1.1.1 identifier=29027 srcintf=\"test1\" srcintfrole=\"undefined\" dstip=2.2.2.2 dstintf=\"test\" dstintfrole=\"undefined\" sessionid=3558919660 proto=1 action=\"accept\" policyid=637 policytype=\"policy\" poluuid=\"b23818a6-8f49-51ea-9db7-4e4965a3483c\" service=\"PING\" dstcountry=\"Reserved\" srccountry=\"Reserved\" trandisp=\"noop\" duration=64 sentbyte=420 rcvdbyte=420 sentpkt=5 rcvdpkt=5 appcat=\"unscanned\""
   },
   "expected": {
+    "message": " time=14:22:37 devname=\"abc\" devid=\"1\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"ROUTER\" eventtime=1602591758311908837 tz=\"+0200\" srcip=1.1.1.1 identifier=29027 srcintf=\"test1\" srcintfrole=\"undefined\" dstip=2.2.2.2 dstintf=\"test\" dstintfrole=\"undefined\" sessionid=3558919660 proto=1 action=\"accept\" policyid=637 policytype=\"policy\" poluuid=\"b23818a6-8f49-51ea-9db7-4e4965a3483c\" service=\"PING\" dstcountry=\"Reserved\" srccountry=\"Reserved\" trandisp=\"noop\" duration=64 sentbyte=420 rcvdbyte=420 sentpkt=5 rcvdpkt=5 appcat=\"unscanned\"",
     "event": {
-      "code": "0000000013",
-      "outcome": "success",
-      "dialect": "fortigate",
       "category": "traffic",
+      "code": "0000000013",
+      "timezone": "+0200",
+      "dialect": "fortigate",
       "created": "2021-04-23T20:02:05.017771Z",
       "original": "1sjze813YtXlmgHp3a1jU4rOAwYpBKMFaWtYCeTQ0QhEtg36Z68bcNi4ahZ2G7Fz",
       "dialect_uuid": "1e256ea1-3947-429e-97a6-abaec8702dc4",
-      "id": "10f0afe9-98a1-4226-a6bd-8f70d461d430",
       "kind": "event"
-    },
-    "log": {
-      "level": "notice"
-    },
-    "message": " time=14:22:37 devname=\"abc\" devid=\"1\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"ROUTER\" eventtime=1602591758311908837 tz=\"+0200\" srcip=1.1.1.1 identifier=29027 srcintf=\"test1\" srcintfrole=\"undefined\" dstip=2.2.2.2 dstintf=\"test\" dstintfrole=\"undefined\" sessionid=3558919660 proto=1 action=\"accept\" policyid=637 policytype=\"policy\" poluuid=\"b23818a6-8f49-51ea-9db7-4e4965a3483c\" service=\"PING\" dstcountry=\"Reserved\" srccountry=\"Reserved\" trandisp=\"noop\" duration=64 sentbyte=420 rcvdbyte=420 sentpkt=5 rcvdpkt=5 appcat=\"unscanned\"",
-    "source": {
-      "ip": "1.1.1.1",
-      "address": "1.1.1.1",
-      "bytes": 420,
-      "packets": 5
-    },
-    "destination": {
-      "address": "2.2.2.2",
-      "ip": "2.2.2.2",
-      "bytes": 420,
-      "packets": 5
-    },
-    "network": {
-      "transport": "icmp",
-      "protocol": "PING"
     },
     "action": {
       "name": "accept",
       "outcome": "success",
       "type": "forward"
+    },
+    "destination": {
+      "address": "2.2.2.2",
+      "bytes": 420,
+      "ip": "2.2.2.2",
+      "packets": 5
+    },
+    "log": {
+      "level": "notice"
+    },
+    "network": {
+      "protocol": "PING",
+      "transport": "icmp"
     },
     "observer": {
       "egress": {
@@ -61,15 +54,17 @@
       "category": "unscanned",
       "ruleset": "policy"
     },
+    "source": {
+      "address": "1.1.1.1",
+      "bytes": 420,
+      "ip": "1.1.1.1",
+      "packets": 5
+    },
     "related": {
       "ip": [
-        "1.1.1.1", "2.2.2.2"
+        "1.1.1.1",
+        "2.2.2.2"
       ]
-    },
-    "sekoiaio": {
-      "intake": {
-        "parsing_status": "success"
-      }
     }
   }
 }

--- a/Fortinet/fortigate/tests/ssh_access.CEF.json
+++ b/Fortinet/fortigate/tests/ssh_access.CEF.json
@@ -9,38 +9,32 @@
     "message": "CEF:0|Fortinet|Fortigate|v6.0.4|32021|event:system login failed|7|deviceExternalId=FGVM2V0000171868 FortinetFortiGatelogid=0100032021 cat=event:system FortinetFortiGatesubtype=system FortinetFortiGatelevel=alert FortinetFortiGatevd=root FortinetFortiGateeventtime=1579172447 FortinetFortiGatelogdesc=Admin login disabled sproc=1.1.1.1 FortinetFortiGateaction=login outcome=failed reason=exceed_limit msg=Login disabled from IP 1.1.1.1 for 60 seconds because of 3 bad attempts"
   },
   "expected": {
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.4|32021|event:system login failed|7|deviceExternalId=FGVM2V0000171868 FortinetFortiGatelogid=0100032021 cat=event:system FortinetFortiGatesubtype=system FortinetFortiGatelevel=alert FortinetFortiGatevd=root FortinetFortiGateeventtime=1579172447 FortinetFortiGatelogdesc=Admin login disabled sproc=1.1.1.1 FortinetFortiGateaction=login outcome=failed reason=exceed_limit msg=Login disabled from IP 1.1.1.1 for 60 seconds because of 3 bad attempts",
     "event": {
+      "action": "exceed_limit",
       "code": "0100032021",
-      "outcome": "success",
+      "reason": "Login disabled from IP 1.1.1.1 for 60 seconds because of 3 bad attempts",
       "dialect": "fortigate",
       "severity": "7",
-      "reason": "Login disabled from IP 1.1.1.1 for 60 seconds because of 3 bad attempts",
       "category": "event",
       "created": "2021-04-23T20:02:05.017771Z",
       "original": "1sjze813YtXlmgHp3a1jU4rOAwYpBKMFaWtYCeTQ0QhEtg36Z68bcNi4ahZ2G7Fz",
       "dialect_uuid": "1e256ea1-3947-429e-97a6-abaec8702dc4",
-      "id": "10f0afe9-98a1-4226-a6bd-8f70d461d430",
-      "kind": "event",
-      "action": "exceed_limit"
+      "kind": "event"
     },
-    "log": {
-      "level": "alert"
-    },
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.4|32021|event:system login failed|7|deviceExternalId=FGVM2V0000171868 FortinetFortiGatelogid=0100032021 cat=event:system FortinetFortiGatesubtype=system FortinetFortiGatelevel=alert FortinetFortiGatevd=root FortinetFortiGateeventtime=1579172447 FortinetFortiGatelogdesc=Admin login disabled sproc=1.1.1.1 FortinetFortiGateaction=login outcome=failed reason=exceed_limit msg=Login disabled from IP 1.1.1.1 for 60 seconds because of 3 bad attempts",
-    "observer": {
-      "type": "Fortigate",
-      "vendor": "Fortinet",
-      "version": "v6.0.4"
-    },
+    "@timestamp": "2020-01-16T11:00:47.000000Z",
     "action": {
       "name": "login",
       "outcome": "success",
       "type": "system"
     },
-    "sekoiaio": {
-      "intake": {
-        "parsing_status": "success"
-      }
+    "log": {
+      "level": "alert"
+    },
+    "observer": {
+      "type": "Fortigate",
+      "vendor": "Fortinet",
+      "version": "v6.0.4"
     }
   }
 }

--- a/Fortinet/fortigate/tests/ssl_new_con.CEF.json
+++ b/Fortinet/fortigate/tests/ssl_new_con.CEF.json
@@ -9,6 +9,7 @@
     "message": "CEF:0|Fortinet|Fortigate|v6.0.10|39943|event:vpn ssl-new-con|2|deviceExternalId=FGT3HD3916803645 FTNTFGTlogid=0101039943 cat=event:vpn FTNTFGTsubtype=vpn FTNTFGTlevel=information FTNTFGTvd=root FTNTFGTeventtime=1637338258 FTNTFGTlogdesc=SSL VPN new connection act=ssl-new-con FTNTFGTtunneltype=ssl FTNTFGTtunnelid=0 dst=2.2.2.2 duser=N/A FTNTFGTgroup=N/A FTNTFGTdst_host=N/A reason=N/A msg=SSL new connection"
   },
   "expected": {
+    "@timestamp": "2021-11-19T16:10:58.000000Z",
     "event": {
       "category": "event",
       "code": "0101039943",
@@ -21,8 +22,7 @@
       "severity": "2",
       "reason": "SSL new connection",
       "kind": "event",
-      "action": "N/A",
-      "ingested": "1637338258"
+      "action": "N/A"
     },
     "log": {
       "level": "information"

--- a/Fortinet/fortigate/tests/ssl_new_con.CEF.json
+++ b/Fortinet/fortigate/tests/ssl_new_con.CEF.json
@@ -21,7 +21,8 @@
       "severity": "2",
       "reason": "SSL new connection",
       "kind": "event",
-      "action": "N/A"
+      "action": "N/A",
+      "ingested": "1637338258"
     },
     "log": {
       "level": "information"

--- a/Fortinet/fortigate/tests/ssl_new_con.CEF.json
+++ b/Fortinet/fortigate/tests/ssl_new_con.CEF.json
@@ -31,7 +31,7 @@
       "address": "2.2.2.2",
       "ip": "2.2.2.2"
     },
-    "message": "CEF - LOG [SEKOIA@53288 intake_key=\"evkyRoUM7fNpYA2MVNDDmQ1kZJWLvLnt\"] CEF:0|Fortinet|Fortigate|v6.0.10|39943|event:vpn ssl-new-con|2|deviceExternalId=FGT3HD3916803645 FTNTFGTlogid=0101039943 cat=event:vpn FTNTFGTsubtype=vpn FTNTFGTlevel=information FTNTFGTvd=root FTNTFGTeventtime=1637338258 FTNTFGTlogdesc=SSL VPN new connection act=ssl-new-con FTNTFGTtunneltype=ssl FTNTFGTtunnelid=0 dst=2.2.2.2 duser=N/A FTNTFGTgroup=N/A FTNTFGTdst_host=N/A reason=N/A msg=SSL new connection",
+    "message": "CEF - LOG [SEKOIA@53288] CEF:0|Fortinet|Fortigate|v6.0.10|39943|event:vpn ssl-new-con|2|deviceExternalId=FGT3HD3916803645 FTNTFGTlogid=0101039943 cat=event:vpn FTNTFGTsubtype=vpn FTNTFGTlevel=information FTNTFGTvd=root FTNTFGTeventtime=1637338258 FTNTFGTlogdesc=SSL VPN new connection act=ssl-new-con FTNTFGTtunneltype=ssl FTNTFGTtunnelid=0 dst=2.2.2.2 duser=N/A FTNTFGTgroup=N/A FTNTFGTdst_host=N/A reason=N/A msg=SSL new connection",
     "observer": {
       "type": "Fortigate",
       "version": "v6.0.10",

--- a/Fortinet/fortigate/tests/traffic_forward.CEF-Axens.json
+++ b/Fortinet/fortigate/tests/traffic_forward.CEF-Axens.json
@@ -9,63 +9,59 @@
     "message": "CEF:0|Fortinet|Fortigate|v6.0.4|00013|traffic:forward timeout|3|deviceExternalId=FGVM2V0000171868 FortinetFortiGatelogid=0000000013 cat=traffic:forward FortinetFortiGatesubtype=forward FortinetFortiGatelevel=notice FortinetFortiGatevd=root FortinetFortiGateeventtime=1572471876 src=1.1.1.1 spt=49260 deviceInboundInterface=port1 FortinetFortiGatesrcintfrole=undefined dst=3.3.3.3 dpt=80 deviceOutboundInterface=port2 FortinetFortiGatedstintfrole=undefined FortinetFortiGatepoluuid=bafe134e-c0ad-51e8-ed9c-52f798dd69d4 externalId=12812952 proto=6 FortinetFortiGateaction=timeout FortinetFortiGatepolicyid=1 FortinetFortiGatepolicytype=policy app=HTTP FortinetFortiGatedstcountry=Reserved FortinetFortiGatesrccountry=United States FortinetFortiGatetrandisp=dnat destinationTranslatedAddress=2.2.2.2 destinationTranslatedPort=80 FortinetFortiGateduration=20 out=48 in=144 FortinetFortiGatesentpkt=1 FortinetFortiGatercvdpkt=3 FortinetFortiGateappcat=unscanned FortinetFortiGatecrscore=5 FortinetFortiGatecraction=262144 FortinetFortiGatecrlevel=low"
   },
   "expected": {
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.4|00013|traffic:forward timeout|3|deviceExternalId=FGVM2V0000171868 FortinetFortiGatelogid=0000000013 cat=traffic:forward FortinetFortiGatesubtype=forward FortinetFortiGatelevel=notice FortinetFortiGatevd=root FortinetFortiGateeventtime=1572471876 src=1.1.1.1 spt=49260 deviceInboundInterface=port1 FortinetFortiGatesrcintfrole=undefined dst=3.3.3.3 dpt=80 deviceOutboundInterface=port2 FortinetFortiGatedstintfrole=undefined FortinetFortiGatepoluuid=bafe134e-c0ad-51e8-ed9c-52f798dd69d4 externalId=12812952 proto=6 FortinetFortiGateaction=timeout FortinetFortiGatepolicyid=1 FortinetFortiGatepolicytype=policy app=HTTP FortinetFortiGatedstcountry=Reserved FortinetFortiGatesrccountry=United States FortinetFortiGatetrandisp=dnat destinationTranslatedAddress=2.2.2.2 destinationTranslatedPort=80 FortinetFortiGateduration=20 out=48 in=144 FortinetFortiGatesentpkt=1 FortinetFortiGatercvdpkt=3 FortinetFortiGateappcat=unscanned FortinetFortiGatecrscore=5 FortinetFortiGatecraction=262144 FortinetFortiGatecrlevel=low",
     "event": {
       "code": "0000000013",
-      "outcome": "success",
       "dialect": "fortigate",
       "severity": "3",
       "category": "traffic",
       "created": "2021-04-23T20:02:05.017771Z",
       "original": "1sjze813YtXlmgHp3a1jU4rOAwYpBKMFaWtYCeTQ0QhEtg36Z68bcNi4ahZ2G7Fz",
       "dialect_uuid": "1e256ea1-3947-429e-97a6-abaec8702dc4",
-      "id": "10f0afe9-98a1-4226-a6bd-8f70d461d430",
       "kind": "event"
     },
-    "log": {
-      "level": "notice"
-    },
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.4|00013|traffic:forward timeout|3|deviceExternalId=FGVM2V0000171868 FortinetFortiGatelogid=0000000013 cat=traffic:forward FortinetFortiGatesubtype=forward FortinetFortiGatelevel=notice FortinetFortiGatevd=root FortinetFortiGateeventtime=1572471876 src=1.1.1.1 spt=49260 deviceInboundInterface=port1 FortinetFortiGatesrcintfrole=undefined dst=3.3.3.3 dpt=80 deviceOutboundInterface=port2 FortinetFortiGatedstintfrole=undefined FortinetFortiGatepoluuid=bafe134e-c0ad-51e8-ed9c-52f798dd69d4 externalId=12812952 proto=6 FortinetFortiGateaction=timeout FortinetFortiGatepolicyid=1 FortinetFortiGatepolicytype=policy app=HTTP FortinetFortiGatedstcountry=Reserved FortinetFortiGatesrccountry=United States FortinetFortiGatetrandisp=dnat destinationTranslatedAddress=2.2.2.2 destinationTranslatedPort=80 FortinetFortiGateduration=20 out=48 in=144 FortinetFortiGatesentpkt=1 FortinetFortiGatercvdpkt=3 FortinetFortiGateappcat=unscanned FortinetFortiGatecrscore=5 FortinetFortiGatecraction=262144 FortinetFortiGatecrlevel=low",
-    "source": {
-      "ip": "1.1.1.1",
-      "address": "1.1.1.1",
-      "port": 49260,
-      "bytes": 144,
-      "packets": 1
+    "@timestamp": "2019-10-30T21:44:36.000000Z",
+    "action": {
+      "name": "timeout",
+      "outcome": "success",
+      "type": "forward"
     },
     "destination": {
+      "address": "3.3.3.3",
+      "bytes": 48,
+      "ip": "3.3.3.3",
       "nat": {
         "ip": "2.2.2.2",
         "port": 80
       },
-      "address": "3.3.3.3",
-      "ip": "3.3.3.3",
-      "port": 80,
-      "bytes": 48,
-      "packets": 3
+      "packets": 3,
+      "port": 80
+    },
+    "log": {
+      "level": "notice"
     },
     "network": {
-      "transport": "tcp",
-      "application": "HTTP"
+      "application": "HTTP",
+      "transport": "tcp"
     },
     "observer": {
       "type": "Fortigate",
       "vendor": "Fortinet",
       "version": "v6.0.4"
     },
-    "action": {
-      "name": "timeout",
-      "outcome": "success",
-      "type": "forward"
+    "source": {
+      "address": "1.1.1.1",
+      "bytes": 144,
+      "ip": "1.1.1.1",
+      "packets": 1,
+      "port": 49260
     },
     "related": {
       "ip": [
-        "1.1.1.1", "2.2.2.2", "3.3.3.3"
+        "1.1.1.1",
+        "2.2.2.2",
+        "3.3.3.3"
       ]
-    },
-    "sekoiaio": {
-      "intake": {
-        "parsing_status": "success"
-      }
     }
   }
 }

--- a/Fortinet/fortigate/tests/traffic_forward.CSV.json
+++ b/Fortinet/fortigate/tests/traffic_forward.CSV.json
@@ -9,46 +9,40 @@
     "message": "date=2018-07-26,time=16:51:36,logid=\"0000000013\",type=\"traffic\",subtype=\"forward\",level=\"notice\",vd=\"root\",eventtime=1532616695,srcip=1.1.1.1,srcport=10016,srcintf=\"test\",srcintfrole=\"undefined\",dstip=2.2.2.2,dstport=20,dstintf=\"dmz1\",dstintfrole=\"dmz\",sessionid=10006,proto=6,action=\"accept\",policyid=1,policytype=\"policy\",service=\"tcp/20\",dstcountry=\"France\",srccountry=\"United States\",trandisp=\"noop\",appid=35421,app=\"application\",appcat=\"Storage.Backup\",apprisk=\"medium\",applist=\"default\",duration=10,sentbyte=2000,rcvdbyte=1000,sentpkt=0,rcvdpkt=0,utmaction=\"allow\",countapp=1,devtype=\"iPad\",osname=\"Apple\",osversion=\"ver\",mastersrcmac=\"01:01:01:01:01:01\",srcmac=\"01:01:01:01:01:01\",srcserver=0,dstdevtype=\"Android Phone\",dstosname=\"Android\",dstosversion=\"ver\",masterdstmac=\"00:00:00:00:00:00\",dstmac=\"00:00:00:00:00:00\",dstserver=0,utmref=65491-194"
   },
   "expected": {
+    "message": "date=2018-07-26,time=16:51:36,logid=\"0000000013\",type=\"traffic\",subtype=\"forward\",level=\"notice\",vd=\"root\",eventtime=1532616695,srcip=1.1.1.1,srcport=10016,srcintf=\"test\",srcintfrole=\"undefined\",dstip=2.2.2.2,dstport=20,dstintf=\"dmz1\",dstintfrole=\"dmz\",sessionid=10006,proto=6,action=\"accept\",policyid=1,policytype=\"policy\",service=\"tcp/20\",dstcountry=\"France\",srccountry=\"United States\",trandisp=\"noop\",appid=35421,app=\"application\",appcat=\"Storage.Backup\",apprisk=\"medium\",applist=\"default\",duration=10,sentbyte=2000,rcvdbyte=1000,sentpkt=0,rcvdpkt=0,utmaction=\"allow\",countapp=1,devtype=\"iPad\",osname=\"Apple\",osversion=\"ver\",mastersrcmac=\"01:01:01:01:01:01\",srcmac=\"01:01:01:01:01:01\",srcserver=0,dstdevtype=\"Android Phone\",dstosname=\"Android\",dstosversion=\"ver\",masterdstmac=\"00:00:00:00:00:00\",dstmac=\"00:00:00:00:00:00\",dstserver=0,utmref=65491-194",
     "event": {
-      "code": "0000000013",
-      "outcome": "success",
-      "dialect": "fortigate",
       "category": "traffic",
+      "code": "0000000013",
+      "dialect": "fortigate",
       "created": "2021-04-23T20:02:05.017771Z",
       "original": "1sjze813YtXlmgHp3a1jU4rOAwYpBKMFaWtYCeTQ0QhEtg36Z68bcNi4ahZ2G7Fz",
       "dialect_uuid": "1e256ea1-3947-429e-97a6-abaec8702dc4",
-      "id": "10f0afe9-98a1-4226-a6bd-8f70d461d430",
       "kind": "event"
     },
-    "log": {
-      "level": "notice"
-    },
-    "message": "date=2018-07-26,time=16:51:36,logid=\"0000000013\",type=\"traffic\",subtype=\"forward\",level=\"notice\",vd=\"root\",eventtime=1532616695,srcip=1.1.1.1,srcport=10016,srcintf=\"test\",srcintfrole=\"undefined\",dstip=2.2.2.2,dstport=20,dstintf=\"dmz1\",dstintfrole=\"dmz\",sessionid=10006,proto=6,action=\"accept\",policyid=1,policytype=\"policy\",service=\"tcp/20\",dstcountry=\"France\",srccountry=\"United States\",trandisp=\"noop\",appid=35421,app=\"application\",appcat=\"Storage.Backup\",apprisk=\"medium\",applist=\"default\",duration=10,sentbyte=2000,rcvdbyte=1000,sentpkt=0,rcvdpkt=0,utmaction=\"allow\",countapp=1,devtype=\"iPad\",osname=\"Apple\",osversion=\"ver\",mastersrcmac=\"01:01:01:01:01:01\",srcmac=\"01:01:01:01:01:01\",srcserver=0,dstdevtype=\"Android Phone\",dstosname=\"Android\",dstosversion=\"ver\",masterdstmac=\"00:00:00:00:00:00\",dstmac=\"00:00:00:00:00:00\",dstserver=0,utmref=65491-194",
-    "source": {
-      "ip": "1.1.1.1",
-      "address": "1.1.1.1",
-      "port": 10016,
-      "bytes": 2000,
-      "packets": 0,
-      "mac": "01:01:01:01:01:01"
+    "@timestamp": "2018-07-26T14:51:35.000000Z",
+    "action": {
+      "name": "accept",
+      "outcome": "success",
+      "type": "forward"
     },
     "destination": {
       "address": "2.2.2.2",
-      "ip": "2.2.2.2",
-      "port": 20,
       "bytes": 1000,
+      "ip": "2.2.2.2",
+      "mac": "00:00:00:00:00:00",
       "packets": 0,
-      "mac": "00:00:00:00:00:00"
+      "port": 20
+    },
+    "fortinet": {
+      "apprisk": "medium"
+    },
+    "log": {
+      "level": "notice"
     },
     "network": {
       "application": "application",
       "protocol": "tcp/20",
       "transport": "tcp"
-    },
-    "action": {
-      "name": "accept",
-      "outcome": "success",
-      "type": "forward"
     },
     "observer": {
       "egress": {
@@ -62,22 +56,23 @@
         }
       }
     },
-    "fortinet": {
-      "apprisk": "medium"
-    },
     "rule": {
       "category": "Storage.Backup",
       "ruleset": "default"
     },
+    "source": {
+      "address": "1.1.1.1",
+      "bytes": 2000,
+      "ip": "1.1.1.1",
+      "mac": "01:01:01:01:01:01",
+      "packets": 0,
+      "port": 10016
+    },
     "related": {
       "ip": [
-        "1.1.1.1", "2.2.2.2"
+        "1.1.1.1",
+        "2.2.2.2"
       ]
-    },
-    "sekoiaio": {
-      "intake": {
-        "parsing_status": "success"
-      }
     }
   }
 }

--- a/Fortinet/fortigate/tests/traffic_forward.STANDARD.json
+++ b/Fortinet/fortigate/tests/traffic_forward.STANDARD.json
@@ -9,43 +9,40 @@
     "message": "date=2018-07-26 time=16:51:36 logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"root\" eventtime=1532616695 srcip=1.1.1.1 srcport=10016 srcintf=\"test\" srcintfrole=\"undefined\" dstip=2.2.2.2 dstport=20 dstintf=\"test1\" dstintfrole=\"dmz\" sessionid=10006 proto=6 action=\"accept\" policyid=1 policytype=\"policy\" service=\"tcp/20\" dstcountry=\"France\" srccountry=\"United States\" trandisp=\"noop\" appid=35421 app=\"Dropbox_File.Download\" appcat=\"Storage.Backup\" apprisk=\"medium\" applist=\"default\" duration=10 sentbyte=2000 rcvdbyte=1000 sentpkt=0 rcvdpkt=0 utmaction=\"allow\" countapp=1 devtype=\"iPad\" osname=\"Apple\" osversion=\"ver\" mastersrcmac=\"01:01:01:01:01:01\" srcmac=\"01:01:01:01:01:01\" srcserver=0 dstdevtype=\"Android Phone\" dstosname=\"Android\" dstosversion=\"ver\" masterdstmac=\"00:00:00:00:00:00\" dstmac=\"00:00:00:00:00:00\" dstserver=0 utmref=65491-194"
   },
   "expected": {
+    "message": "date=2018-07-26 time=16:51:36 logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"root\" eventtime=1532616695 srcip=1.1.1.1 srcport=10016 srcintf=\"test\" srcintfrole=\"undefined\" dstip=2.2.2.2 dstport=20 dstintf=\"test1\" dstintfrole=\"dmz\" sessionid=10006 proto=6 action=\"accept\" policyid=1 policytype=\"policy\" service=\"tcp/20\" dstcountry=\"France\" srccountry=\"United States\" trandisp=\"noop\" appid=35421 app=\"Dropbox_File.Download\" appcat=\"Storage.Backup\" apprisk=\"medium\" applist=\"default\" duration=10 sentbyte=2000 rcvdbyte=1000 sentpkt=0 rcvdpkt=0 utmaction=\"allow\" countapp=1 devtype=\"iPad\" osname=\"Apple\" osversion=\"ver\" mastersrcmac=\"01:01:01:01:01:01\" srcmac=\"01:01:01:01:01:01\" srcserver=0 dstdevtype=\"Android Phone\" dstosname=\"Android\" dstosversion=\"ver\" masterdstmac=\"00:00:00:00:00:00\" dstmac=\"00:00:00:00:00:00\" dstserver=0 utmref=65491-194",
     "event": {
-      "code": "0000000013",
-      "outcome": "success",
-      "dialect": "fortigate",
       "category": "traffic",
+      "code": "0000000013",
+      "dialect": "fortigate",
       "created": "2021-04-23T20:02:05.017771Z",
       "original": "1sjze813YtXlmgHp3a1jU4rOAwYpBKMFaWtYCeTQ0QhEtg36Z68bcNi4ahZ2G7Fz",
       "dialect_uuid": "1e256ea1-3947-429e-97a6-abaec8702dc4",
-      "id": "10f0afe9-98a1-4226-a6bd-8f70d461d430",
       "kind": "event"
     },
-    "message": "date=2018-07-26 time=16:51:36 logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"root\" eventtime=1532616695 srcip=1.1.1.1 srcport=10016 srcintf=\"test\" srcintfrole=\"undefined\" dstip=2.2.2.2 dstport=20 dstintf=\"test1\" dstintfrole=\"dmz\" sessionid=10006 proto=6 action=\"accept\" policyid=1 policytype=\"policy\" service=\"tcp/20\" dstcountry=\"France\" srccountry=\"United States\" trandisp=\"noop\" appid=35421 app=\"Dropbox_File.Download\" appcat=\"Storage.Backup\" apprisk=\"medium\" applist=\"default\" duration=10 sentbyte=2000 rcvdbyte=1000 sentpkt=0 rcvdpkt=0 utmaction=\"allow\" countapp=1 devtype=\"iPad\" osname=\"Apple\" osversion=\"ver\" mastersrcmac=\"01:01:01:01:01:01\" srcmac=\"01:01:01:01:01:01\" srcserver=0 dstdevtype=\"Android Phone\" dstosname=\"Android\" dstosversion=\"ver\" masterdstmac=\"00:00:00:00:00:00\" dstmac=\"00:00:00:00:00:00\" dstserver=0 utmref=65491-194",
-    "source": {
-      "ip": "1.1.1.1",
-      "address": "1.1.1.1",
-      "port": 10016,
-      "bytes": 2000,
-      "packets": 0,
-      "mac": "01:01:01:01:01:01"
-    },
-    "destination": {
-      "ip": "2.2.2.2",
-      "address": "2.2.2.2",
-      "port": 20,
-      "bytes": 1000,
-      "packets": 0,
-      "mac": "00:00:00:00:00:00"
-    },
-    "network": {
-      "protocol": "tcp/20",
-      "transport": "tcp",
-      "application": "Dropbox_File.Download"
-    },
+    "@timestamp": "2018-07-26T14:51:35.000000Z",
     "action": {
       "name": "accept",
       "outcome": "success",
       "type": "forward"
+    },
+    "destination": {
+      "address": "2.2.2.2",
+      "bytes": 1000,
+      "ip": "2.2.2.2",
+      "mac": "00:00:00:00:00:00",
+      "packets": 0,
+      "port": 20
+    },
+    "fortinet": {
+      "apprisk": "medium"
+    },
+    "log": {
+      "level": "notice"
+    },
+    "network": {
+      "application": "Dropbox_File.Download",
+      "protocol": "tcp/20",
+      "transport": "tcp"
     },
     "observer": {
       "egress": {
@@ -59,25 +56,23 @@
         }
       }
     },
-    "fortinet": {
-      "apprisk": "medium"
-    },
     "rule": {
       "category": "Storage.Backup",
       "ruleset": "default"
     },
+    "source": {
+      "address": "1.1.1.1",
+      "bytes": 2000,
+      "ip": "1.1.1.1",
+      "mac": "01:01:01:01:01:01",
+      "packets": 0,
+      "port": 10016
+    },
     "related": {
       "ip": [
-        "1.1.1.1", "2.2.2.2"
+        "1.1.1.1",
+        "2.2.2.2"
       ]
-    },
-    "log": {
-      "level": "notice"
-    },
-    "sekoiaio": {
-      "intake": {
-        "parsing_status": "success"
-      }
     }
   }
 }

--- a/Fortinet/fortigate/tests/traffic_forward.STANDARD_STET.json
+++ b/Fortinet/fortigate/tests/traffic_forward.STANDARD_STET.json
@@ -9,41 +9,34 @@
     "message": "date=2021-06-21 time=09:38:29 devname=\"abc\" devid=\"1\" logid=\"0000000010\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"PRX1-AA\" eventtime=1624261109 srcip=1.1.1.1 srcport=50592 srcintf=\"port2\" srcintfrole=\"dmz\" dstip=2.2.2.2 dstport=443 dstintf=\"test\" dstintfrole=\"wan\" sessionid=1224900441 poluuid=\"1eb429d4-ff52-51ea-d119-d1db60e409a6\" dstcountry=\"United Kingdom\" srccountry=\"Reserved\" service=\"HTTPS\" wanoptapptype=\"web-proxy\" proto=6 action=\"accept\" duration=37 policyid=1 policytype=\"proxy-policy\" wanin=5851 rcvdbyte=5851 wanout=2523 lanin=2769 sentbyte=2769 lanout=5923 appcat=\"unscanned\" utmaction=\"allow\" countweb=1"
   },
   "expected": {
+    "message": "date=2021-06-21 time=09:38:29 devname=\"abc\" devid=\"1\" logid=\"0000000010\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"PRX1-AA\" eventtime=1624261109 srcip=1.1.1.1 srcport=50592 srcintf=\"port2\" srcintfrole=\"dmz\" dstip=2.2.2.2 dstport=443 dstintf=\"test\" dstintfrole=\"wan\" sessionid=1224900441 poluuid=\"1eb429d4-ff52-51ea-d119-d1db60e409a6\" dstcountry=\"United Kingdom\" srccountry=\"Reserved\" service=\"HTTPS\" wanoptapptype=\"web-proxy\" proto=6 action=\"accept\" duration=37 policyid=1 policytype=\"proxy-policy\" wanin=5851 rcvdbyte=5851 wanout=2523 lanin=2769 sentbyte=2769 lanout=5923 appcat=\"unscanned\" utmaction=\"allow\" countweb=1",
     "event": {
-      "code": "0000000010",
-      "outcome": "success",
-      "dialect": "fortigate",
       "category": "traffic",
+      "code": "0000000010",
+      "dialect": "fortigate",
       "created": "2021-04-23T20:02:05.017771Z",
       "original": "1sjze813YtXlmgHp3a1jU4rOAwYpBKMFaWtYCeTQ0QhEtg36Z68bcNi4ahZ2G7Fz",
       "dialect_uuid": "1e256ea1-3947-429e-97a6-abaec8702dc4",
-      "id": "10f0afe9-98a1-4226-a6bd-8f70d461d430",
       "kind": "event"
     },
-    "log": {
-      "level": "notice"
-    },
-    "message": "date=2021-06-21  time=09:38:29 devname=\"abc\" devid=\"1\" logid=\"0000000010\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"PRX1-AA\" eventtime=1624261109 srcip=1.1.1.1 srcport=50592 srcintf=\"port2\" srcintfrole=\"dmz\" dstip=2.2.2.2 dstport=443 dstintf=\"test\" dstintfrole=\"wan\" sessionid=1224900441 poluuid=\"1eb429d4-ff52-51ea-d119-d1db60e409a6\" dstcountry=\"United Kingdom\" srccountry=\"Reserved\" service=\"HTTPS\" wanoptapptype=\"web-proxy\" proto=6 action=\"accept\" duration=37 policyid=1 policytype=\"proxy-policy\" wanin=5851 rcvdbyte=5851 wanout=2523 lanin=2769 sentbyte=2769 lanout=5923 appcat=\"unscanned\" utmaction=\"allow\" countweb=1",
-    "source": {
-      "ip": "1.1.1.1",
-      "address": "1.1.1.1",
-      "port": 50592,
-      "bytes": 2769
-    },
-    "destination": {
-      "ip": "2.2.2.2",
-      "address": "2.2.2.2",
-      "port": 443,
-      "bytes": 5851
-    },
-    "network": {
-      "protocol": "HTTPS",
-      "transport": "tcp"
-    },
+    "@timestamp": "2021-06-21T07:38:29.000000Z",
     "action": {
       "name": "accept",
       "outcome": "success",
       "type": "forward"
+    },
+    "destination": {
+      "address": "2.2.2.2",
+      "bytes": 5851,
+      "ip": "2.2.2.2",
+      "port": 443
+    },
+    "log": {
+      "level": "notice"
+    },
+    "network": {
+      "protocol": "HTTPS",
+      "transport": "tcp"
     },
     "observer": {
       "egress": {
@@ -57,19 +50,21 @@
         }
       }
     },
-    "related": {
-      "ip": [
-        "1.1.1.1", "2.2.2.2"
-      ]
-    },
     "rule": {
       "category": "unscanned",
       "ruleset": "proxy-policy"
     },
-    "sekoiaio": {
-      "intake": {
-        "parsing_status": "success"
-      }
+    "source": {
+      "address": "1.1.1.1",
+      "bytes": 2769,
+      "ip": "1.1.1.1",
+      "port": 50592
+    },
+    "related": {
+      "ip": [
+        "1.1.1.1",
+        "2.2.2.2"
+      ]
     }
   }
 }

--- a/Fortinet/fortigate/tests/traffic_forward_FTNTFGTtz.CEF.json
+++ b/Fortinet/fortigate/tests/traffic_forward_FTNTFGTtz.CEF.json
@@ -1,0 +1,52 @@
+{
+  "input": {
+    "sekoiaio": {
+      "intake": {
+        "dialect": "fortigate",
+        "dialect_uuid": "5702ae4e-7d8a-455f-a47b-ef64dd87c981"
+      }
+    },
+    "message": "CEF:0|Fortinet|Fortigate|v6.4.9|00011|traffic:forward dns|4|deviceExternalId=FG5H0ETB19909686 FTNTFGTeventtime=1662381825920035319 FTNTFGTtz=+0200 FTNTFGTlogid=0000000011 cat=traffic:forward FTNTFGTsubtype=forward FTNTFGTlevel=warning FTNTFGTvd=root src=172.16.222.150 spt=49956 deviceInboundInterface=port1 FTNTFGTsrcintfrole=wan dst=172.18.67.10 dpt=53 deviceOutboundInterface=RWC FRANCE 2023 FTNTFGTdstintfrole=lan FTNTFGTsrccountry=Reserved FTNTFGTdstcountry=Reserved externalId=1797928567 proto=17 act=dns FTNTFGTpolicyid=30 FTNTFGTpolicytype=policy FTNTFGTpoluuid=6c8b6672-0b92-51ea-95a0-556c3c0fdb8f FTNTFGTpolicyname=CLT-RWC2023-001 FTNTFGTcentralnatid=6 app=DNS FTNTFGTappcat=unscanned FTNTFGTcrscore=5 FTNTFGTcraction=262144 FTNTFGTcrlevel=low FTNTFGTdsthwvendor=VMware FTNTFGTdstdevtype=Server FTNTFGTdstfamily=Virtual Machine FTNTFGTdstosname=Windows FTNTFGTdsthwversion=Workstation Pro FTNTFGTdstswversion=7 FTNTFGTmasterdstmac=00:50:56:86:7a:ab FTNTFGTdstmac=00:50:56:86:7a:ab FTNTFGTdstserver=0"
+  },
+  "expected": {
+    "message": "CEF:0|Fortinet|Fortigate|v6.4.9|00011|traffic:forward dns|4|deviceExternalId=FG5H0ETB19909686 FTNTFGTeventtime=1662381825920035319 FTNTFGTtz=+0200 FTNTFGTlogid=0000000011 cat=traffic:forward FTNTFGTsubtype=forward FTNTFGTlevel=warning FTNTFGTvd=root src=172.16.222.150 spt=49956 deviceInboundInterface=port1 FTNTFGTsrcintfrole=wan dst=172.18.67.10 dpt=53 deviceOutboundInterface=RWC FRANCE 2023 FTNTFGTdstintfrole=lan FTNTFGTsrccountry=Reserved FTNTFGTdstcountry=Reserved externalId=1797928567 proto=17 act=dns FTNTFGTpolicyid=30 FTNTFGTpolicytype=policy FTNTFGTpoluuid=6c8b6672-0b92-51ea-95a0-556c3c0fdb8f FTNTFGTpolicyname=CLT-RWC2023-001 FTNTFGTcentralnatid=6 app=DNS FTNTFGTappcat=unscanned FTNTFGTcrscore=5 FTNTFGTcraction=262144 FTNTFGTcrlevel=low FTNTFGTdsthwvendor=VMware FTNTFGTdstdevtype=Server FTNTFGTdstfamily=Virtual Machine FTNTFGTdstosname=Windows FTNTFGTdsthwversion=Workstation Pro FTNTFGTdstswversion=7 FTNTFGTmasterdstmac=00:50:56:86:7a:ab FTNTFGTdstmac=00:50:56:86:7a:ab FTNTFGTdstserver=0",
+    "event": {
+      "code": "0000000011",
+      "timezone": "+0200"
+    },
+    "@timestamp": "2022-09-05T12:43:45.920035Z",
+    "action": {
+      "name": "dns",
+      "outcome": "success",
+      "type": "forward"
+    },
+    "destination": {
+      "address": "172.18.67.10",
+      "ip": "172.18.67.10",
+      "port": 53
+    },
+    "log": {
+      "level": "warning"
+    },
+    "network": {
+      "application": "DNS",
+      "transport": "udp"
+    },
+    "observer": {
+      "type": "Fortigate",
+      "vendor": "Fortinet",
+      "version": "v6.4.9"
+    },
+    "source": {
+      "address": "172.16.222.150",
+      "ip": "172.16.222.150",
+      "port": 49956
+    },
+    "related": {
+      "ip": [
+        "172.16.222.150",
+        "172.18.67.10"
+      ]
+    }
+  }
+}

--- a/Fortinet/fortigate/tests/traffic_forward_FTNTFGTtz.CEF.json
+++ b/Fortinet/fortigate/tests/traffic_forward_FTNTFGTtz.CEF.json
@@ -14,7 +14,7 @@
       "code": "0000000011",
       "timezone": "+0200"
     },
-    "@timestamp": "2022-09-05T12:43:45.920035Z",
+    "@timestamp": "2022-09-05T10:43:45.920035Z",
     "action": {
       "name": "dns",
       "outcome": "success",

--- a/Fortinet/fortigate/tests/traffic_nat.STANDARD.json
+++ b/Fortinet/fortigate/tests/traffic_nat.STANDARD.json
@@ -9,6 +9,17 @@
     "message": "date=2018-07-26 time=14:56:21 devname=\"abc\" devid=\"1\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"root\" eventtime=1609941381 srcip=1.1.1.1 srcport=52125 srcintf=\"port9\" srcintfrole=\"undefined\" dstip=3.3.3.3 dstport=3727 dstintf=\"port10\" dstintfrole=\"undefined\" poluuid=\"d77c53b2-a3c6-51e9-49b2-61c9e68c1f7e\" sessionid=578033623 proto=6 action=\"server-rst\" policyid=207 policytype=\"policy\" service=\"tcp/3727\" dstcountry=\"France\" srccountry=\"Netherlands\" trandisp=\"dnat\" tranip=2.2.2.2 tranport=3727 duration=5 sentbyte=80 rcvdbyte=40 sentpkt=2 rcvdpkt=1 appcat=\"unscanned\" dstdevtype=\"Router/NAT Device\" dstdevcategory=\"Windows Device\" masterdstmac=\"00:00:00:00:00:00\" dstmac=\"00:00:00:00:00:00\" dstserver=1"
   },
   "expected": {
+    "message": "date=2018-07-26 time=14:56:21 devname=\"abc\" devid=\"1\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"root\" eventtime=1609941381 srcip=1.1.1.1 srcport=52125 srcintf=\"port9\" srcintfrole=\"undefined\" dstip=3.3.3.3 dstport=3727 dstintf=\"port10\" dstintfrole=\"undefined\" poluuid=\"d77c53b2-a3c6-51e9-49b2-61c9e68c1f7e\" sessionid=578033623 proto=6 action=\"server-rst\" policyid=207 policytype=\"policy\" service=\"tcp/3727\" dstcountry=\"France\" srccountry=\"Netherlands\" trandisp=\"dnat\" tranip=2.2.2.2 tranport=3727 duration=5 sentbyte=80 rcvdbyte=40 sentpkt=2 rcvdpkt=1 appcat=\"unscanned\" dstdevtype=\"Router/NAT Device\" dstdevcategory=\"Windows Device\" masterdstmac=\"00:00:00:00:00:00\" dstmac=\"00:00:00:00:00:00\" dstserver=1",
+    "event": {
+      "category": "traffic",
+      "code": "0000000013",
+      "dialect": "fortigate",
+      "created": "2021-04-23T20:02:05.017771Z",
+      "original": "1sjze813YtXlmgHp3a1jU4rOAwYpBKMFaWtYCeTQ0QhEtg36Z68bcNi4ahZ2G7Fz",
+      "dialect_uuid": "1e256ea1-3947-429e-97a6-abaec8702dc4",
+      "kind": "event"
+    },
+    "@timestamp": "2021-01-06T13:56:21.000000Z",
     "action": {
       "name": "server-rst",
       "outcome": "success",
@@ -25,27 +36,8 @@
       "packets": 1,
       "port": 3727
     },
-    "event": {
-      "code": "0000000013",
-      "outcome": "success",
-      "dialect": "fortigate",
-      "category": "traffic",
-      "created": "2021-04-23T20:02:05.017771Z",
-      "original": "1sjze813YtXlmgHp3a1jU4rOAwYpBKMFaWtYCeTQ0QhEtg36Z68bcNi4ahZ2G7Fz",
-      "dialect_uuid": "1e256ea1-3947-429e-97a6-abaec8702dc4",
-      "id": "10f0afe9-98a1-4226-a6bd-8f70d461d430",
-      "kind": "event"
-    },
     "log": {
       "level": "notice"
-    },
-    "message": "date=2018-07-26 time=14:56:21 devname=\"abc\" devid=\"1\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"root\" eventtime=1609941381 srcip=1.1.1.1 srcport=52125 srcintf=\"port9\" srcintfrole=\"undefined\" dstip=3.3.3.3 dstport=3727 dstintf=\"port10\" dstintfrole=\"undefined\" poluuid=\"d77c53b2-a3c6-51e9-49b2-61c9e68c1f7e\" sessionid=578033623 proto=6 action=\"server-rst\" policyid=207 policytype=\"policy\" service=\"tcp/3727\" dstcountry=\"France\" srccountry=\"Netherlands\" trandisp=\"dnat\" tranip=2.2.2.2 tranport=3727 duration=5 sentbyte=80 rcvdbyte=40 sentpkt=2 rcvdpkt=1 appcat=\"unscanned\" dstdevtype=\"Router/NAT Device\" dstdevcategory=\"Windows Device\" masterdstmac=\"00:00:00:00:00:00\" dstmac=\"00:00:00:00:00:00\" dstserver=1",
-    "source": {
-      "address": "1.1.1.1",
-      "bytes": 80,
-      "ip": "1.1.1.1",
-      "packets": 2,
-      "port": 52125
     },
     "network": {
       "protocol": "tcp/3727",
@@ -67,15 +59,19 @@
       "category": "unscanned",
       "ruleset": "policy"
     },
+    "source": {
+      "address": "1.1.1.1",
+      "bytes": 80,
+      "ip": "1.1.1.1",
+      "packets": 2,
+      "port": 52125
+    },
     "related": {
       "ip": [
-        "1.1.1.1", "2.2.2.2", "3.3.3.3"
+        "1.1.1.1",
+        "2.2.2.2",
+        "3.3.3.3"
       ]
-    },
-    "sekoiaio": {
-      "intake": {
-        "parsing_status": "success"
-      }
     }
   }
 }

--- a/Fortinet/fortigate/tests/tunnel.json
+++ b/Fortinet/fortigate/tests/tunnel.json
@@ -21,6 +21,7 @@
       "dialect_uuid": "1e256ea1-3947-429e-97a6-abaec8702dc4",
       "kind": "event"
     },
+    "@timestamp": "2019-08-27T12:27:40.000000Z",
     "action": {
       "name": "tunnel-stats",
       "outcome": "success",

--- a/Fortinet/fortigate/tests/tunnel.json
+++ b/Fortinet/fortigate/tests/tunnel.json
@@ -9,26 +9,33 @@
     "message": "logver=60 timestamp=1566916060 tz=\"UTC+2\" devname=\"abc\" devid=\"1\" vd=\"IPSEC\" date=2019-08-27 time=16:27:40 logid=\"0101039949\" type=\"event\" subtype=\"vpn\" level=\"information\" eventtime=1566916060 logdesc=\"SSL VPN statistics\" action=\"tunnel-stats\" tunneltype=\"ssl-tunnel\" tunnelid=1995 remip=1.1.1.1 tunnelip=2.2.2.2 user=\"test\" group=\"GRP_Generic_JAIL_VPN\" dst_host=\"N/A\" nextstat=600 duration=8437 sentbyte=71524041 rcvdbyte=6151809 msg=\"SSL tunnel statistics\"\n"
   },
   "expected": {
+    "message": "logver=60 timestamp=1566916060 tz=\"UTC+2\" devname=\"abc\" devid=\"1\" vd=\"IPSEC\" date=2019-08-27 time=16:27:40 logid=\"0101039949\" type=\"event\" subtype=\"vpn\" level=\"information\" eventtime=1566916060 logdesc=\"SSL VPN statistics\" action=\"tunnel-stats\" tunneltype=\"ssl-tunnel\" tunnelid=1995 remip=1.1.1.1 tunnelip=2.2.2.2 user=\"test\" group=\"GRP_Generic_JAIL_VPN\" dst_host=\"N/A\" nextstat=600 duration=8437 sentbyte=71524041 rcvdbyte=6151809 msg=\"SSL tunnel statistics\"\n",
     "event": {
-      "code": "0101039949",
-      "outcome": "success",
-      "dialect": "fortigate",
-      "reason": "SSL tunnel statistics",
       "category": "event",
+      "code": "0101039949",
+      "reason": "SSL tunnel statistics",
+      "timezone": "UTC+2",
+      "dialect": "fortigate",
       "created": "2021-04-23T20:02:05.017771Z",
       "original": "1sjze813YtXlmgHp3a1jU4rOAwYpBKMFaWtYCeTQ0QhEtg36Z68bcNi4ahZ2G7Fz",
       "dialect_uuid": "1e256ea1-3947-429e-97a6-abaec8702dc4",
-      "id": "10f0afe9-98a1-4226-a6bd-8f70d461d430",
       "kind": "event"
+    },
+    "action": {
+      "name": "tunnel-stats",
+      "outcome": "success",
+      "type": "vpn"
+    },
+    "destination": {
+      "bytes": 6151809
     },
     "log": {
       "level": "information"
     },
-    "message": "logver=60 timestamp=1566916060 tz=\"UTC+2\" devname=\"abc\" devid=\"1\" vd=\"IPSEC\" date=2019-08-27 time=16:27:40 logid=\"0101039949\" type=\"event\" subtype=\"vpn\" level=\"information\" eventtime=1566916060 logdesc=\"SSL VPN statistics\" action=\"tunnel-stats\" tunneltype=\"ssl-tunnel\" tunnelid=1995 remip=1.1.1.1 tunnelip=2.2.2.2 user=\"test\" group=\"GRP_Generic_JAIL_VPN\" dst_host=\"N/A\" nextstat=600 duration=8437 sentbyte=71524041 rcvdbyte=6151809 msg=\"SSL tunnel statistics\"\n",
     "source": {
+      "address": "1.1.1.1",
       "bytes": 71524041,
       "ip": "1.1.1.1",
-      "address": "1.1.1.1",
       "nat": {
         "ip": "2.2.2.2"
       },
@@ -36,24 +43,14 @@
         "name": "test"
       }
     },
-    "destination": {
-      "bytes": 6151809
-    },
-    "action": {
-      "name": "tunnel-stats",
-      "outcome": "success",
-      "type": "vpn"
-    },
     "related": {
-      "ip": [
-        "1.1.1.1", "2.2.2.2"
+      "user": [
+        "test"
       ],
-      "user": ["test"]
-    },
-    "sekoiaio": {
-      "intake": {
-        "parsing_status": "success"
-      }
+      "ip": [
+        "1.1.1.1",
+        "2.2.2.2"
+      ]
     }
   }
 }

--- a/Fortinet/fortigate/tests/tunnel_statistics.CSV.json
+++ b/Fortinet/fortigate/tests/tunnel_statistics.CSV.json
@@ -9,25 +9,32 @@
     "message": " time=12:02:57 devname=\"abc\" devid=\"1\" logid=\"0101037141\" type=\"event\" subtype=\"vpn\" level=\"notice\" vd=\"root\" eventtime=1614855777 logdesc=\"IPsec tunnel statistics\" msg=\"IPsec tunnel statistics\" action=\"tunnel-stats\" remip=1.1.1.1 locip=93.187.43.9 remport=500 locport=500 outintf=\"N/A\" cookies=\"9b064274e0648c03/662c2b1264a2295e\" user=\"N/A\" group=\"N/A\" xauthuser=\"N/A\" xauthgroup=\"N/A\" assignip=N/A vpntunnel=\"VPN-HELPLINE\" tunnelip=N/A tunnelid=0 tunneltype=\"ipsec\" duration=102908570 sentbyte=7649 rcvdbyte=0 nextstat=600"
   },
   "expected": {
+    "message": " time=12:02:57 devname=\"abc\" devid=\"1\" logid=\"0101037141\" type=\"event\" subtype=\"vpn\" level=\"notice\" vd=\"root\" eventtime=1614855777 logdesc=\"IPsec tunnel statistics\" msg=\"IPsec tunnel statistics\" action=\"tunnel-stats\" remip=1.1.1.1 locip=93.187.43.9 remport=500 locport=500 outintf=\"N/A\" cookies=\"9b064274e0648c03/662c2b1264a2295e\" user=\"N/A\" group=\"N/A\" xauthuser=\"N/A\" xauthgroup=\"N/A\" assignip=N/A vpntunnel=\"VPN-HELPLINE\" tunnelip=N/A tunnelid=0 tunneltype=\"ipsec\" duration=102908570 sentbyte=7649 rcvdbyte=0 nextstat=600",
     "event": {
-      "code": "0101037141",
-      "outcome": "success",
-      "dialect": "fortigate",
-      "reason": "IPsec tunnel statistics",
       "category": "event",
+      "code": "0101037141",
+      "reason": "IPsec tunnel statistics",
+      "dialect": "fortigate",
       "created": "2021-04-23T20:02:05.017771Z",
       "original": "1sjze813YtXlmgHp3a1jU4rOAwYpBKMFaWtYCeTQ0QhEtg36Z68bcNi4ahZ2G7Fz",
       "dialect_uuid": "1e256ea1-3947-429e-97a6-abaec8702dc4",
-      "id": "10f0afe9-98a1-4226-a6bd-8f70d461d430",
       "kind": "event"
+    },
+    "@timestamp": "2021-03-04T11:02:57.000000Z",
+    "action": {
+      "name": "tunnel-stats",
+      "outcome": "success",
+      "type": "vpn"
+    },
+    "destination": {
+      "bytes": 0
     },
     "log": {
       "level": "notice"
     },
-    "message": " time=12:02:57 devname=\"abc\" devid=\"1\" logid=\"0101037141\" type=\"event\" subtype=\"vpn\" level=\"notice\" vd=\"root\" eventtime=1614855777 logdesc=\"IPsec tunnel statistics\" msg=\"IPsec tunnel statistics\" action=\"tunnel-stats\" remip=1.1.1.1 locip=93.187.43.9 remport=500 locport=500 outintf=\"N/A\" cookies=\"9b064274e0648c03/662c2b1264a2295e\" user=\"N/A\" group=\"N/A\" xauthuser=\"N/A\" xauthgroup=\"N/A\" assignip=N/A vpntunnel=\"VPN-HELPLINE\" tunnelip=N/A tunnelid=0 tunneltype=\"ipsec\" duration=102908570 sentbyte=7649 rcvdbyte=0 nextstat=600",
     "source": {
-      "bytes": 7649,
       "address": "1.1.1.1",
+      "bytes": 7649,
       "ip": "1.1.1.1",
       "nat": {
         "ip": "N/A"
@@ -36,24 +43,14 @@
         "name": "N/A"
       }
     },
-    "destination": {
-      "bytes": 0
-    },
-    "action": {
-      "name": "tunnel-stats",
-      "outcome": "success",
-      "type": "vpn"
-    },
     "related": {
-      "ip": [
-        "1.1.1.1", "N/A"
+      "user": [
+        "N/A"
       ],
-      "user": ["N/A"]
-    },
-    "sekoiaio": {
-      "intake": {
-        "parsing_status": "success"
-      }
+      "ip": [
+        "1.1.1.1",
+        "N/A"
+      ]
     }
   }
 }

--- a/Fortinet/fortigate/tests/vpn.STANDARD.json
+++ b/Fortinet/fortigate/tests/vpn.STANDARD.json
@@ -9,23 +9,23 @@
     "message": " time=14:38:46 devname=\"abc\" devid=\"1\" logid=\"0101041987\" type=\"event\" subtype=\"vpn\" level=\"information\" vd=\"root\" eventtime=1615469926 logdesc=\"Certificate updated\" action=\"info\" cert-type=\"CRL\" status=\"success\" name=\"CRL_1\" method=\"HTTP\" reason=\"N/A\" msg=\"A certificate is updated\""
   },
   "expected": {
+    "message": " time=14:38:46 devname=\"abc\" devid=\"1\" logid=\"0101041987\" type=\"event\" subtype=\"vpn\" level=\"information\" vd=\"root\" eventtime=1615469926 logdesc=\"Certificate updated\" action=\"info\" cert-type=\"CRL\" status=\"success\" name=\"CRL_1\" method=\"HTTP\" reason=\"N/A\" msg=\"A certificate is updated\"",
+    "event": {
+      "action": "N/A",
+      "category": "event",
+      "code": "0101041987",
+      "reason": "A certificate is updated",
+      "created": "2021-03-11T15:53:56.988590Z",
+      "dialect": "fortigate",
+      "dialect_uuid": "418b5714-cddd-4ac3-8eea-d4aa7d37f99d",
+      "original": "Xxzvh5M2kuKGZtZnGQCn2YSy7Jx6Qng3Bo97HaKNydZTDl5Wub0okUtb4ww7Y0jA",
+      "kind": "event"
+    },
+    "@timestamp": "2021-03-11T13:38:46.000000Z",
     "action": {
       "name": "CRL_1",
       "outcome": "success",
       "type": "vpn"
-    },
-    "event": {
-      "category": "event",
-      "code": "0101041987",
-      "created": "2021-03-11T15:53:56.988590Z",
-      "dialect": "fortigate",
-      "dialect_uuid": "418b5714-cddd-4ac3-8eea-d4aa7d37f99d",
-      "id": "b0f4e7f4-c807-4656-8ce4-ce6d254146ba",
-      "reason": "A certificate is updated",
-      "original": "Xxzvh5M2kuKGZtZnGQCn2YSy7Jx6Qng3Bo97HaKNydZTDl5Wub0okUtb4ww7Y0jA",
-      "outcome": "success",
-      "action": "N/A",
-      "kind": "event"
     },
     "http": {
       "request": {
@@ -34,12 +34,6 @@
     },
     "log": {
       "level": "information"
-    },
-    "message": " time=14:38:46 devname=\"abc\" devid=\"1\" logid=\"0101041987\" type=\"event\" subtype=\"vpn\" level=\"information\" vd=\"root\" eventtime=1615469926 logdesc=\"Certificate updated\" action=\"info\" cert-type=\"CRL\" status=\"success\" name=\"CRL_1\" method=\"HTTP\" reason=\"N/A\" msg=\"A certificate is updated\"",
-    "sekoiaio": {
-      "intake": {
-        "parsing_status": "success"
-      }
     }
   }
 }


### PR DESCRIPTION
This is a fix to [#28115](https://github.com/SekoiaLab/platform/issues/28115)