### PR TITLE
feat(Fortinet/Fortigate): Add backward compatibility

### DIFF
--- a/Fortinet/fortigate/_meta/fields.yml
+++ b/Fortinet/fortigate/_meta/fields.yml
@@ -22,3 +22,38 @@ fortinet.event.type:
   name: fortinet.event.type
   type: keyword
   description: "Type of the event."
+
+action.target:
+  name: action.target
+  type: keyword
+  description: "Target of the action (backward compatibility)"
+
+action.properties.icmp_code:
+  name: action.properties.icmp_code
+  type: keyword
+  description: "ICMP code (backward compatibility)"
+
+action.properties.icmp_type:
+  name: action.properties.icmp_type
+  type: keyword
+  description: "ICMP type (backward compatibility)"
+
+fortinet.event.severity:
+  name: fortinet.event.severity
+  type: keyword
+  description: "Anomaly severity as reported by Fortigate"
+
+dns.rname:
+  name: dns.rname
+  type: keyword
+  description: "DNS requested name (backward compatibility)"
+
+dns.rtype:
+  name: dns.rtype
+  type: keyword
+  description: "DNS request type (backward compatibility)"
+
+rule.apprisk:
+  name: rule.apprisk
+  type: keyword
+  description: "App risk reported by Fortigate (backward compatibility)"

--- a/Fortinet/fortigate/ingest/parser.yml
+++ b/Fortinet/fortigate/ingest/parser.yml
@@ -70,14 +70,51 @@ pipeline:
         timezone: '{{parsed_event.message.tz}}'
 
   - name: field_extraction
-  - name: ecs_categorization_fields
   - name: set_event_dataset
+#  commented for backward compatibility
+#  - name: ecs_categorization_fields
+  - name: backward_compatibility
 
 stages:
+  backward_compatibility:
+    actions:
+      - set:
+          event.category: "{{parsed_event.message.type or parsed_event.message.cat.split(':')[0]}}"
+          event.reason: "{{parsed_event.message.reason}}"
+          event.provider: "{{parsed_event.message.method}}"
+          action.name: "{{final.event.action}}"
+          event.type: "{{parsed_event.message.desc}}"
+          action.type: "{{parsed_event.message.subtype or parsed_event.message.FTNTFGTsubtype or parsed_event.message.FortinetFortiGatesubtype}}"
+          action.outcome: "{{parsed_event.message.status or parsed_event.message.outcome}}"
+          action.outcome_reason: "{{parsed_event.message.outcome_reason or or parsed_event.message.reason}}"
+          action.outcome_reason: "{{parsed_event.message.msg.strip('\n').strip('\"')}}"
+          action.properties.icmp_code: "{{parsed_event.message.icmpcode}}"
+          action.properties.icmp_type: "{{parsed_event.message.icmptype}}"
+          log.description: "{{parsed_event.message.logdesc}}"
+          log.hostname: "{{parsed_event.message.devname}}"
+          url.full: "{{final.url.original}}"
+          dns.rname: "{{final.dns.question.name}}"
+          dns.rtype: "{{final.dns.question.type}}"
+          rule.apprisk: "{{parsed_event.message.apprisk}}"
+
+      - set:
+          action.type: '{{parsed_event.message.get("FTNTFGTeventtype")}} - {{backward_compatibility.action.type}}'
+        filter: '{{parsed_event.message.get("FTNTFGTeventtype") != None }}'
+
+      - set:
+          action.target: "network-traffic"
+        filter: '{{final.source != None and final.destination != None and final.action != None}}'
+
+
+      - set:
+          action.outcome: "success"
+        filter: '{{backward_compatibility.action.name != None and backward_compatibility.action.get("outcome") == None}}'
+
+
   set_event_dataset:
-      # This stage is used so harmonize the value
-      # of event.dataset between every supported event formats (cef, kv, standard)
-      # the formats kv and standard types are translated to CEF events "cat" field
+    # This stage is used so harmonize the value
+    # of event.dataset between every supported event formats (cef, kv, standard)
+    # the formats kv and standard types are translated to CEF events "cat" field
     actions:
       - set:
           event.dataset: "{{ parsed_event.message.cat}}"
@@ -105,20 +142,20 @@ stages:
           event.category: ["network"]
 
       - set:
-          event.type: ["allowed", "connection"]
+          event.type: [ "allowed", "connection" ]
         filter: '{{parsed_event.message.action == "accept"
          or parsed_event.message.act in ["pass", "permit", "passthrough", "log-only", "ssl-new-con", "accept", "dns"]
          or parsed_event.message.action in ["pass", "ip-conn"] 
          or parsed_event.message.FortinetFortiGateaction in ["accept"] }}'
 
       - set:
-          event.type: ["connection", "end"]
+          event.type: [ "connection", "end" ]
         filter: '{{parsed_event.message.act == "close"
          or parsed_event.message.action in ["server-rst"]
          or parsed_event.message.FortinetFortiGateaction in ["timeout"]}}'
 
       - set:
-          event.type: ["denied", "connection", "end"]
+          event.type: [ "denied", "connection", "end" ]
         filter: '{{parsed_event.message.act in ["block", "blocked", "clear_session", "reset"]
          or parsed_event.message.action in ["clear_session"]}}'
 
@@ -127,11 +164,7 @@ stages:
     actions:
       - set:
           '@timestamp': "{{parsed_date.date}}"
-          # action.name needs to be removed in the future.
-          action.name: "{{parsed_event.message.name or parsed_event.message.FTNTFGTaction or parsed_event.message.FortinetFortiGateaction or parsed_event.message.act or parsed_event.message.action or parsed_event.message.reason}}"
           event.action: "{{parsed_event.message.name or parsed_event.message.FTNTFGTaction or parsed_event.message.FortinetFortiGateaction or parsed_event.message.act or parsed_event.message.action or parsed_event.message.reason}}"
-          action.outcome: "{{parsed_event.message.status or parsed_event.message.outcome}}"
-          action.type: "{{parsed_event.message.subtype or parsed_event.message.FTNTFGTsubtype or parsed_event.message.FortinetFortiGatesubtype}}"
           destination.address: "{{parsed_event.message.dstip or parsed_event.message.dst}}"
           destination.bytes: "{{parsed_event.message.rcvdbyte or parsed_event.message.out}}"
           destination.domain: "{{parsed_event.message.hostname or parsed_event.message.dhost}}"
@@ -146,6 +179,7 @@ stages:
           dns.question.name: "{{parsed_event.message.qname or parsed_event.message.FTNFGTqname or parsed_event.message.FortinetFortiGateqname}}"
           dns.question.type: "{{parsed_event.message.qtype or parsed_event.message.FTNFGTqtype or parsed_event.message.FortinetFortiGateqtype}}"
           fortinet.event.type: "{{parsed_event.message.type}}"
+          fortinet.event.severity: "{{parsed_event.message.severity}}"
           event.code: "{{parsed_event.message.logid or parsed_event.message.FTNTFGTlogid or parsed_event.message.FortinetFortiGatelogid}}"
           event.reason: "{{parsed_event.message.msg}}"
           event.severity: "{{parsed_event.message.Severity}}"

--- a/Fortinet/fortigate/ingest/parser.yml
+++ b/Fortinet/fortigate/ingest/parser.yml
@@ -135,29 +135,29 @@ stages:
         filter: '{{parsed_event.message.get("subtype") != None}}'
 
 
