### PR TITLE
Update smart-descriptions.json

### DIFF
--- a/Fortinet/fortigate/_meta/smart-descriptions.json
+++ b/Fortinet/fortigate/_meta/smart-descriptions.json
@@ -315,7 +315,7 @@
         ]
     },
     {
-        "value": "{log.hostname} denied {network.protocol} traffic initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
+        "value": "{observer.hostname} denied {network.protocol} traffic initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
         "conditions": [
             {
                 "field": "action.name",
@@ -338,7 +338,7 @@
         ]
     },
     {
-        "value": "{log.hostname} accepted {network.protocol} traffic initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
+        "value": "{observer.hostname} accepted {network.protocol} traffic initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
         "conditions": [
             {
                 "field": "action.name",
@@ -361,7 +361,7 @@
         ]
     },
     {
-        "value": "{log.hostname} observed client reset {network.protocol} session initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
+        "value": "{observer.hostname} observed client reset {network.protocol} session initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
         "conditions": [
             {
                 "field": "action.name",
@@ -377,7 +377,7 @@
         ]
     },
     {
-        "value": "{log.hostname} observed server reset {network.protocol} session initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
+        "value": "{observer.hostname} observed server reset {network.protocol} session initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
         "conditions": [
             {
                 "field": "action.name",
@@ -393,7 +393,7 @@
         ]
     },
     {
-        "value": "{log.hostname} observed timeout {network.protocol} session initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
+        "value": "{observer.hostname} observed timeout {network.protocol} session initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
         "conditions": [
             {
                 "field": "action.name",
@@ -409,7 +409,7 @@
         ]
     },
     {
-        "value": "{log.hostname} observed start {network.protocol} session initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
+        "value": "{observer.hostname} observed start {network.protocol} session initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
         "conditions": [
             {
                 "field": "action.name",
@@ -425,7 +425,7 @@
         ]
     },
     {
-        "value": "{log.hostname} observed close {network.protocol} session initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
+        "value": "{observer.hostname} observed close {network.protocol} session initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
         "conditions": [
             {
                 "field": "action.name",
@@ -441,7 +441,7 @@
         ]
     },
     {
-        "value": "{log.hostname} observed DNS session initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
+        "value": "{observer.hostname} observed DNS session initiated by {source.ip}:{source.port} to {destination.ip}:{destination.port}",
         "conditions": [
             {
                 "field": "action.name",


### PR DESCRIPTION
use {observer.hostname} field instead of {log.hostname} in smart description of Fortigate

Freshdesk [7556](https://support.sekoia.io/a/tickets/7556)