### PR TITLE
Fortigate: fill url.full when url.original starts with http

### DIFF
--- a/Fortinet/fortigate/ingest/parser.yml
+++ b/Fortinet/fortigate/ingest/parser.yml
@@ -89,10 +89,12 @@ stages:
           action.properties.icmp_type: "{{parsed_event.message.icmptype}}"
           log.description: "{{parsed_event.message.logdesc}}"
           log.hostname: "{{parsed_event.message.devname}}"
-          url.full: "{{final.url.original}}"
           dns.rrname: "{{final.dns.question.name}}"
           dns.rrtype: "{{final.dns.question.type}}"
           rule.apprisk: "{{parsed_event.message.apprisk}}"
+      - set:
+          url.full: "{{final.url.original}}"
+        filter: '{{final.url.get("original") != None and final.url.original.startswith("http")}}'
 
       - set:
           event.reason: "{{parsed_event.message.reason}}"

--- a/Fortinet/fortigate/tests/DLP.CEF.json
+++ b/Fortinet/fortigate/tests/DLP.CEF.json
@@ -68,7 +68,6 @@
     },
     "url": {
       "original": "/dlp/flower.gif",
-      "full": "/dlp/flower.gif",
       "path": "/dlp/flower.gif"
     },
     "user_agent": {

--- a/Fortinet/fortigate/tests/IPS.CEF.json
+++ b/Fortinet/fortigate/tests/IPS.CEF.json
@@ -65,7 +65,6 @@
     },
     "url": {
       "original": "/virus/eicar.com",
-      "full": "/virus/eicar.com",
       "path": "/virus/eicar.com"
     },
     "action": {

--- a/Fortinet/fortigate/tests/application.CEF.json
+++ b/Fortinet/fortigate/tests/application.CEF.json
@@ -59,7 +59,6 @@
     },
     "url": {
       "original": "/success.txt",
-      "full": "/success.txt",
       "path": "/success.txt"
     },
     "action": {

--- a/Fortinet/fortigate/tests/hostname.STANDARD.json
+++ b/Fortinet/fortigate/tests/hostname.STANDARD.json
@@ -68,7 +68,6 @@
     },
     "url": {
       "original": "/",
-      "full": "/",
       "path": "/"
     },
     "action": {

--- a/Fortinet/fortigate/tests/webfilter.CEF.json
+++ b/Fortinet/fortigate/tests/webfilter.CEF.json
@@ -65,7 +65,6 @@
     },
     "url": {
       "original": "/bizsquads",
-      "full": "/bizsquads",
       "path": "/bizsquads"
     },
     "action": {


### PR DESCRIPTION
add a condition to only fill url.full when url.original starts with http

Copy the behavior define in the logstash parser.