### PR TITLE
fix/Microsoft_Defender

### DIFF
--- a/Microsoft Defender/microsoft-defender-for-endpoints/_meta/smart-descriptions.json
+++ b/Microsoft Defender/microsoft-defender-for-endpoints/_meta/smart-descriptions.json
@@ -1,16 +1,5 @@
 [
   {
-    "value": "{service.name} has raised alert {microsoft.defender.alert.id}",
-    "conditions": [
-      {
-        "field":"microsoft.defender.alert.id"
-      },
-      {
-        "field":"service.name"
-      }
-    ]
-  },
-  {
     "value": "Technique {threat.technique.name} with {microsoft.defender.threat.severity} detected",
     "conditions": [
       {
@@ -33,13 +22,10 @@
     ]
   },
   {
-    "value": "New alert detected {microsoft.defender.alert.title} affecting {service.name}",
+    "value": "New alert {microsoft.defender.alert.title} detected by {service.name}",
     "conditions": [
       {
         "field": "microsoft.defender.alert.title"
-      },
-      {
-        "field": "threat.technique.name"
       },
       {
         "field": "service.name"
@@ -264,6 +250,17 @@
       },
       {
         "field":"user.name"
+      }
+    ]
+  },
+  {
+    "value": "{service.name} has raised alert {microsoft.defender.alert.id}",
+    "conditions": [
+      {
+        "field":"microsoft.defender.alert.id"
+      },
+      {
+        "field":"service.name"
       }
     ]
   }


### PR DESCRIPTION
Catch-all condition needs to be at the end of the file.
Because in case of equality in numbers of conditions fields it will take the first smart descritption.
This information needs to be capitalized in the documentation 
