### PR TITLE
Fortigate: fix severity

### DIFF
--- a/Fortinet/fortigate/_meta/smart-descriptions.json
+++ b/Fortinet/fortigate/_meta/smart-descriptions.json
@@ -669,7 +669,7 @@
     ]
   },
     {
-    "value": "Connexion from {source.ip} to {destination.ip}:{destination.port} action {event.action}",
+    "value": "Connection from {source.ip} to {destination.ip}:{destination.port} action {event.action}",
     "conditions": [
       {
         "field": "source.ip"

--- a/Fortinet/fortigate/ingest/parser.yml
+++ b/Fortinet/fortigate/ingest/parser.yml
@@ -181,7 +181,6 @@ stages:
           fortinet.fortigate.event.severity: "{{parsed_event.message.severity}}"
           event.code: "{{parsed_event.message.logid or parsed_event.message.FTNTFGTlogid or parsed_event.message.FortinetFortiGatelogid or parsed_event.message.DeviceEventClassID}}"
           event.reason: "{{parsed_event.message.msg}}"
-          event.severity: "{{parsed_event.message.Severity}}"
           event.timezone: "{{parsed_event.message.FortinetFortiGatetz or parsed_event.message.tz or parsed_event.message.FTNTFGTtz }}"
           file.name: "{{parsed_event.message.fname}}"
           file.size: '{{parsed_event.message.fsize}}'

--- a/Fortinet/fortigate/ingest/parser.yml
+++ b/Fortinet/fortigate/ingest/parser.yml
@@ -178,7 +178,7 @@ stages:
           dns.question.name: "{{parsed_event.message.qname or parsed_event.message.FTNFGTqname or parsed_event.message.FortinetFortiGateqname}}"
           dns.question.type: "{{parsed_event.message.qtype or parsed_event.message.FTNFGTqtype or parsed_event.message.FortinetFortiGateqtype}}"
           fortinet.fortigate.event.type: "{{parsed_event.message.type}}"
-          fortinet.fortigate.event.severity: "{{parsed_event.message.severity}}"
+          fortinet.fortigate.event.severity: "{{parsed_event.message.severity or parsed_event.message.FTNTFGTseverity}}"
           event.code: "{{parsed_event.message.logid or parsed_event.message.FTNTFGTlogid or parsed_event.message.FortinetFortiGatelogid or parsed_event.message.DeviceEventClassID}}"
           event.reason: "{{parsed_event.message.msg}}"
           event.timezone: "{{parsed_event.message.FortinetFortiGatetz or parsed_event.message.tz or parsed_event.message.FTNTFGTtz }}"

--- a/Fortinet/fortigate/tests/Configuration_changed.CEF.json
+++ b/Fortinet/fortigate/tests/Configuration_changed.CEF.json
@@ -13,7 +13,6 @@
     "event": {
       "code": "0100032102",
       "reason": "Configuration is changed in the admin session",
-      "severity": 7,
       "timezone": "+0100",
       "dataset": "event:system",
       "category": "event"

--- a/Fortinet/fortigate/tests/DLP.CEF.json
+++ b/Fortinet/fortigate/tests/DLP.CEF.json
@@ -13,7 +13,6 @@
     "event": {
       "action": "block",
       "code": "0954024576",
-      "severity": 4,
       "dataset": "utm:dlp",
       "category": "utm"
     },

--- a/Fortinet/fortigate/tests/DLP.CEF.json
+++ b/Fortinet/fortigate/tests/DLP.CEF.json
@@ -26,6 +26,13 @@
         "name": "bob"
       }
     },
+    "fortinet": {
+      "fortigate": {
+        "event": {
+          "severity": "medium"
+        }
+      }
+    },
     "file": {
       "name": "flower.gif",
       "size": 1209

--- a/Fortinet/fortigate/tests/DNS.CEF.json
+++ b/Fortinet/fortigate/tests/DNS.CEF.json
@@ -14,7 +14,6 @@
       "action": "pass",
       "code": "1501054802",
       "reason": "Domain is monitored",
-      "severity": 3,
       "dataset": "dns:dns-response",
       "category": "dns"
     },

--- a/Fortinet/fortigate/tests/IPS.CEF.json
+++ b/Fortinet/fortigate/tests/IPS.CEF.json
@@ -14,7 +14,6 @@
       "action": "reset",
       "code": "0419016384",
       "reason": "file_transfer: Eicar.Virus.Test.File,",
-      "severity": 7,
       "dataset": "utm:ips",
       "category": "utm"
     },

--- a/Fortinet/fortigate/tests/IPS.CEF.json
+++ b/Fortinet/fortigate/tests/IPS.CEF.json
@@ -27,6 +27,13 @@
         "name": "bob"
       }
     },