-  ecs_categorization_fields:
-    actions:
-      - set:
-          event.kind: "event"
-          event.category: ["network"]
-
-      - set:
-          event.type: [ "allowed", "connection" ]
-        filter: '{{parsed_event.message.action == "accept"
-         or parsed_event.message.act in ["pass", "permit", "passthrough", "log-only", "ssl-new-con", "accept", "dns"]
-         or parsed_event.message.action in ["pass", "ip-conn"] 
-         or parsed_event.message.FortinetFortiGateaction in ["accept"] }}'
-
-      - set:
-          event.type: [ "connection", "end" ]
-        filter: '{{parsed_event.message.act == "close"
-         or parsed_event.message.action in ["server-rst"]
-         or parsed_event.message.FortinetFortiGateaction in ["timeout"]}}'
-
-      - set:
-          event.type: [ "denied", "connection", "end" ]
-        filter: '{{parsed_event.message.act in ["block", "blocked", "clear_session", "reset"]
-         or parsed_event.message.action in ["clear_session"]}}'
+#  ecs_categorization_fields:
+#    actions:
+#      - set:
+#          event.kind: "event"
+#          event.category: ["network"]
+#
+#      - set:
+#          event.type: [ "allowed", "connection" ]
+#        filter: '{{parsed_event.message.action == "accept"
+#         or parsed_event.message.act in ["pass", "permit", "passthrough", "log-only", "ssl-new-con", "accept", "dns"]
+#         or parsed_event.message.action in ["pass", "ip-conn"]
+#         or parsed_event.message.FortinetFortiGateaction in ["accept"] }}'
+#
+#      - set:
+#          event.type: [ "connection", "end" ]
+#        filter: '{{parsed_event.message.act == "close"
+#         or parsed_event.message.action in ["server-rst"]
+#         or parsed_event.message.FortinetFortiGateaction in ["timeout"]}}'
+#
+#      - set:
+#          event.type: [ "denied", "connection", "end" ]
+#        filter: '{{parsed_event.message.act in ["block", "blocked", "clear_session", "reset"]
+#         or parsed_event.message.action in ["clear_session"]}}'
 
 
   field_extraction:

--- a/Fortinet/fortigate/tests/Configuration_changed.CEF.json
+++ b/Fortinet/fortigate/tests/Configuration_changed.CEF.json
@@ -15,16 +15,10 @@
       "reason": "Configuration is changed in the admin session",
       "severity": 7,
       "timezone": "+0100",
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "dataset": "event:system"
+      "dataset": "event:system",
+      "category": "event"
     },
     "@timestamp": "2021-11-23T14:35:08.541882Z",
-    "action": {
-      "type": "system"
-    },
     "log": {
       "level": "alert"
     },
@@ -32,6 +26,12 @@
       "type": "Fortigate",
       "vendor": "Fortinet",
       "version": "v6.2.9"
+    },
+    "action": {
+      "type": "system",
+      "outcome_reason": "Configuration is changed in the admin session",
+      "target": "network-traffic",
+      "outcome": "success"
     }
   }
 }

--- a/Fortinet/fortigate/tests/DLP.CEF.json
+++ b/Fortinet/fortigate/tests/DLP.CEF.json
@@ -14,22 +14,10 @@
       "action": "block",
       "code": "0954024576",
       "severity": 4,
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "denied",
-        "connection",
-        "end"
-      ],
-      "dataset": "utm:dlp"
+      "dataset": "utm:dlp",
+      "category": "utm"
     },
     "@timestamp": "2018-12-27T22:29:36.000000Z",
-    "action": {
-      "name": "block",
-      "type": "dlp"
-    },
     "destination": {
       "address": "172.18.62.158",
       "domain": "172.18.62.158",
@@ -74,10 +62,17 @@
     },
     "url": {
       "original": "/dlp/flower.gif",
+      "full": "/dlp/flower.gif",
       "path": "/dlp/flower.gif"
     },
     "user_agent": {
       "original": "curl/7.47.0"
+    },
+    "action": {
+      "name": "block",
+      "type": "dlp - dlp",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "user": [

--- a/Fortinet/fortigate/tests/DNS.CEF.json
+++ b/Fortinet/fortigate/tests/DNS.CEF.json
@@ -15,21 +15,10 @@
       "code": "1501054802",
       "reason": "Domain is monitored",
       "severity": 3,
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "allowed",
-        "connection"
-      ],
-      "dataset": "dns:dns-response"
+      "dataset": "dns:dns-response",
+      "category": "dns"
     },
     "@timestamp": "2018-12-27T22:45:26.000000Z",
-    "action": {
-      "name": "pass",
-      "type": "dns-response"
-    },
     "destination": {
       "address": "172.16.200.55",
       "ip": "172.16.200.55",
@@ -63,6 +52,13 @@
       "ip": "10.1.100.11",
       "port": 54621,
       "address": "10.1.100.11"
+    },
+    "action": {
+      "name": "pass",
+      "type": "dns-response",
+      "outcome_reason": "Domain is monitored",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "user": [

--- a/Fortinet/fortigate/tests/IPS.CEF.json
+++ b/Fortinet/fortigate/tests/IPS.CEF.json
@@ -15,22 +15,10 @@
       "code": "0419016384",
       "reason": "file_transfer: Eicar.Virus.Test.File,",
       "severity": 7,
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "denied",
-        "connection",
-        "end"
-      ],
-      "dataset": "utm:ips"
+      "dataset": "utm:ips",
+      "category": "utm"
     },
     "@timestamp": "2018-12-27T19:28:07.000000Z",
-    "action": {
-      "name": "reset",
-      "type": "ips"
-    },
     "destination": {
       "address": "10.1.100.11",
       "domain": "172.16.200.55",
@@ -71,7 +59,15 @@
     },
     "url": {
       "original": "/virus/eicar.com",
+      "full": "/virus/eicar.com",
       "path": "/virus/eicar.com"
+    },
+    "action": {
+      "name": "reset",
+      "type": "signature - ips",
+      "outcome_reason": "file_transfer: Eicar.Virus.Test.File,",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "user": [

--- a/Fortinet/fortigate/tests/IP_SEC.STANDARD.json
+++ b/Fortinet/fortigate/tests/IP_SEC.STANDARD.json
@@ -12,37 +12,38 @@
     "message": "time=17:24:16 devname=\"abc\" devid=\"1\" logid=\"0101037130\" type=\"event\" subtype=\"vpn\" level=\"error\" vd=\"root\" eventtime=1580142256 logdesc=\"Progress IPsec phase 2\" msg=\"progress IPsec phase 2\" action=\"negotiate\" remip=1.1.1.1 locip=93.187.43.9 remport=500 locport=500 outintf=\"N/A\" cookies=\"07f928d94dd975ea/89b1d990f54f0b82\" user=\"N/A\" group=\"N/A\" xauthuser=\"N/A\" xauthgroup=\"N/A\" assignip=N/A vpntunnel=\"VPN-FOOBAR\" status=\"failure\" init=\"local\" exch=\"CREATE_CHILD\" dir=\"inbound\" role=\"initiator\" result=\"ERROR\" version=\"IKEv2\"",
     "event": {
       "action": "negotiate",
-      "dataset": "event:vpn",
       "code": "0101037130",
       "reason": "progress IPsec phase 2",
-      "kind": "event",
-      "category": [
-        "network"
-      ]
+      "dataset": "event:vpn",
+      "category": "event"
     },
     "@timestamp": "2020-01-27T16:24:16.000000Z",
-    "action": {
-      "name": "negotiate",
-      "outcome": "failure",
-      "type": "vpn"
-    },
     "fortinet": {
       "event": {
         "type": "event"
       }
     },
     "log": {
-      "level": "error"
+      "level": "error",
+      "description": "Progress IPsec phase 2",
+      "hostname": "abc"
     },
     "observer": {
       "hostname": "abc"
     },
     "source": {
-      "address": "1.1.1.1",
       "ip": "1.1.1.1",
       "user": {
         "name": "N/A"
-      }
+      },
+      "address": "1.1.1.1"
+    },
+    "action": {
+      "name": "negotiate",
+      "type": "vpn",
+      "outcome": "failure",
+      "outcome_reason": "progress IPsec phase 2",
+      "target": "network-traffic"
     },
     "related": {
       "hosts": [
@@ -54,6 +55,9 @@
       "ip": [
         "1.1.1.1"
       ]
+    },
+    "host": {
+      "name": "abc"
     }
   }
 }

