### PR TITLE
AWS: fix smart-descriptions

### DIFF
--- a/AWS/aws-cloudtrail/_meta/fields.yml
+++ b/AWS/aws-cloudtrail/_meta/fields.yml
@@ -73,6 +73,7 @@ aws.cloudtrail.recipient_account_id:
   description: "The account ID that received the event"
   type: keyword
   observable:
+    name: recipient account ID
     type: user-account
     property: account_login
 

--- a/AWS/aws-cloudtrail/_meta/fields.yml
+++ b/AWS/aws-cloudtrail/_meta/fields.yml
@@ -73,7 +73,7 @@ aws.cloudtrail.recipient_account_id:
   description: "The account ID that received the event"
   type: keyword
   observable:
-    name: recipient account ID
+    name: Recipient account ID
     type: user-account
     property: account_login
 

--- a/AWS/aws-cloudtrail/_meta/fields.yml
+++ b/AWS/aws-cloudtrail/_meta/fields.yml
@@ -91,6 +91,10 @@ aws.cloudtrail.user_identity.arn:
   name: aws.cloudtrail.user_identity.arn
   description: "The ARN of the principal that sent the request"
   type: keyword
+  observable:
+    name: User ARN
+    type: user-account
+    property: account_login
 
 aws.cloudtrail.user_identity.principalId:
   name: aws.cloudtrail.user_identity.principalId

--- a/AWS/aws-cloudtrail/_meta/smart-descriptions.json
+++ b/AWS/aws-cloudtrail/_meta/smart-descriptions.json
@@ -1,13 +1,13 @@
 [
   {
-    "value": "{cloud.account.id} called {event.action} method from {event.provider} ",
+    "value": "{aws.cloudtrail.user_identity.arn} called {event.action} method from {event.provider} ",
     "conditions": [
       {
           "field": "action.type",
           "value": "AwsApiCall"
       },
       {
-        "field": "cloud.account.id"
+        "field": "aws.cloudtrail.user_identity.arn"
       },
       {
         "field": "event.action"
@@ -18,7 +18,7 @@
     ],
     "relationships": [
       {
-        "source": "cloud.account.id",
+        "source": "aws.cloudtrail.user_identity.arn",
         "target": "event.provider",
         "type": "requested"
       }
@@ -50,14 +50,14 @@
     ]
   },
   {
-    "value": "{cloud.account.id} called {event.action} method from {event.provider} ",
+    "value": "{aws.cloudtrail.user_identity.arn} called {event.action} method from {event.provider} ",
     "conditions": [
       {
           "field": "action.type",
           "value": "AwsConsoleAction"
       },
       {
-        "field": "cloud.account.id"
+        "field": "aws.cloudtrail.user_identity.arn"
       },
       {
         "field": "event.action"
@@ -68,21 +68,21 @@
     ],
     "relationships": [
       {
-        "source": "cloud.account.id",
+        "source": "aws.cloudtrail.user_identity.arn",
         "target": "event.provider",
         "type": "requested"
       }
     ]
   },
   {
-    "value": "{cloud.account.id} called {event.action} method from {event.provider} ",
+    "value": "{aws.cloudtrail.user_identity.arn} called {event.action} method from {event.provider} ",
     "conditions": [
       {
           "field": "action.type",
           "value": "AwsServiceEvent"
       },
       {
-        "field": "cloud.account.id"
+        "field": "aws.cloudtrail.user_identity.arn"
       },
       {
         "field": "event.action"
@@ -93,7 +93,7 @@
     ],
     "relationships": [
       {
-        "source": "cloud.account.id",
+        "source": "aws.cloudtrail.user_identity.arn",
         "target": "event.provider",
         "type": "requested"
       }

--- a/AWS/aws-cloudtrail/_meta/smart-descriptions.json
+++ b/AWS/aws-cloudtrail/_meta/smart-descriptions.json
@@ -1,6 +1,6 @@
 [
   {
-    "value": "{aws.cloudtrail.user_identity.arn} called {event.action} method from {event.provider} ",
+    "value": "{aws.cloudtrail.user_identity.arn} called {event.action} method from {event.provider}",
     "conditions": [
       {
           "field": "action.type",
@@ -50,7 +50,7 @@
     ]
   },
   {
-    "value": "{aws.cloudtrail.user_identity.arn} called {event.action} method from {event.provider} ",
+    "value": "{aws.cloudtrail.user_identity.arn} called {event.action} method from {event.provider}",
     "conditions": [
       {
           "field": "action.type",
@@ -75,7 +75,7 @@
     ]
   },
   {
-    "value": "{aws.cloudtrail.user_identity.arn} called {event.action} method from {event.provider} ",
+    "value": "{aws.cloudtrail.user_identity.arn} called {event.action} method from {event.provider}",
     "conditions": [
       {
           "field": "action.type",


### PR DESCRIPTION
Use the ARN instead of the account ID in smart-description