### PR TITLE
Fortinet: extract DeviceEventClassId from the CEF message

### DIFF
--- a/Fortinet/fortigate/ingest/parser.yml
+++ b/Fortinet/fortigate/ingest/parser.yml
@@ -180,7 +180,7 @@ stages:
           dns.question.type: "{{parsed_event.message.qtype or parsed_event.message.FTNFGTqtype or parsed_event.message.FortinetFortiGateqtype}}"
           fortinet.fortigate.event.type: "{{parsed_event.message.type}}"
           fortinet.fortigate.event.severity: "{{parsed_event.message.severity}}"
-          event.code: "{{parsed_event.message.logid or parsed_event.message.FTNTFGTlogid or parsed_event.message.FortinetFortiGatelogid}}"
+          event.code: "{{parsed_event.message.logid or parsed_event.message.FTNTFGTlogid or parsed_event.message.FortinetFortiGatelogid or parsed_event.message.DeviceEventClassID}}"
           event.reason: "{{parsed_event.message.msg}}"
           event.severity: "{{parsed_event.message.Severity}}"
           event.timezone: "{{parsed_event.message.FortinetFortiGatetz or parsed_event.message.tz or parsed_event.message.FTNTFGTtz }}"

--- a/Fortinet/fortigate/tests/traffic_forward-RDP.CEF.json
+++ b/Fortinet/fortigate/tests/traffic_forward-RDP.CEF.json
@@ -12,6 +12,7 @@
     "message": "CEF:0|Fortinet|FortiGate-1000C|5.6.14,build1727 (GA)|0000000020|forward traffic accept|5|start=Oct 12 2022 12:50:31 logver=506141727 deviceExternalId=FGT123 dvchost=FW-123 ad.vd=root ad.logid=0000000020 cat=traffic ad.subtype=forward deviceSeverity=notice ad.eventtime=1665571831 src=1.1.1.1 spt=55390 deviceInboundInterface=abc ad.srcintfrole=undefined dst=2.2.2.2 dpt=1522 deviceOutboundInterface=efg ad.dstintfrole=lan foo.poluuid=ec6ff8fe-5e41-51ec-bcbe-9e5484033dc8 externalID=3812440508 proto=6 act=accept ad.policyid=185 ad.policytype=policy app=SQLNET-1522 ad.dstcountry=Reserved ad.srccountry=Reserved ad.trandisp=noop ad.duration=268 out=202 in=52 ad.sentpkt=3 ad.rcvdpkt=1 ad.appcat=unscanned ad.sentdelta=0 ad.rcvddelta=0 tz=\"+0200\"",
     "event": {
       "action": "accept",
+      "code": "0000000020",
       "severity": 5,
       "timezone": "+0200",
       "dataset": "traffic",


### PR DESCRIPTION
extract DeviceEventClassId from the CEF message to value `event.code`