+    "fortinet": {
+      "fortigate": {
+        "event": {
+          "severity": "info"
+        }
+      }
+    },
     "log": {
       "level": "alert"
     },

--- a/Fortinet/fortigate/tests/SSH.CEF-2.json
+++ b/Fortinet/fortigate/tests/SSH.CEF-2.json
@@ -25,6 +25,13 @@
         "name": "bob"
       }
     },
+    "fortinet": {
+      "fortigate": {
+        "event": {
+          "severity": "low"
+        }
+      }
+    },
     "log": {
       "level": "notice"
     },

--- a/Fortinet/fortigate/tests/SSH.CEF-2.json
+++ b/Fortinet/fortigate/tests/SSH.CEF-2.json
@@ -13,7 +13,6 @@
     "event": {
       "action": "passthrough",
       "code": "1600061002",
-      "severity": 3,
       "dataset": "utm:ssh",
       "category": "utm"
     },

--- a/Fortinet/fortigate/tests/VoIP.CEF.json
+++ b/Fortinet/fortigate/tests/VoIP.CEF.json
@@ -13,7 +13,6 @@
     "event": {
       "action": "permit",
       "code": "0814044032",
-      "severity": 2,
       "dataset": "utm:voip",
       "category": "utm"
     },

--- a/Fortinet/fortigate/tests/WAF.CEF.json
+++ b/Fortinet/fortigate/tests/WAF.CEF.json
@@ -25,6 +25,13 @@
         "name": "bob"
       }
     },
+    "fortinet": {
+      "fortigate": {
+        "event": {
+          "severity": "medium"
+        }
+      }
+    },
     "log": {
       "level": "warning"
     },

--- a/Fortinet/fortigate/tests/WAF.CEF.json
+++ b/Fortinet/fortigate/tests/WAF.CEF.json
@@ -13,7 +13,6 @@
     "event": {
       "action": "passthrough",
       "code": "1203030258",
-      "severity": 4,
       "dataset": "utm:waf",
       "category": "utm"
     },

--- a/Fortinet/fortigate/tests/anomaly.CEF-2.json
+++ b/Fortinet/fortigate/tests/anomaly.CEF-2.json
@@ -22,6 +22,13 @@
       "address": "172.16.200.55",
       "ip": "172.16.200.55"
     },
+    "fortinet": {
+      "fortigate": {
+        "event": {
+          "severity": "critical"
+        }
+      }
+    },
     "log": {
       "level": "alert"
     },

--- a/Fortinet/fortigate/tests/anomaly.CEF-2.json
+++ b/Fortinet/fortigate/tests/anomaly.CEF-2.json
@@ -14,7 +14,6 @@
       "action": "clear_session",
       "code": "0720018433",
       "reason": "anomaly: icmp_flood, 51 > threshold 50",
-      "severity": 7,
       "dataset": "utm:anomaly",
       "category": "utm"
     },

--- a/Fortinet/fortigate/tests/anomaly.CEF.json
+++ b/Fortinet/fortigate/tests/anomaly.CEF.json
@@ -22,6 +22,13 @@
       "ip": "2.2.2.2",
       "port": 20882
     },
+    "fortinet": {
+      "fortigate": {
+        "event": {
+          "severity": "critical"
+        }
+      }
+    },
     "log": {
       "level": "alert"
     },

--- a/Fortinet/fortigate/tests/anomaly.CEF.json
+++ b/Fortinet/fortigate/tests/anomaly.CEF.json
@@ -14,7 +14,6 @@
       "action": "clear_session",
       "code": "0720018433",
       "reason": "anomaly: icmp_flood, 34 > threshold 25, repeats 306 times",
-      "severity": 7,
       "dataset": "anomaly:anomaly",
       "category": "anomaly"
     },

--- a/Fortinet/fortigate/tests/antivirus.CEF-2.json
+++ b/Fortinet/fortigate/tests/antivirus.CEF-2.json
@@ -14,7 +14,6 @@
       "action": "blocked",
       "code": "0211008192",
       "reason": "File is infected.",
-      "severity": 4,
       "dataset": "utm:virus",
       "category": "utm"
     },

--- a/Fortinet/fortigate/tests/antivirus.CEF.json
+++ b/Fortinet/fortigate/tests/antivirus.CEF.json
@@ -14,7 +14,6 @@
       "action": "blocked",
       "code": "0211008192",
       "reason": "File is infected",
-      "severity": 4,
       "dataset": "utm:virus",
       "category": "utm"
     },

--- a/Fortinet/fortigate/tests/application.CEF.json
+++ b/Fortinet/fortigate/tests/application.CEF.json
@@ -14,7 +14,6 @@
       "action": "pass",
       "code": "1059028704",
       "reason": "Web.Client: HTTP.BROWSER_Firefox,",
