### PR TITLE
Update smart-descriptions.json

### DIFF
--- a/Fortinet/fortigate/_meta/smart-descriptions.json
+++ b/Fortinet/fortigate/_meta/smart-descriptions.json
@@ -315,7 +315,7 @@
         ]
     },
     {
-        "value": "{log.hostname} denied {network.protocol} traffic initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
+        "value": "{observer.hostname} denied {network.protocol} traffic initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
         "conditions": [
             {
                 "field": "action.name",
@@ -338,7 +338,7 @@
         ]
     },
     {
-        "value": "{log.hostname} accepted {network.protocol} traffic initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
+        "value": "{observer.hostname} accepted {network.protocol} traffic initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
         "conditions": [
             {
                 "field": "action.name",
@@ -361,7 +361,7 @@
         ]
     },
     {
-        "value": "{log.hostname} observed client reset {network.protocol} session initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
+        "value": "{observer.hostname} observed client reset {network.protocol} session initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
         "conditions": [
             {
                 "field": "action.name",
@@ -377,7 +377,7 @@
         ]
     },
     {
-        "value": "{log.hostname} observed server reset {network.protocol} session initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
+        "value": "{observer.hostname} observed server reset {network.protocol} session initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
         "conditions": [
             {
                 "field": "action.name",
@@ -393,7 +393,7 @@
         ]
     },
     {
-        "value": "{log.hostname} observed timeout {network.protocol} session initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
+        "value": "{observer.hostname} observed timeout {network.protocol} session initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
         "conditions": [
             {
                 "field": "action.name",
@@ -409,7 +409,7 @@
         ]
     },
     {
-        "value": "{log.hostname} observed start {network.protocol} session initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
+        "value": "{observer.hostname} observed start {network.protocol} session initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
         "conditions": [
             {
                 "field": "action.name",
@@ -425,7 +425,7 @@
         ]
     },
     {
-        "value": "{log.hostname} observed close {network.protocol} session initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
+        "value": "{observer.hostname} observed close {network.protocol} session initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
         "conditions": [
             {
                 "field": "action.name",
@@ -441,7 +441,465 @@
         ]
     },
     {
-        "value": "{log.hostname} observed DNS session initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
+        "value": "{observer.hostname} observed DNS session initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
+        "conditions": [
+            {
+                "field": "action.name",
+                "value": "dns"
+            },
+            {
+                "field": "action.outcome",
+                "value": "success"
+            },
+            {
+                "field": "action.type"
+            }
+        ]
+    }
+][
+    {
+        "value": "{source.ip} connected to {destination.ip}:{destination.port}",
+        "conditions": [
+            {
+                "field": "action.outcome",
+                "value": "passthrough"
+            }
+        ],
+        "relationships": [
+            {
+                "source": "source.ip",
+                "target": "destination.ip",
+                "type": "connected to"
+            }
+        ]
+    },
+    {
+        "value": "{source.ip} was denied a connection to {destination.ip}:{destination.port}",
+        "conditions": [
+            {
+                "field": "action.outcome",
+                "value": "block"
+            }
+        ],
+        "relationships": [
+            {
+                "source": "source.ip",
+                "target": "destination.ip",
+                "type": "was denied a connection to"
+            }
+        ]
+    },
+    {
+        "value": "{source.ip} was denied a connection to {destination.ip}:{destination.port}",
+        "conditions": [
+            {
+                "field": "action.outcome",
+                "value": "blocked"
+            }
+        ],
+        "relationships": [
+            {
+                "source": "source.ip",
+                "target": "destination.ip",
+                "type": "was denied a connection to"
+            }
+        ]
+    },
+    {
+        "value": "{source.ip} connected to {destination.ip}:{destination.port}",
+        "conditions": [
+            {
+                "field": "event.dataset",
+                "value": "fortinet.ips"
+            }
+        ],
+        "relationships": [
+            {
+                "source": "source.ip",
+                "target": "destination.ip",
+                "type": "connected to"
+            }
+        ]
+    },
+    {
+        "value": "{source.ip} was denied a connection to {destination.ip}:{destination.port}",
+        "conditions": [
+            {
+                "field": "event.dataset",
+                "value": "fortinet.ips"
+            },
+            {
+                "field": "action.name",
+                "value": "blocked"
+            }
+        ],
+        "relationships": [
+            {
+                "source": "source.ip",
+                "target": "destination.ip",
+                "type": "was denied a connection to"
+            }
+        ]
+    },
+    {
+        "value": "{source.ip} connected to malicious URL {url.original} (threat: {virus.virus})",
+        "conditions": [
+            {
+                "field": "event.dataset",
+                "value": "fortinet.antivirus"
+            },
+            {
+                "field": "virus.virus"
+            }
+        ],
+        "relationships": [
+            {
+                "source": "source.ip",
+                "target": "url.original",
+                "type": "connected to malicious"
+            }
+        ]
+    },
+    {
+        "value": "{source.ip} was denied a connection to malicious URL {url.original} (threat: {virus.virus})",
+        "conditions": [
+            {
+                "field": "event.dataset",
+                "value": "fortinet.antivirus"
+            },
+            {
+                "field": "action.name",
+                "value": "blocked"
+            }
+        ],
+        "relationships": [
+            {
+                "source": "source.ip",
+                "target": "url.original",
+                "type": "was blocked from connecting to malicious"
+            }
+        ]
+    },
+    {
+        "value": "{source.ip} failed to connect to {destination.ip}:{destination.port} because of SSL anomalies",
+        "conditions": [
+            {
+                "field": "action.type",
+                "value": "ssl-anomalies"
+            }
+        ],
+        "relationships": [
+            {
+                "source": "source.ip",
+                "target": "destination.ip",
+                "type": "failed to connect to"
+            }
+        ]
+    },
+    {
+        "value": "{source.ip} was denied a connection to {url.original} (category {rule.category})",
+        "conditions": [
+            {
+                "field": "action.type",
+                "value": "webfilter"
+            },
+            {
+                "field": "action.name",
+                "value": "blocked"
+            }
+        ],
+        "relationships": [
+            {
+                "source": "source.ip",
+                "target": "url.original",
+                "type": "was denied a connection to"
+            },
+            {
+                "source": "url.original",
+                "target": "destination.domain",
+                "type": "hosted on"
+            },
+            {
+                "source": "destination.domain",
+                "target": "destination.ip",
+                "type": "resolves to"
+            }
+        ]
+    },
+    {
+        "value": "{source.ip} connected to {url.domain}{url.path} on {customer.zone_name} (category {application.category})",
+        "conditions": [
+            {
+                "field": "event.dataset",
+                "value": "fortinet.webfilter"
+            },
+            {
+                "field": "action.name",
+                "value": "passthrough"
+            }
+        ],
+        "relationships": [
+            {
+                "source": "source.ip",
+                "target": "url.domain",
+                "type": "connected to"
+            },
+            {
+                "source": "url.domain",
+                "target": "destination.ip",
+                "type": "resolves to"
+            }
+        ]
+    },
+    {
+        "value": "{source.ip} was denied a connection to {url.domain}{url.path} (category {application.category})",
+        "conditions": [
+            {
+                "field": "event.dataset",
+                "value": "fortinet.webfilter"
+            },
+            {
+                "field": "action.name",
+                "value": "blocked"
+            }
+        ],
+        "relationships": [
+            {
+                "source": "source.ip",
+                "target": "url.domain",
+                "type": "was denied a connection to"
+            },
+            {
+                "source": "url.domain",
+                "target": "destination.ip",
+                "type": "resolves to"
+            }
+        ]
+    },
+    {
+        "value": "{source.ip} connected to {destination.ip}:{destination.port} (recognised as {application.category}/{application.name})",
+        "conditions": [
+            {
+                "field": "event.dataset",
+                "value": "fortinet.app-ctrl"
+            },
+            {
+                "field": "action.name",
+                "value": "pass"
+            }
+        ],
+        "relationships": [
+            {
+                "source": "source.ip",
+                "target": "destination.ip",
+                "type": "connected to"
+            }
+        ]
+    },
+    {
+        "value": "{source.ip} connected to {url.domain}{url.path} (recognised as {application.category}/{application.name})",
+        "conditions": [
+            {
+                "field": "event.dataset",
+                "value": "fortinet.app-ctrl"
+            },
+            {
+                "field": "action.name",
+                "value": "pass"
+            },
+            {
+                "field": "url.domain"
+            }
+        ],
+        "relationships": [
+            {
+                "source": "source.ip",
+                "target": "url.domain",
+                "type": "connected to"
+            },
+            {
+                "source": "url.domain",
+                "target": "destination.ip",
+                "type": "resolves to"
+            }
+        ]
+    },
+    {
+        "value": "{source.ip} was denied a connection to {destination.ip}:{destination.port} (recognised as {application.category}/{application.name})",
+        "conditions": [
+            {
+                "field": "event.dataset",
+                "value": "fortinet.app-ctrl"
+            },
+            {
+                "field": "action.name",
+                "value": "block"
+            }
+        ],
+        "relationships": [
+            {
+                "source": "source.ip",
+                "target": "destination.ip",
+                "type": "was denied a connection to"
+            }
+        ]
+    },
+    {
+        "value": "{source.ip} was denied a connection to {url.domain}{url.path} (recognised as {application.category}/{application.name})",
+        "conditions": [
+            {
+                "field": "event.dataset",
+                "value": "fortinet.app-ctrl"
+            },
+            {
+                "field": "action.name",
+                "value": "block"
+            },
+            {
+                "field": "url.domain"
+            }
+        ],
+        "relationships": [
+            {
+                "source": "source.ip",
+                "target": "url.domain",
+                "type": "was denied a connection to"
+            },
+            {
+                "source": "url.domain",
+                "target": "destination.ip",
+                "type": "resolves to"
+            }
+        ]
+    },
+    {
+        "value": "{observer.hostname} denied {network.protocol} traffic initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
+        "conditions": [
+            {
+                "field": "action.name",
+                "value": "deny"
+            },
+            {
+                "field": "action.outcome",
+                "value": "success"
+            },
+            {
+                "field": "action.type"
+            }
+        ],
+        "relationships": [
+            {
+                "source": "source.ip",
+                "target": "destination.ip",
+                "type": "was denied a connection to"
+            }
+        ]
+    },
+    {
+        "value": "{observer.hostname} accepted {network.protocol} traffic initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
+        "conditions": [
+            {
+                "field": "action.name",
+                "value": "accept"
+            },
+            {
+                "field": "action.outcome",
+                "value": "success"
+            },
+            {
+                "field": "action.type"
+            }
+        ],
+        "relationships": [
+            {
+                "source": "source.ip",
+                "target": "destination.ip",
+                "type": "connected to"
+            }
+        ]
+    },
+    {
+        "value": "{observer.hostname} observed client reset {network.protocol} session initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
+        "conditions": [
+            {
+                "field": "action.name",
+                "value": "client-rst"
+            },
+            {
+                "field": "action.outcome",
+                "value": "success"
+            },
+            {
+                "field": "action.type"
+            }
+        ]
+    },
+    {
+        "value": "{observer.hostname} observed server reset {network.protocol} session initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
+        "conditions": [
+            {
+                "field": "action.name",
+                "value": "server-rst"
+            },
+            {
+                "field": "action.outcome",
+                "value": "success"
+            },
+            {
+                "field": "action.type"
+            }
+        ]
+    },
+    {
+        "value": "{observer.hostname} observed timeout {network.protocol} session initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
+        "conditions": [
+            {
+                "field": "action.name",
+                "value": "timeout"
+            },
+            {
+                "field": "action.outcome",
+                "value": "success"
+            },
+            {
+                "field": "action.type"
+            }
+        ]
+    },
+    {
+        "value": "{observer.hostname} observed start {network.protocol} session initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
+        "conditions": [
+            {
+                "field": "action.name",
+                "value": "start"
+            },
+            {
+                "field": "action.outcome",
+                "value": "success"
+            },
+            {
+                "field": "action.type"
+            }
+        ]
+    },
+    {
+        "value": "{observer.hostname} observed close {network.protocol} session initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
+        "conditions": [
+            {
+                "field": "action.name",
+                "value": "close"
+            },
+            {
+                "field": "action.outcome",
+                "value": "success"
+            },
+            {
+                "field": "action.type"
+            }
+        ]
+    },
+    {
+        "value": "{observer.hostname} observed DNS session initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
         "conditions": [
             {
                 "field": "action.name",


### PR DESCRIPTION
use {observer.hostname} field instead of {log.hostname} in smart description of Fortigate

Freshdesk [7556](https://support.sekoia.io/a/tickets/7556)