--- a/Fortinet/fortigate/tests/LOGOUT.STANDARD.json
+++ b/Fortinet/fortigate/tests/LOGOUT.STANDARD.json
@@ -12,20 +12,13 @@
     "message": "time=16:48:00 devname=\"abc\" devid=\"1\" logid=\"0100032003\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" eventtime=1619621280 logdesc=\"Admin logout successful\" sn=\"1619620402\" user=\"test\" ui=\"jsconsole\" method=\"jsconsole\" srcip=1.1.1.1 dstip=2.2.2.2 action=\"logout\" status=\"success\" duration=878 reason=\"exit\" msg=\"Administrator test logged out from jsconsole\"",
     "event": {
       "action": "logout",
-      "dataset": "event:system",
       "code": "0100032003",
-      "reason": "Administrator test logged out from jsconsole",
-      "kind": "event",
-      "category": [
-        "network"
-      ]
+      "reason": "exit",
+      "dataset": "event:system",
+      "category": "event",
+      "provider": "jsconsole"
     },
     "@timestamp": "2021-04-28T14:48:00.000000Z",
-    "action": {
-      "name": "logout",
-      "outcome": "success",
-      "type": "system"
-    },
     "destination": {
       "address": "2.2.2.2",
       "ip": "2.2.2.2"
@@ -41,17 +34,26 @@
       }
     },
     "log": {
-      "level": "information"
+      "level": "information",
+      "description": "Admin logout successful",
+      "hostname": "abc"
     },
     "observer": {
       "hostname": "abc"
     },
     "source": {
-      "address": "1.1.1.1",
       "ip": "1.1.1.1",
       "user": {
         "name": "test"
-      }
+      },
+      "address": "1.1.1.1"
+    },
+    "action": {
+      "name": "logout",
+      "type": "system",
+      "outcome": "success",
+      "outcome_reason": "Administrator test logged out from jsconsole",
+      "target": "network-traffic"
     },
     "related": {
       "hosts": [
@@ -64,6 +66,9 @@
       "user": [
         "test"
       ]
+    },
+    "host": {
+      "name": "abc"
     }
   }
 }

--- a/Fortinet/fortigate/tests/ROLL-LOG.STANDARD.json
+++ b/Fortinet/fortigate/tests/ROLL-LOG.STANDARD.json
@@ -13,33 +13,38 @@
     "event": {
       "action": "roll-log",
       "code": "0100032011",
-      "reason": "Disk log has rolled.",
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "dataset": "event:system"
+      "reason": "file-size",
+      "dataset": "event:system",
+      "category": "event"
     },
     "@timestamp": "2021-04-28T14:23:50.000000Z",
-    "action": {
-      "name": "roll-log",
-      "type": "system"
-    },
     "fortinet": {
       "event": {
         "type": "event"
       }
     },
     "log": {
-      "level": "notice"
+      "level": "notice",
+      "description": "Disk log rolled",
+      "hostname": "abc"
     },
     "observer": {
       "hostname": "abc"
+    },
+    "action": {
+      "name": "roll-log",
+      "type": "system",
+      "outcome_reason": "Disk log has rolled.",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "hosts": [
         "abc"
       ]
+    },
+    "host": {
+      "name": "abc"
     }
   }
 }

--- a/Fortinet/fortigate/tests/SSH.CEF-2.json
+++ b/Fortinet/fortigate/tests/SSH.CEF-2.json
@@ -14,21 +14,10 @@
       "action": "passthrough",
       "code": "1600061002",
       "severity": 3,
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "allowed",
-        "connection"
-      ],
-      "dataset": "utm:ssh"
+      "dataset": "utm:ssh",
+      "category": "utm"
     },
     "@timestamp": "2018-12-27T22:36:15.000000Z",
-    "action": {
-      "name": "passthrough",
-      "type": "ssh"
-    },
     "destination": {
       "address": "172.16.200.55",
       "ip": "172.16.200.55",
@@ -62,6 +51,12 @@
       "ip": "10.1.100.11",
       "port": 56698,
       "address": "10.1.100.11"
+    },
+    "action": {
+      "name": "passthrough",
+      "type": "ssh-command - ssh",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "user": [

--- a/Fortinet/fortigate/tests/VoIP.CEF.json
+++ b/Fortinet/fortigate/tests/VoIP.CEF.json
@@ -14,22 +14,10 @@
       "action": "permit",
       "code": "0814044032",
       "severity": 2,
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "allowed",
-        "connection"
-      ],
-      "dataset": "utm:voip"
+      "dataset": "utm:voip",
+      "category": "utm"
     },
     "@timestamp": "2018-12-28T00:47:08.000000Z",
-    "action": {
-      "name": "permit",
-      "outcome": "start",
-      "type": "voip"
-    },
     "destination": {
       "address": "172.16.200.55",
       "ip": "172.16.200.55",
@@ -66,6 +54,12 @@
         "name": "sip:sipp@127.0.0.1:5060"
       },
       "address": "10.1.100.11"
+    },
+    "action": {
+      "name": "permit",
+      "type": "voip - voip",
+      "outcome": "start",
+      "target": "network-traffic"
     },
     "related": {
       "user": [

--- a/Fortinet/fortigate/tests/WAD.STANDARD.json
+++ b/Fortinet/fortigate/tests/WAD.STANDARD.json
@@ -14,17 +14,11 @@
       "action": "send",
       "code": "0105048039",
       "reason": "SSL Alert sent",
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "dataset": "utm:wad"
+      "dataset": "utm:wad",
+      "category": "event",
+      "type": "illegal parameter"
     },
     "@timestamp": "2021-04-28T13:29:39.000000Z",
-    "action": {
-      "name": "send",
-      "type": "wad"
-    },
     "destination": {
       "address": "1.1.1.1",
       "ip": "1.1.1.1",
@@ -37,15 +31,24 @@
       }
     },
     "log": {
-      "level": "error"
+      "level": "error",
+      "description": "SSL fatal alert sent",
+      "hostname": "abc"
     },
     "observer": {
       "hostname": "abc"
     },
     "source": {
-      "address": "2.2.2.2",
       "ip": "2.2.2.2",
-      "port": 47782
+      "port": 47782,
+      "address": "2.2.2.2"
+    },
+    "action": {
+      "name": "send",
+      "type": "wad",
+      "outcome_reason": "SSL Alert sent",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "hosts": [
@@ -55,6 +58,9 @@
         "1.1.1.1",
         "2.2.2.2"
       ]
+    },
+    "host": {
+      "name": "abc"
     }
   }
 }

--- a/Fortinet/fortigate/tests/WAF.CEF.json
+++ b/Fortinet/fortigate/tests/WAF.CEF.json
@@ -14,21 +14,10 @@
       "action": "passthrough",
       "code": "1203030258",
       "severity": 4,
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "allowed",
-        "connection"
-      ],
-      "dataset": "utm:waf"
+      "dataset": "utm:waf",
+      "category": "utm"
     },
     "@timestamp": "2018-12-27T22:55:20.000000Z",
-    "action": {
-      "name": "passthrough",
-      "type": "waf"
-    },
     "destination": {
       "address": "172.16.200.55",
       "ip": "172.16.200.55",
@@ -68,14 +57,21 @@
     },
     "url": {
       "original": "http://172.16.200.55/index.html?a\\=0123456789&b\\=0123456789&c\\=0123456789",
+      "full": "http://172.16.200.55/index.html?a\\=0123456789&b\\=0123456789&c\\=0123456789",
       "domain": "172.16.200.55",
+      "path": "/index.html",
       "scheme": "http",
       "query": "a\\=0123456789&b\\=0123456789&c\\=0123456789",
-      "path": "/index.html",
       "port": 80
     },
     "user_agent": {
       "original": "curl/7.47.0"
+    },
+    "action": {
+      "name": "passthrough",
+      "type": "waf-http-constraint - waf",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "user": [

--- a/Fortinet/fortigate/tests/anomaly.CEF-2.json
+++ b/Fortinet/fortigate/tests/anomaly.CEF-2.json
@@ -15,22 +15,10 @@
       "code": "0720018433",
       "reason": "anomaly: icmp_flood, 51 > threshold 50",
       "severity": 7,
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "denied",
-        "connection",
-        "end"
-      ],
-      "dataset": "utm:anomaly"
+      "dataset": "utm:anomaly",
+      "category": "utm"
     },
     "@timestamp": "2018-12-27T19:40:04.000000Z",
