### PR TITLE
MDForEndpoint: fix the working directory for a process

### DIFF
--- a/Microsoft Defender/microsoft-defender-for-endpoints/ingest/parser.yml
+++ b/Microsoft Defender/microsoft-defender-for-endpoints/ingest/parser.yml
@@ -97,7 +97,7 @@ stages:
           process.start: '{{json_event.message.properties.ProcessCreationTime or json_event.message.properties.InitiatingProcessCreationTime}}'
           process.executable: '{{json_event.message.properties.InitiatingProcessFileName}}'
           process.command_line: '{{json_event.message.properties.ProcessCommandLine or json_event.message.properties.InitiatingProcessCommandLine}}'
-          process.working_directory: '{{json_event.message.properties.InitiatingProcessFolderPath}}'
+          process.working_directory: '{{json_event.message.properties.InitiatingProcessFolderPath | dirname}}'
           process.user.domain: '{{json_event.message.properties.InitiatingProcessAccountDomain}}'
           process.user.name: '{{json_event.message.properties.InitiatingProcessAccountName}}'
           process.user.id: '{{json_event.message.properties.InitiatingProcessAccountSid}}'

--- a/Microsoft Defender/microsoft-defender-for-endpoints/tests/test_device_event.json
+++ b/Microsoft Defender/microsoft-defender-for-endpoints/tests/test_device_event.json
@@ -32,7 +32,7 @@
       "start": "2022-09-01T06:56:23.7887846Z",
       "executable": "software_reporter_tool.exe",
       "command_line": "\"software_reporter_tool.exe\" --use-crash-handler-with-id=\"\\\\.\\pipe\\crashpad_11111_XXXXXXXXXXXXXXXX\" --sandboxed-process-id=2 --init-done-notifier=804 --sandbox-mojo-pipe-token=********** --mojo-platform-channel-handle=780 --engine=2",
-      "working_directory": "c:\\users\\USER\\appdata\\local\\google\\chrome\\user data\\swreporter\\102.286.200\\software_reporter_tool.exe",
+      "working_directory": "c:\\users\\USER\\appdata\\local\\google\\chrome\\user data\\swreporter\\102.286.200",
       "user": {
         "domain": "intranet",
         "name": "group1",

--- a/Microsoft Defender/microsoft-defender-for-endpoints/tests/test_device_file_event.json
+++ b/Microsoft Defender/microsoft-defender-for-endpoints/tests/test_device_file_event.json
@@ -34,7 +34,7 @@
       "start": "2022-09-01T07:46:34.0214941Z",
       "executable": "OneDriveSetup.exe",
       "command_line": "OneDriveSetup.exe /update /restart /updateSource:ODU /peruser /childprocess /extractFilesWithLessThreadCount /renameReplaceOneDriveExe /renameReplaceODSUExe /removeNonCurrentVersions /enableODSUReportingMode ",
-      "working_directory": "c:\\users\\USER\\appdata\\local\\microsoft\\onedrive\\update\\onedrivesetup.exe",
+      "working_directory": "c:\\users\\USER\\appdata\\local\\microsoft\\onedrive\\update",
       "user": {
         "domain": "intranet",
         "name": "group1",

--- a/Microsoft Defender/microsoft-defender-for-endpoints/tests/test_device_image_load_event.json
+++ b/Microsoft Defender/microsoft-defender-for-endpoints/tests/test_device_image_load_event.json
@@ -40,7 +40,7 @@
       "start": "2022-09-01T07:47:58.182445Z",
       "executable": "autosync.exe",
       "command_line": "\"autosync.exe\" /c C:\\PROGRA~2\\adobe\\8.1\\Client\\bin\\fra\\adobe.cfg /c \" usa\"",
-      "working_directory": "c:\\program files (x86)\\adobe\\8.1\\client\\bin\\autosync.exe",
+      "working_directory": "c:\\program files (x86)\\adobe\\8.1\\client\\bin",
       "user": {
         "domain": "intranet",
         "name": "group1",

--- a/Microsoft Defender/microsoft-defender-for-endpoints/tests/test_local_ip.json
+++ b/Microsoft Defender/microsoft-defender-for-endpoints/tests/test_local_ip.json
@@ -30,7 +30,7 @@
       "start": "2022-09-01T06:56:23.7887846Z",
       "executable": "software_reporter_tool.exe",
       "command_line": "\"software_reporter_tool.exe\" --use-crash-handler-with-id=\"\\\\.\\pipe\\crashpad_11111_XXXXXXXXXXXXXXXX\" --sandboxed-process-id=2 --init-done-notifier=804 --sandbox-mojo-pipe-token=********** --mojo-platform-channel-handle=780 --engine=2",
-      "working_directory": "c:\\users\\USER\\appdata\\local\\google\\chrome\\user data\\swreporter\\102.286.200\\software_reporter_tool.exe",
+      "working_directory": "c:\\users\\USER\\appdata\\local\\google\\chrome\\user data\\swreporter\\102.286.200",
       "user": {
         "domain": "intranet",
         "name": "group1",


### PR DESCRIPTION
Use the filter `dirname` to only get the path to the working directory, as the original field contains the executable.