### PR TITLE
Fix/fortinet/test

### DIFF
--- a/Fortinet/fortigate/tests/dns.CSV.json
+++ b/Fortinet/fortigate/tests/dns.CSV.json
@@ -26,7 +26,10 @@
     "dns": {
       "question": {
         "name": "detectportal.firefox.com",
-        "type": "A"
+        "type": "A",
+        "top_level_domain": "com",
+        "subdomain": "detectportal",
+        "registered_domain": "firefox.com"
       },
       "rrname": "detectportal.firefox.com",
       "rrtype": "A"


### PR DESCRIPTION
Ingest is now better, and creates automatically registered_domain for dns.fields