-    "action": {
-      "name": "clear_session",
-      "type": "anomaly"
-    },
     "destination": {
       "address": "172.16.200.55",
       "ip": "172.16.200.55"
@@ -56,6 +44,13 @@
     "source": {
       "ip": "10.1.100.11",
       "address": "10.1.100.11"
+    },
+    "action": {
+      "name": "clear_session",
+      "type": "anomaly - anomaly",
+      "outcome_reason": "anomaly: icmp_flood, 51 > threshold 50",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "ip": [

--- a/Fortinet/fortigate/tests/anomaly.CEF.json
+++ b/Fortinet/fortigate/tests/anomaly.CEF.json
@@ -15,20 +15,8 @@
       "code": "0720018433",
       "reason": "anomaly: icmp_flood, 34 > threshold 25, repeats 306 times",
       "severity": 7,
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "denied",
-        "connection",
-        "end"
-      ],
-      "dataset": "anomaly:anomaly"
-    },
-    "action": {
-      "name": "clear_session",
-      "type": "anomaly"
+      "dataset": "anomaly:anomaly",
+      "category": "anomaly"
     },
     "destination": {
       "address": "2.2.2.2",
@@ -56,6 +44,13 @@
     "source": {
       "ip": "1.1.1.1",
       "address": "1.1.1.1"
+    },
+    "action": {
+      "name": "clear_session",
+      "type": "anomaly",
+      "outcome_reason": "anomaly: icmp_flood, 34 > threshold 25, repeats 306 times",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "ip": [

--- a/Fortinet/fortigate/tests/anomaly.CSV.json
+++ b/Fortinet/fortigate/tests/anomaly.CSV.json
@@ -14,20 +14,8 @@
       "action": "clear_session",
       "code": "0720018433",
       "reason": "anomaly: icmp_flood, 34 > threshold 25, repeats 306 times",
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "denied",
-        "connection",
-        "end"
-      ],
-      "dataset": "utm:anomaly"
-    },
-    "action": {
-      "name": "clear_session",
-      "type": "anomaly"
+      "dataset": "utm:anomaly",
+      "category": "anomaly"
     },
     "destination": {
       "address": "2.2.2.2",
@@ -36,7 +24,8 @@
     },
     "fortinet": {
       "event": {
-        "type": "anomaly"
+        "type": "anomaly",
+        "severity": "critical"
       }
     },
     "log": {
@@ -54,14 +43,25 @@
       }
     },
     "source": {
-      "address": "1.1.1.1",
-      "ip": "1.1.1.1"
+      "ip": "1.1.1.1",
+      "address": "1.1.1.1"
     },
     "icmp": {
       "request": {
         "type": "0x92",
         "code": "0x51"
       }
+    },
+    "action": {
+      "name": "clear_session",
+      "type": "anomaly",
+      "outcome_reason": "anomaly: icmp_flood, 34 > threshold 25, repeats 306 times",
+      "properties": {
+        "icmp_code": "0x51",
+        "icmp_type": "0x92"
+      },
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "ip": [

--- a/Fortinet/fortigate/tests/anomaly.STANDARD.json
+++ b/Fortinet/fortigate/tests/anomaly.STANDARD.json
@@ -14,20 +14,8 @@
       "action": "clear_session",
       "code": "0720018433",
       "reason": "anomaly: icmp_flood, 34 > threshold 25, repeats 306 times",
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "denied",
-        "connection",
-        "end"
-      ],
-      "dataset": "utm:anomaly"
-    },
-    "action": {
-      "name": "clear_session",
-      "type": "anomaly"
+      "dataset": "utm:anomaly",
+      "category": "anomaly"
     },
     "destination": {
       "address": "2.2.2.2",
@@ -36,7 +24,8 @@
     },
     "fortinet": {
       "event": {
-        "type": "anomaly"
+        "type": "anomaly",
+        "severity": "critical"
       }
     },
     "log": {
@@ -54,14 +43,25 @@
       }
     },
     "source": {
-      "address": "1.1.1.1",
-      "ip": "1.1.1.1"
+      "ip": "1.1.1.1",
+      "address": "1.1.1.1"
     },
     "icmp": {
       "request": {
         "type": "0x92",
         "code": "0x51"
       }
+    },
+    "action": {
+      "name": "clear_session",
+      "type": "anomaly",
+      "outcome_reason": "anomaly: icmp_flood, 34 > threshold 25, repeats 306 times",
+      "properties": {
+        "icmp_code": "0x51",
+        "icmp_type": "0x92"
+      },
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "ip": [

--- a/Fortinet/fortigate/tests/antivirus.CEF-2.json
+++ b/Fortinet/fortigate/tests/antivirus.CEF-2.json
@@ -15,22 +15,10 @@
       "code": "0211008192",
       "reason": "File is infected.",
       "severity": 4,
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "denied",
-        "connection",
-        "end"
-      ],
-      "dataset": "utm:virus"
+      "dataset": "utm:virus",
+      "category": "utm"
     },
     "@timestamp": "2018-12-27T19:20:48.000000Z",
-    "action": {
-      "name": "blocked",
-      "type": "virus"
-    },
     "destination": {
       "address": "172.16.200.55",
       "ip": "172.16.200.55",
@@ -73,13 +61,21 @@
     },
     "url": {
       "original": "http://172.16.200.55/virus/eicar.com",
+      "full": "http://172.16.200.55/virus/eicar.com",
       "domain": "172.16.200.55",
-      "scheme": "http",
       "path": "/virus/eicar.com",
+      "scheme": "http",
       "port": 80
     },
     "user_agent": {
       "original": "curl/7.47.0"
+    },
+    "action": {
+      "name": "blocked",
+      "type": "infected - virus",
+      "outcome_reason": "File is infected.",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "user": [

--- a/Fortinet/fortigate/tests/antivirus.CEF.json
+++ b/Fortinet/fortigate/tests/antivirus.CEF.json
@@ -15,20 +15,8 @@
       "code": "0211008192",
       "reason": "File is infected",
       "severity": 4,
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "denied",
-        "connection",
-        "end"
-      ],
-      "dataset": "utm:virus"
-    },
-    "action": {
-      "name": "blocked",
-      "type": "virus"
+      "dataset": "utm:virus",
+      "category": "utm"
     },
     "destination": {
       "address": "2.2.2.2",
@@ -69,13 +57,21 @@
     },
     "url": {
       "original": "http://2.2.2.2/eicar.com",
+      "full": "http://2.2.2.2/eicar.com",
       "domain": "2.2.2.2",
-      "scheme": "http",
       "path": "/eicar.com",
+      "scheme": "http",
       "port": 80
     },
     "user_agent": {
       "original": "Wget/1 10 2"
+    },
+    "action": {
+      "name": "blocked",
+      "type": "infected - virus",
+      "outcome_reason": "File is infected",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "ip": [

--- a/Fortinet/fortigate/tests/application.CEF.json
+++ b/Fortinet/fortigate/tests/application.CEF.json
@@ -15,21 +15,10 @@
       "code": "1059028704",
       "reason": "Web.Client: HTTP.BROWSER_Firefox,",
       "severity": 2,
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "allowed",
-        "connection"
-      ],
-      "dataset": "utm:app-ctrl"
+      "dataset": "utm:app-ctrl",
+      "category": "utm"
     },
     "@timestamp": "2018-12-27T22:28:08.000000Z",
-    "action": {
-      "name": "pass",
-      "type": "app-ctrl"
-    },
     "destination": {
       "address": "104.80.89.24",
       "domain": "detectportal.firefox.com",
@@ -67,7 +56,15 @@
     },
     "url": {
       "original": "/success.txt",
+      "full": "/success.txt",
       "path": "/success.txt"
+    },
+    "action": {
+      "name": "pass",
+      "type": "app-ctrl-all - app-ctrl",
+      "outcome_reason": "Web.Client: HTTP.BROWSER_Firefox,",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "hosts": [

--- a/Fortinet/fortigate/tests/dns.CSV.json
+++ b/Fortinet/fortigate/tests/dns.CSV.json
@@ -14,21 +14,10 @@
       "action": "pass",
       "code": "1501054802",
       "reason": "Domain is monitored",
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "allowed",
-        "connection"
-      ],
-      "dataset": "dns:dns-response"
+      "dataset": "dns:dns-response",
+      "category": "dns"
     },
     "@timestamp": "2018-12-27T22:45:26.000000Z",
