### PR TITLE
Symantec EPP: fix parser

### DIFF
--- a/Broadcom/symantec-endpoint-protection/_meta/smart-descriptions.json
+++ b/Broadcom/symantec-endpoint-protection/_meta/smart-descriptions.json
@@ -53,7 +53,7 @@
         }
     ]
 },{
-    "value": "Process {process.name} blocked on {host.hostname}",
+    "value": "Process {process.name} was blocked on {host.hostname}",
     "conditions": [
         {
             "field": "event.type",
@@ -64,6 +64,9 @@
         },
         {
             "field": "host.hostname"
+        },
+        {
+            "field": "file.path"
         }
     ],
     "relationships": [

--- a/Broadcom/symantec-endpoint-protection/ingest/parser.yml
+++ b/Broadcom/symantec-endpoint-protection/ingest/parser.yml
@@ -84,7 +84,7 @@ stages:
           event.action: event.type
         fallback: ["info"]
       - set:
-          process.args: "{{parsed_event.message.process_params.split(' ')}}"
+          process.args: '["{{parsed_event.message.process_params}}"]'
         filter: "{{parsed_event.message.get('process_params') != None}}"
       - set:
           threat.enrichments: >

--- a/Broadcom/symantec-endpoint-protection/ingest/parser.yml
+++ b/Broadcom/symantec-endpoint-protection/ingest/parser.yml
@@ -31,14 +31,12 @@ pipeline:
       properties:
         input_field: '{{parsed_event.message.start_date}}'
         output_field: datetime
-    filter: '{{parsed_event.message.get("start_date") != None}}'
   - name: parse_end_date
     external:
       name: date.parse
       properties:
         input_field: '{{parsed_event.message.end_date}}'
         output_field: datetime
-    filter: '{{parsed_event.message.get("end_date") != None}}'
   - name: parse_modification_date
     external:
       name: date.parse
@@ -69,7 +67,7 @@ stages:
           event.action: "{{parsed_event.message.action}}"
           host.ip: "{{parsed_event.message.host_ip}}"
           host.hostname: "{{parsed_event.message.host_hostname}}"
-          host.name: "{{parsed_event.message.host_name or parsed_event.message.host_hostname}}"
+          host.name: "{{parsed_event.message.host_name}}"
           user.name: "{{parsed_event.message.username}}"
           file.path: "{{parsed_event.message.file_path}}"
           file.size: "{{parsed_event.message.file_size}}"

--- a/Broadcom/symantec-endpoint-protection/tests/test_behavior_logs.json
+++ b/Broadcom/symantec-endpoint-protection/tests/test_behavior_logs.json
@@ -37,11 +37,7 @@
       "name": "CUAGENT.EXE",
       "working_directory": "C:\\PROGRAM FILES\\SMART-X\\CONTROLUPAGENT\\VERSION 8.1.5.634",
       "args": [
-        "C:\\Program",
-        "Files",
-        "(x86)\\Symantec\\Symantec",
-        "Endpoint",
-        "Protection\\14.3.4615.2000.105\\Bin64\\ccSvcHst.exe"
+        "C:\\Program Files (x86)\\Symantec\\Symantec Endpoint Protection\f.3.4615.2000.105\\Bin64\\ccSvcHst.exe"
       ]
     },
     "related": {


### PR DESCRIPTION
Update parser with last modification
fix `process.args`: don't split the content as the parameters are in one piece.