-      "severity": 2,
       "dataset": "utm:app-ctrl",
       "category": "utm"
     },

--- a/Fortinet/fortigate/tests/email-spamfilter.CEF.json
+++ b/Fortinet/fortigate/tests/email-spamfilter.CEF.json
@@ -14,7 +14,6 @@
       "action": "log-only",
       "code": "0508020503",
       "reason": "general email log",
-      "severity": 2,
       "dataset": "utm:emailfilter",
       "category": "utm"
     },

--- a/Fortinet/fortigate/tests/event_log_system_subtype.CEF.json
+++ b/Fortinet/fortigate/tests/event_log_system_subtype.CEF.json
@@ -14,7 +14,6 @@
       "action": "login",
       "code": "0100032002",
       "reason": "name_invalid",
-      "severity": 7,
       "dataset": "event:system",
       "category": "event"
     },

--- a/Fortinet/fortigate/tests/event_log_user_subtype.CEF.json
+++ b/Fortinet/fortigate/tests/event_log_user_subtype.CEF.json
@@ -14,7 +14,6 @@
       "action": "authentication",
       "code": "0102043008",
       "reason": "N/A",
-      "severity": 3,
       "dataset": "event:user",
       "category": "event"
     },

--- a/Fortinet/fortigate/tests/icmp_CEF.json
+++ b/Fortinet/fortigate/tests/icmp_CEF.json
@@ -13,7 +13,6 @@
     "event": {
       "action": "accept",
       "code": "0001000014",
-      "severity": 3,
       "dataset": "traffic:local",
       "category": "traffic"
     },

--- a/Fortinet/fortigate/tests/ssh_access.CEF.json
+++ b/Fortinet/fortigate/tests/ssh_access.CEF.json
@@ -14,7 +14,6 @@
       "action": "login",
       "code": "0100032021",
       "reason": "exceed_limit",
-      "severity": 7,
       "dataset": "event:system",
       "category": "event"
     },

--- a/Fortinet/fortigate/tests/ssl_new_con.CEF.json
+++ b/Fortinet/fortigate/tests/ssl_new_con.CEF.json
@@ -14,7 +14,6 @@
       "action": "ssl-new-con",
       "code": "0101039943",
       "reason": "N/A",
-      "severity": 2,
       "dataset": "event:vpn",
       "category": "event"
     },

--- a/Fortinet/fortigate/tests/traffic_forward-RDP.CEF.json
+++ b/Fortinet/fortigate/tests/traffic_forward-RDP.CEF.json
@@ -13,7 +13,6 @@
     "event": {
       "action": "accept",
       "code": "0000000020",
-      "severity": 5,
       "timezone": "+0200",
       "dataset": "traffic",
       "category": "traffic"

--- a/Fortinet/fortigate/tests/traffic_forward.CEF-2.json
+++ b/Fortinet/fortigate/tests/traffic_forward.CEF-2.json
@@ -13,7 +13,6 @@
     "event": {
       "action": "timeout",
       "code": "0000000013",
-      "severity": 3,
       "dataset": "traffic:forward",
       "category": "traffic"
     },

--- a/Fortinet/fortigate/tests/traffic_forward.CEF-3.json
+++ b/Fortinet/fortigate/tests/traffic_forward.CEF-3.json
@@ -13,7 +13,6 @@
     "event": {
       "action": "close",
       "code": "0000000013",
-      "severity": 3,
       "dataset": "traffic:forward",
       "category": "traffic"
     },

--- a/Fortinet/fortigate/tests/traffic_forward.CEF.json
+++ b/Fortinet/fortigate/tests/traffic_forward.CEF.json
@@ -13,7 +13,6 @@
     "event": {
       "action": "close",
       "code": "0000000013",
-      "severity": 3,
       "dataset": "traffic:forward",
       "category": "traffic"
     },

--- a/Fortinet/fortigate/tests/traffic_forward_FTNTFGTtz.CEF.json
+++ b/Fortinet/fortigate/tests/traffic_forward_FTNTFGTtz.CEF.json
@@ -13,7 +13,6 @@
     "event": {
       "action": "dns",
       "code": "0000000011",
-      "severity": 4,
       "timezone": "+0200",
       "dataset": "traffic:forward",
       "category": "traffic"

--- a/Fortinet/fortigate/tests/webfilter.CEF.json
+++ b/Fortinet/fortigate/tests/webfilter.CEF.json
@@ -14,7 +14,6 @@
       "action": "blocked",
       "code": "0316013056",
       "reason": "URL belongs to a denied category in policy",
-      "severity": 4,
       "dataset": "utm:webfilter",
       "category": "utm"
     },


### PR DESCRIPTION
- Remove `event.severity` to avoid indexing issue
- Extract FTNTFGTseverity from events
- Fix smart-description