-    "action": {
-      "name": "pass",
-      "type": "dns-response"
-    },
     "destination": {
       "address": "2.2.2.2",
       "ip": "2.2.2.2",
@@ -38,7 +27,9 @@
       "question": {
         "name": "detectportal.firefox.com",
         "type": "A"
-      }
+      },
+      "rname": "detectportal.firefox.com",
+      "rtype": "A"
     },
     "fortinet": {
       "event": {
@@ -67,13 +58,20 @@
       "category": "Information Technology"
     },
     "source": {
-      "address": "1.1.1.1",
       "ip": "1.1.1.1",
       "mac": "00:00:00:00:00:00",
       "port": 54621,
       "user": {
         "name": "bob"
-      }
+      },
+      "address": "1.1.1.1"
+    },
+    "action": {
+      "name": "pass",
+      "type": "dns-response",
+      "outcome_reason": "Domain is monitored",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "ip": [

--- a/Fortinet/fortigate/tests/email-spamfilter.CEF.json
+++ b/Fortinet/fortigate/tests/email-spamfilter.CEF.json
@@ -15,21 +15,10 @@
       "code": "0508020503",
       "reason": "general email log",
       "severity": 2,
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "allowed",
-        "connection"
-      ],
-      "dataset": "utm:emailfilter"
+      "dataset": "utm:emailfilter",
+      "category": "utm"
     },
     "@timestamp": "2018-12-27T19:36:58.000000Z",
-    "action": {
-      "name": "log-only",
-      "type": "emailfilter"
-    },
     "destination": {
       "address": "172.18.62.158",
       "ip": "172.18.62.158",
@@ -69,6 +58,13 @@
         "name": "testpc1@qa.fortinet.com"
       },
       "address": "10.1.100.11"
+    },
+    "action": {
+      "name": "log-only",
+      "type": "smtp - emailfilter",
+      "outcome_reason": "general email log",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "user": [

--- a/Fortinet/fortigate/tests/event_log_system_subtype.CEF.json
+++ b/Fortinet/fortigate/tests/event_log_system_subtype.CEF.json
@@ -13,20 +13,12 @@
     "event": {
       "action": "login",
       "code": "0100032002",
-      "reason": "Administrator admin1 login failed from https(172.16.200.254) because of invalid user name",
+      "reason": "name_invalid",
       "severity": 7,
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "dataset": "event:system"
+      "dataset": "event:system",
+      "category": "event"
     },
     "@timestamp": "2018-12-27T19:15:40.000000Z",
-    "action": {
-      "name": "login",
-      "outcome": "failed",
-      "type": "system"
-    },
     "destination": {
       "address": "172.16.200.1",
       "ip": "172.16.200.1",
@@ -43,8 +35,15 @@
       "version": "v6.0.3"
     },
     "source": {
-      "address": "172.16.200.254",
-      "ip": "172.16.200.254"
+      "ip": "172.16.200.254",
+      "address": "172.16.200.254"
+    },
+    "action": {
+      "name": "login",
+      "type": "system",
+      "outcome": "failed",
+      "outcome_reason": "Administrator admin1 login failed from https(172.16.200.254) because of invalid user name",
+      "target": "network-traffic"
     },
     "related": {
       "user": [

--- a/Fortinet/fortigate/tests/event_log_user_subtype.CEF.json
+++ b/Fortinet/fortigate/tests/event_log_user_subtype.CEF.json
@@ -13,20 +13,12 @@
     "event": {
       "action": "authentication",
       "code": "0102043008",
-      "reason": "User bob succeeded in authentication",
+      "reason": "N/A",
       "severity": 3,
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "dataset": "event:user"
+      "dataset": "event:user",
+      "category": "event"
     },
     "@timestamp": "2018-12-27T19:17:35.000000Z",
-    "action": {
-      "name": "authentication",
-      "outcome": "success",
-      "type": "user"
-    },
     "destination": {
       "address": "172.16.200.55",
       "ip": "172.16.200.55",
@@ -50,6 +42,13 @@
     "source": {
       "ip": "10.1.100.11",
       "address": "10.1.100.11"
+    },
+    "action": {
+      "name": "authentication",
+      "type": "user",
+      "outcome": "success",
+      "outcome_reason": "User bob succeeded in authentication",
+      "target": "network-traffic"
     },
     "related": {
       "user": [

--- a/Fortinet/fortigate/tests/hostname.STANDARD.json
+++ b/Fortinet/fortigate/tests/hostname.STANDARD.json
@@ -14,21 +14,10 @@
       "action": "pass",
       "code": "1059028704",
       "reason": "Web.Client: HTTPS.BROWSER,",
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "allowed",
-        "connection"
-      ],
-      "dataset": "utm:app-ctrl"
+      "dataset": "utm:app-ctrl",
+      "category": "utm"
     },
     "@timestamp": "2020-01-24T10:09:50.000000Z",
-    "action": {
-      "name": "pass",
-      "type": "app-ctrl"
-    },
     "destination": {
       "address": "2.2.2.2",
       "domain": "abcd",
@@ -42,7 +31,8 @@
       "apprisk": "medium"
     },
     "log": {
-      "level": "information"
+      "level": "information",
+      "hostname": "abc"
     },
     "observer": {
       "hostname": "abc",
@@ -64,7 +54,8 @@
     },
     "rule": {
       "category": "Web.Client",
-      "ruleset": "default"
+      "ruleset": "default",
+      "apprisk": "medium"
     },
     "source": {
       "ip": "1.1.1.1",
@@ -73,7 +64,15 @@
     },
     "url": {
       "original": "/",
+      "full": "/",
       "path": "/"
+    },
+    "action": {
+      "name": "pass",
+      "type": "app-ctrl",
+      "outcome_reason": "Web.Client: HTTPS.BROWSER,",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "hosts": [
@@ -84,6 +83,9 @@
         "1.1.1.1",
         "2.2.2.2"
       ]
+    },
+    "host": {
+      "name": "abc"
     }
   }
 }

--- a/Fortinet/fortigate/tests/icmp.json
+++ b/Fortinet/fortigate/tests/icmp.json
@@ -14,21 +14,10 @@
       "action": "ip-conn",
       "code": "0000000011",
       "timezone": "+0300",
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "allowed",
-        "connection"
-      ],
-      "dataset": "traffic:forward"
+      "dataset": "traffic:forward",
+      "category": "traffic"
     },
     "@timestamp": "2020-10-13T09:22:43.587868Z",
-    "action": {
-      "name": "ip-conn",
-      "type": "forward"
-    },
     "destination": {
       "address": "2.2.2.2",
       "ip": "2.2.2.2"
@@ -39,7 +28,8 @@
       }
     },
     "log": {
-      "level": "warning"
+      "level": "warning",
+      "hostname": "abc"
     },
     "observer": {
       "hostname": "abc",
@@ -63,8 +53,14 @@
       "ruleset": "policy"
     },
     "source": {
-      "address": "1.1.1.1",
-      "ip": "1.1.1.1"
+      "ip": "1.1.1.1",
+      "address": "1.1.1.1"
+    },
+    "action": {
+      "name": "ip-conn",
+      "type": "forward",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "hosts": [
@@ -74,6 +70,9 @@
         "1.1.1.1",
         "2.2.2.2"
       ]
+    },
+    "host": {
+      "name": "abc"
     }
   }
 }

--- a/Fortinet/fortigate/tests/icmp6.json
+++ b/Fortinet/fortigate/tests/icmp6.json
@@ -14,21 +14,10 @@
       "action": "accept",
       "code": "0001000014",
       "timezone": "+0200",
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "allowed",
-        "connection"
-      ],
-      "dataset": "traffic:local"
+      "dataset": "traffic:local",
+      "category": "traffic"
     },
     "@timestamp": "2020-10-13T09:02:14.900309Z",
-    "action": {
-      "name": "accept",
-      "type": "local"
-    },
     "destination": {
       "address": "12::16",
       "bytes": 0,
@@ -41,7 +30,8 @@
       }
     },
     "log": {
-      "level": "notice"
+      "level": "notice",
+      "hostname": "abc"
     },
     "observer": {
       "hostname": "abc",
@@ -66,10 +56,16 @@
       "ruleset": "local-in-policy6"
     },
     "source": {
-      "address": "00::00:00:00:00",
-      "bytes": 76,
       "ip": "00::00:00:00:00",
-      "packets": 1
+      "bytes": 76,
+      "packets": 1,
+      "address": "00::00:00:00:00"
+    },
+    "action": {
+      "name": "accept",
+      "type": "local",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "hosts": [
@@ -79,6 +75,9 @@
         "00::00:00:00:00",
         "12::16"
       ]
+    },
+    "host": {
+      "name": "abc"
     }
   }
 }

--- a/Fortinet/fortigate/tests/icmp_CEF.json
+++ b/Fortinet/fortigate/tests/icmp_CEF.json
@@ -14,21 +14,10 @@
       "action": "accept",
       "code": "0001000014",
       "severity": 3,
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "allowed",
-        "connection"
-      ],
-      "dataset": "traffic:local"
+      "dataset": "traffic:local",
+      "category": "traffic"
     },
     "@timestamp": "2020-10-14T08:11:38.000000Z",
-    "action": {
-      "name": "accept",
-      "type": "local"
-    },
     "destination": {
       "address": "2.2.2.2",
       "bytes": 84,
@@ -63,6 +52,12 @@
       "bytes": 84,
       "packets": 1,
       "address": "1.1.1.1"
+    },
+    "action": {
+      "name": "accept",
+      "type": "local",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "ip": [

--- a/Fortinet/fortigate/tests/ping.json
+++ b/Fortinet/fortigate/tests/ping.json
@@ -14,21 +14,10 @@
       "action": "accept",
       "code": "0000000013",
       "timezone": "+0200",
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "allowed",
-        "connection"
-      ],
-      "dataset": "traffic:forward"
+      "dataset": "traffic:forward",
+      "category": "traffic"
     },
     "@timestamp": "2020-10-13T10:22:38.311909Z",
-    "action": {
-      "name": "accept",
-      "type": "forward"
-    },
     "destination": {
       "address": "2.2.2.2",
       "bytes": 420,
@@ -41,7 +30,8 @@
       }
     },
     "log": {
-      "level": "notice"
+      "level": "notice",
+      "hostname": "abc"
     },
     "observer": {
       "hostname": "abc",
@@ -65,10 +55,16 @@
       "ruleset": "policy"
     },
     "source": {
-      "address": "1.1.1.1",
-      "bytes": 420,
       "ip": "1.1.1.1",
-      "packets": 5
+      "bytes": 420,
+      "packets": 5,
+      "address": "1.1.1.1"
+    },
+    "action": {
+      "name": "accept",
+      "type": "forward",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "hosts": [
@@ -78,6 +74,9 @@
         "1.1.1.1",
         "2.2.2.2"
       ]
+    },
+    "host": {
+      "name": "abc"
     }
   }
 }

--- a/Fortinet/fortigate/tests/ssh_access.CEF.json
+++ b/Fortinet/fortigate/tests/ssh_access.CEF.json
@@ -13,20 +13,12 @@
     "event": {
       "action": "login",
       "code": "0100032021",
-      "reason": "Login disabled from IP 1.1.1.1 for 60 seconds because of 3 bad attempts",
+      "reason": "exceed_limit",
       "severity": 7,
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "dataset": "event:system"
+      "dataset": "event:system",
+      "category": "event"
     },
     "@timestamp": "2020-01-16T11:00:47.000000Z",
-    "action": {
-      "name": "login",
-      "outcome": "failed",
-      "type": "system"
-    },
     "log": {
       "level": "alert"
     },
@@ -34,6 +26,13 @@
       "type": "Fortigate",
       "vendor": "Fortinet",
       "version": "v6.0.4"
+    },
+    "action": {
+      "name": "login",
+      "type": "system",
+      "outcome": "failed",
+      "outcome_reason": "Login disabled from IP 1.1.1.1 for 60 seconds because of 3 bad attempts",
+      "target": "network-traffic"
     }
   }
 }

--- a/Fortinet/fortigate/tests/ssl_new_con.CEF.json
+++ b/Fortinet/fortigate/tests/ssl_new_con.CEF.json
@@ -13,23 +13,12 @@
     "event": {
       "action": "ssl-new-con",
       "code": "0101039943",
-      "reason": "SSL new connection",
+      "reason": "N/A",
       "severity": 2,
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "allowed",
-        "connection"
-      ],
-      "dataset": "event:vpn"
+      "dataset": "event:vpn",
+      "category": "event"
     },
     "@timestamp": "2021-11-19T16:10:58.000000Z",
-    "action": {
-      "name": "ssl-new-con",
-      "type": "vpn"
-    },
     "destination": {
       "address": "2.2.2.2",
       "ip": "2.2.2.2",
@@ -44,6 +33,13 @@
       "type": "Fortigate",
       "vendor": "Fortinet",
       "version": "v6.0.10"
+    },
+    "action": {
+      "name": "ssl-new-con",
+      "type": "vpn",
+      "outcome_reason": "SSL new connection",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "user": [

--- a/Fortinet/fortigate/tests/traffic_forward-RDP.CEF.json
+++ b/Fortinet/fortigate/tests/traffic_forward-RDP.CEF.json
@@ -14,20 +14,10 @@
       "action": "accept",
       "severity": 5,
       "timezone": "+0200",
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "allowed",
-        "connection"
-      ],
-      "dataset": "traffic"
+      "dataset": "traffic",
+      "category": "traffic"
     },
     "@timestamp": "2022-10-12T10:50:31.000000Z",
-    "action": {
-      "name": "accept"
-    },
     "destination": {
       "address": "2.2.2.2",
       "bytes": 202,
@@ -59,6 +49,11 @@
       "bytes": 52,
       "port": 55390,
       "address": "1.1.1.1"
+    },
+    "action": {
+      "name": "accept",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "ip": [

--- a/Fortinet/fortigate/tests/traffic_forward.CEF-2.json
+++ b/Fortinet/fortigate/tests/traffic_forward.CEF-2.json
@@ -14,21 +14,10 @@
       "action": "timeout",
       "code": "0000000013",
       "severity": 3,
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "connection",
-        "end"
-      ],
-      "dataset": "traffic:forward"
+      "dataset": "traffic:forward",
+      "category": "traffic"
     },
     "@timestamp": "2019-10-30T21:44:36.000000Z",
-    "action": {
-      "name": "timeout",
-      "type": "forward"
-    },
     "destination": {
       "address": "3.3.3.3",
       "bytes": 48,
@@ -69,6 +58,12 @@
       "packets": 1,
       "port": 49260,
       "address": "1.1.1.1"
+    },
+    "action": {
+      "name": "timeout",
+      "type": "forward",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "ip": [

--- a/Fortinet/fortigate/tests/traffic_forward.CEF-3.json
+++ b/Fortinet/fortigate/tests/traffic_forward.CEF-3.json
@@ -14,21 +14,10 @@
       "action": "close",
       "code": "0000000013",
       "severity": 3,
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "connection",
-        "end"
-      ],
-      "dataset": "traffic:forward"
+      "dataset": "traffic:forward",
+      "category": "traffic"
     },
     "@timestamp": "2018-12-27T19:07:55.000000Z",
-    "action": {
-      "name": "close",
-      "type": "forward"
-    },
     "destination": {
       "address": "52.53.140.235",
       "bytes": 3652,
@@ -68,6 +57,12 @@
       "packets": 58,
       "port": 54190,
       "address": "10.1.100.11"
+    },
+    "action": {
+      "name": "close",
+      "type": "forward",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "ip": [

--- a/Fortinet/fortigate/tests/traffic_forward.CEF.json
+++ b/Fortinet/fortigate/tests/traffic_forward.CEF.json
@@ -14,19 +14,8 @@
       "action": "close",
       "code": "0000000013",
       "severity": 3,
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "connection",
-        "end"
-      ],
-      "dataset": "traffic:forward"
-    },
-    "action": {
-      "name": "close",
-      "type": "forward"
+      "dataset": "traffic:forward",
+      "category": "traffic"
     },
     "destination": {
       "address": "3.3.3.3",
@@ -70,6 +59,12 @@
       "packets": 5,
       "port": 45719,
       "address": "2.2.2.2"
+    },
+    "action": {
+      "name": "close",
+      "type": "forward",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "hosts": [

--- a/Fortinet/fortigate/tests/traffic_forward.CSV.json
+++ b/Fortinet/fortigate/tests/traffic_forward.CSV.json
@@ -13,21 +13,10 @@
     "event": {
       "action": "accept",
       "code": "0000000013",
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "allowed",
-        "connection"
-      ],
-      "dataset": "traffic:forward"
+      "dataset": "traffic:forward",
+      "category": "traffic"
     },
     "@timestamp": "2018-07-26T14:51:35.000000Z",
-    "action": {
-      "name": "accept",
-      "type": "forward"
-    },
     "destination": {
       "address": "2.2.2.2",
       "bytes": 1000,
@@ -64,15 +53,22 @@
     },
     "rule": {
       "category": "Storage.Backup",
-      "ruleset": "default"
+      "ruleset": "default",
+      "apprisk": "medium"
     },
     "source": {
-      "address": "1.1.1.1",
-      "bytes": 2000,
       "ip": "1.1.1.1",
+      "bytes": 2000,
       "mac": "01:01:01:01:01:01",
       "packets": 0,
-      "port": 10016
+      "port": 10016,
+      "address": "1.1.1.1"
+    },
+    "action": {
+      "name": "accept",
+      "type": "forward",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "ip": [

--- a/Fortinet/fortigate/tests/traffic_forward.STANDARD.json
+++ b/Fortinet/fortigate/tests/traffic_forward.STANDARD.json
@@ -13,21 +13,10 @@
     "event": {
       "action": "accept",
       "code": "0000000013",
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "allowed",
-        "connection"
-      ],
-      "dataset": "traffic:forward"
+      "dataset": "traffic:forward",
+      "category": "traffic"
     },
     "@timestamp": "2018-07-26T14:51:35.000000Z",
-    "action": {
-      "name": "accept",
-      "type": "forward"
-    },
     "destination": {
       "address": "2.2.2.2",
       "bytes": 1000,
@@ -64,15 +53,22 @@
     },
     "rule": {
       "category": "Storage.Backup",
-      "ruleset": "default"
+      "ruleset": "default",
+      "apprisk": "medium"
     },
     "source": {
-      "address": "1.1.1.1",
-      "bytes": 2000,
       "ip": "1.1.1.1",
+      "bytes": 2000,
       "mac": "01:01:01:01:01:01",
       "packets": 0,
-      "port": 10016
+      "port": 10016,
+      "address": "1.1.1.1"
+    },
+    "action": {
+      "name": "accept",
+      "type": "forward",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "ip": [

--- a/Fortinet/fortigate/tests/traffic_forward.STANDARD_2.json
+++ b/Fortinet/fortigate/tests/traffic_forward.STANDARD_2.json
@@ -13,21 +13,10 @@
     "event": {
       "action": "accept",
       "code": "0000000010",
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "allowed",
-        "connection"
-      ],
-      "dataset": "traffic:forward"
+      "dataset": "traffic:forward",
+      "category": "traffic"
     },
     "@timestamp": "2021-06-21T07:38:29.000000Z",
-    "action": {
-      "name": "accept",
-      "type": "forward"
-    },
     "destination": {
       "address": "2.2.2.2",
       "bytes": 5851,
@@ -40,7 +29,8 @@
       }
     },
     "log": {
-      "level": "notice"
+      "level": "notice",
+      "hostname": "abc"
     },
     "observer": {
       "hostname": "abc",
@@ -64,10 +54,16 @@
       "ruleset": "proxy-policy"
     },
     "source": {
-      "address": "1.1.1.1",
-      "bytes": 2769,
       "ip": "1.1.1.1",
-      "port": 50592
+      "bytes": 2769,
+      "port": 50592,
+      "address": "1.1.1.1"
+    },
+    "action": {
+      "name": "accept",
+      "type": "forward",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "hosts": [
@@ -77,6 +73,9 @@
         "1.1.1.1",
         "2.2.2.2"
       ]
+    },
+    "host": {
+      "name": "abc"
     }
   }
 }

--- a/Fortinet/fortigate/tests/traffic_forward_FTNTFGTtz.CEF.json
+++ b/Fortinet/fortigate/tests/traffic_forward_FTNTFGTtz.CEF.json
@@ -15,21 +15,10 @@
       "code": "0000000011",
       "severity": 4,
       "timezone": "+0200",
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "allowed",
-        "connection"
-      ],
-      "dataset": "traffic:forward"
+      "dataset": "traffic:forward",
+      "category": "traffic"
     },
     "@timestamp": "2022-09-05T10:43:45.920035Z",
-    "action": {
-      "name": "dns",
-      "type": "forward"
-    },
     "destination": {
       "address": "172.18.67.10",
       "ip": "172.18.67.10",
@@ -62,6 +51,12 @@
       "ip": "172.16.222.150",
       "port": 49956,
       "address": "172.16.222.150"
+    },
+    "action": {
+      "name": "dns",
+      "type": "forward",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "ip": [

--- a/Fortinet/fortigate/tests/traffic_nat.STANDARD.json
+++ b/Fortinet/fortigate/tests/traffic_nat.STANDARD.json
@@ -13,21 +13,10 @@
     "event": {
       "action": "server-rst",
       "code": "0000000013",
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "connection",
-        "end"
-      ],
-      "dataset": "traffic:forward"
+      "dataset": "traffic:forward",
+      "category": "traffic"
     },
     "@timestamp": "2021-01-06T13:56:21.000000Z",
-    "action": {
-      "name": "server-rst",
-      "type": "forward"
-    },
     "destination": {
       "address": "3.3.3.3",
       "bytes": 40,
@@ -45,7 +34,8 @@
       }
     },
     "log": {
-      "level": "notice"
+      "level": "notice",
+      "hostname": "abc"
     },
     "observer": {
       "hostname": "abc",
@@ -69,11 +59,17 @@
       "ruleset": "policy"
     },
     "source": {
-      "address": "1.1.1.1",
-      "bytes": 80,
       "ip": "1.1.1.1",
+      "bytes": 80,
       "packets": 2,
-      "port": 52125
+      "port": 52125,
+      "address": "1.1.1.1"
+    },
+    "action": {
+      "name": "server-rst",
+      "type": "forward",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "hosts": [
@@ -84,6 +80,9 @@
         "2.2.2.2",
         "3.3.3.3"
       ]
+    },
+    "host": {
+      "name": "abc"
     }
   }
 }

--- a/Fortinet/fortigate/tests/tunnel.json
+++ b/Fortinet/fortigate/tests/tunnel.json
@@ -15,17 +15,10 @@
       "code": "0101039949",
       "reason": "\"SSL tunnel statistics\"\n",
       "timezone": "UTC+2",
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "dataset": "event:vpn"
+      "dataset": "event:vpn",
+      "category": "event"
     },
     "@timestamp": "2019-08-27T12:27:40.000000Z",
-    "action": {
-      "name": "tunnel-stats",
-      "type": "vpn"
-    },
     "destination": {
       "bytes": 6151809
     },
@@ -35,21 +28,30 @@
       }
     },
     "log": {
-      "level": "information"
+      "level": "information",
+      "description": "SSL VPN statistics",
+      "hostname": "abc"
     },
     "observer": {
       "hostname": "abc"
     },
     "source": {
-      "address": "1.1.1.1",
-      "bytes": 71524041,
       "ip": "1.1.1.1",
+      "bytes": 71524041,
       "nat": {
         "ip": "2.2.2.2"
       },
       "user": {
         "name": "test"
-      }
+      },
+      "address": "1.1.1.1"
+    },
+    "action": {
+      "name": "tunnel-stats",
+      "type": "vpn",
+      "outcome_reason": "SSL tunnel statistics",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "hosts": [
@@ -62,6 +64,9 @@
         "1.1.1.1",
         "2.2.2.2"
       ]
+    },
+    "host": {
+      "name": "abc"
     }
   }
 }

--- a/Fortinet/fortigate/tests/tunnel_statistics.CSV.json
+++ b/Fortinet/fortigate/tests/tunnel_statistics.CSV.json
@@ -14,17 +14,10 @@
       "action": "tunnel-stats",
       "code": "0101037141",
       "reason": "IPsec tunnel statistics",
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "dataset": "event:vpn"
+      "dataset": "event:vpn",
+      "category": "event"
     },
     "@timestamp": "2021-03-04T11:02:57.000000Z",
-    "action": {
-      "name": "tunnel-stats",
-      "type": "vpn"
-    },
     "destination": {
       "bytes": 0
     },
@@ -34,21 +27,30 @@
       }
     },
     "log": {
-      "level": "notice"
+      "level": "notice",
+      "description": "IPsec tunnel statistics",
+      "hostname": "abc"
     },
     "observer": {
       "hostname": "abc"
     },
     "source": {
-      "address": "1.1.1.1",
-      "bytes": 7649,
       "ip": "1.1.1.1",
+      "bytes": 7649,
       "nat": {
         "ip": "N/A"
       },
       "user": {
         "name": "N/A"
-      }
+      },
+      "address": "1.1.1.1"
+    },
+    "action": {
+      "name": "tunnel-stats",
+      "type": "vpn",
+      "outcome_reason": "IPsec tunnel statistics",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "hosts": [
@@ -61,6 +63,9 @@
         "1.1.1.1",
         "N/A"
       ]
+    },
+    "host": {
+      "name": "abc"
     }
   }
 }

--- a/Fortinet/fortigate/tests/vpn.STANDARD.json
+++ b/Fortinet/fortigate/tests/vpn.STANDARD.json
@@ -12,20 +12,13 @@
     "message": " time=14:38:46 devname=\"abc\" devid=\"1\" logid=\"0101041987\" type=\"event\" subtype=\"vpn\" level=\"information\" vd=\"root\" eventtime=1615469926 logdesc=\"Certificate updated\" action=\"info\" cert-type=\"CRL\" status=\"success\" name=\"CRL_1\" method=\"HTTP\" reason=\"N/A\" msg=\"A certificate is updated\"",
     "event": {
       "action": "CRL_1",
-      "dataset": "event:vpn",
       "code": "0101041987",
-      "reason": "A certificate is updated",
-      "kind": "event",
-      "category": [
-        "network"
-      ]
+      "reason": "N/A",
+      "dataset": "event:vpn",
+      "category": "event",
+      "provider": "HTTP"
     },
     "@timestamp": "2021-03-11T13:38:46.000000Z",
-    "action": {
-      "name": "CRL_1",
-      "outcome": "success",
-      "type": "vpn"
-    },
     "fortinet": {
       "event": {
         "type": "event"
@@ -37,15 +30,27 @@
       }
     },
     "log": {
-      "level": "information"
+      "level": "information",
+      "description": "Certificate updated",
+      "hostname": "abc"
     },
     "observer": {
       "hostname": "abc"
+    },
+    "action": {
+      "name": "CRL_1",
+      "type": "vpn",
+      "outcome": "success",
+      "outcome_reason": "A certificate is updated",
+      "target": "network-traffic"
     },
     "related": {
       "hosts": [
         "abc"
       ]
+    },
+    "host": {
+      "name": "abc"
     }
   }
 }

--- a/Fortinet/fortigate/tests/vpn_login_failed.STANDARD.json
+++ b/Fortinet/fortigate/tests/vpn_login_failed.STANDARD.json
@@ -1,0 +1,64 @@
+{
+  "input": {
+    "sekoiaio": {
+      "intake": {
+        "dialect": "fortigate",
+        "dialect_uuid": "5702ae4e-7d8a-455f-a47b-ef64dd87c981"
+      }
+    },
+    "message": "time=17:43:43 devname=\"FW-FOOBAR\" devid=\"FG123\" eventtime=1665675824075327440 tz=\"+0200\" logid=\"0101039426\" type=\"event\" subtype=\"vpn\" level=\"alert\" vd=\"root\" logdesc=\"SSL VPN login fail\" action=\"ssl-login-fail\" tunneltype=\"ssl-web\" tunnelid=0 remip=1.1.1.1 user=\"CN = foo.bar.baz.com\" group=\"N/A\" dst_host=\"N/A\" reason=\"sslvpn_login_cert_checked_error\" msg=\"SSL user failed to logged in\""
+  },
+  "expected": {
+    "message": "time=17:43:43 devname=\"FW-FOOBAR\" devid=\"FG123\" eventtime=1665675824075327440 tz=\"+0200\" logid=\"0101039426\" type=\"event\" subtype=\"vpn\" level=\"alert\" vd=\"root\" logdesc=\"SSL VPN login fail\" action=\"ssl-login-fail\" tunneltype=\"ssl-web\" tunnelid=0 remip=1.1.1.1 user=\"CN = foo.bar.baz.com\" group=\"N/A\" dst_host=\"N/A\" reason=\"sslvpn_login_cert_checked_error\" msg=\"SSL user failed to logged in\"",
+    "event": {
+      "action": "ssl-login-fail",
+      "code": "0101039426",
+      "reason": "sslvpn_login_cert_checked_error",
+      "timezone": "+0200",
+      "dataset": "event:vpn",
+      "category": "event"
+    },
+    "@timestamp": "2022-10-13T13:43:44.075328Z",
+    "fortinet": {
+      "event": {
+        "type": "event"
+      }
+    },
+    "log": {
+      "level": "alert",
+      "description": "SSL VPN login fail",
+      "hostname": "FW-FOOBAR"
+    },
+    "observer": {
+      "hostname": "FW-FOOBAR"
+    },
+    "source": {
+      "ip": "1.1.1.1",
+      "user": {
+        "name": "CN = foo.bar.baz.com"
+      },
+      "address": "1.1.1.1"
+    },
+    "action": {
+      "name": "ssl-login-fail",
+      "type": "vpn",
+      "outcome_reason": "SSL user failed to logged in",
+      "target": "network-traffic",
+      "outcome": "success"
+    },
+    "related": {
+      "hosts": [
+        "FW-FOOBAR"
+      ],
+      "user": [
+        "CN = foo.bar.baz.com"
+      ],
+      "ip": [
+        "1.1.1.1"
+      ]
+    },
+    "host": {
+      "name": "FW-FOOBAR"
+    }
+  }
+}

--- a/Fortinet/fortigate/tests/webfilter.CEF.json
+++ b/Fortinet/fortigate/tests/webfilter.CEF.json
@@ -15,22 +15,10 @@
       "code": "0316013056",
       "reason": "URL belongs to a denied category in policy",
       "severity": 4,
-      "kind": "event",
-      "category": [
-        "network"
-      ],
-      "type": [
-        "denied",
-        "connection",
-        "end"
-      ],
-      "dataset": "utm:webfilter"
+      "dataset": "utm:webfilter",
+      "category": "utm"
     },
     "@timestamp": "2018-12-27T19:23:49.000000Z",
-    "action": {
-      "name": "blocked",
-      "type": "webfilter"
-    },
     "destination": {
       "address": "185.230.61.185",
       "bytes": 96,
@@ -76,7 +64,15 @@
     },
     "url": {
       "original": "/bizsquads",
+      "full": "/bizsquads",
       "path": "/bizsquads"
+    },
+    "action": {
+      "name": "blocked",
+      "type": "ftgd_blk - webfilter",
+      "outcome_reason": "URL belongs to a denied category in policy",
+      "target": "network-traffic",
+      "outcome": "success"
     },
     "related": {
       "user": [


### PR DESCRIPTION
This work should allow to deploy the Fortigate Ingest format without breaking stuff.

Smart descriptions might need to be tested/reworked with this new version.

Fields not added to backward compatibility:
- event.message (used to contain event.reason value)
- network.bytes (value of source.bytes + dest.bytes)

Not done: split ` app="icmp6/143/0"` in icmp6.json

Parent task:
- https://github.com/SekoiaLab/platform/issues/34507