### PR TITLE
Fortinet: fix date parsing

### DIFF
--- a/Fortinet/fortigate/ingest/parser.yml
+++ b/Fortinet/fortigate/ingest/parser.yml
@@ -31,7 +31,7 @@ pipeline:
       properties:
         input_field: '{{parsed_event.message.FTNTFGTeventtime}}'
         output_field: date
-        timezone: '{{parsed_event.message.FTNTFGTtz}}'
+        timezone: 'UTC'
 
   - name: parsed_date
     filter: '{{parsed_event.message.get("FortinetFortiGateeventtime") != None}}'
@@ -40,7 +40,7 @@ pipeline:
       properties:
         input_field: '{{parsed_event.message.FortinetFortiGateeventtime}}'
         output_field: date
-        timezone: '{{parsed_event.message.FortinetFortiGatetz}}'
+        timezone: 'UTC'
 
   - name: parsed_date
     filter: '{{parsed_event.message.get("eventtime") != None}}'
@@ -49,7 +49,7 @@ pipeline:
       properties:
         input_field: '{{parsed_event.message.eventtime }}'
         output_field: date
-        timezone: '{{parsed_event.message.tz}}'
+        timezone: 'UTC'
 
   - name: parsed_date
     filter: '{{parsed_event.message.get("timestamp") != None}}'
@@ -58,7 +58,7 @@ pipeline:
       properties:
         input_field: '{{parsed_event.message.timestamp }}'
         output_field: date
-        timezone: '{{parsed_event.message.tz}}'
+        timezone: 'UTC'
 
   - name: parsed_date
     filter: '{{parsed_event.message.get("start") != None}}'

--- a/Fortinet/fortigate/tests/Configuration_changed.CEF.json
+++ b/Fortinet/fortigate/tests/Configuration_changed.CEF.json
@@ -17,7 +17,7 @@
       "dataset": "event:system",
       "category": "event"
     },
-    "@timestamp": "2021-11-23T14:35:08.541882Z",
+    "@timestamp": "2021-11-23T15:35:08.541882Z",
     "log": {
       "level": "alert"
     },

--- a/Fortinet/fortigate/tests/DNS.STANDARD.json
+++ b/Fortinet/fortigate/tests/DNS.STANDARD.json
@@ -15,7 +15,7 @@
       "timezone": "+0100",
       "category": "utm"
     },
-    "@timestamp": "2022-11-09T12:51:59.663486Z",
+    "@timestamp": "2022-11-09T13:51:59.663486Z",
     "destination": {
       "address": "8.8.8.8",
       "port": 53,

--- a/Fortinet/fortigate/tests/DNS2.STANDARD.json
+++ b/Fortinet/fortigate/tests/DNS2.STANDARD.json
@@ -15,7 +15,7 @@
       "timezone": "+0100",
       "category": "utm"
     },
-    "@timestamp": "2022-11-09T12:58:39.383196Z",
+    "@timestamp": "2022-11-09T13:58:39.383196Z",
     "destination": {
       "address": "8.8.8.8",
       "port": 53,

--- a/Fortinet/fortigate/tests/icmp.json
+++ b/Fortinet/fortigate/tests/icmp.json
@@ -17,7 +17,7 @@
       "dataset": "traffic:forward",
       "category": "traffic"
     },
-    "@timestamp": "2020-10-13T09:22:43.587868Z",
+    "@timestamp": "2020-10-13T12:22:43.587868Z",
     "destination": {
       "address": "2.2.2.2",
       "ip": "2.2.2.2"

--- a/Fortinet/fortigate/tests/icmp6.json
+++ b/Fortinet/fortigate/tests/icmp6.json
@@ -17,7 +17,7 @@
       "dataset": "traffic:local",
       "category": "traffic"
     },
-    "@timestamp": "2020-10-13T09:02:14.900309Z",
+    "@timestamp": "2020-10-13T11:02:14.900309Z",
     "destination": {
       "address": "12::16",
       "bytes": 0,

--- a/Fortinet/fortigate/tests/ping.json
+++ b/Fortinet/fortigate/tests/ping.json
@@ -17,7 +17,7 @@
       "dataset": "traffic:forward",
       "category": "traffic"
     },
-    "@timestamp": "2020-10-13T10:22:38.311909Z",
+    "@timestamp": "2020-10-13T12:22:38.311909Z",
     "destination": {
       "address": "2.2.2.2",
       "bytes": 420,

--- a/Fortinet/fortigate/tests/test_unauthuser.json
+++ b/Fortinet/fortigate/tests/test_unauthuser.json
@@ -17,7 +17,7 @@
       "dataset": "traffic:forward",
       "category": "traffic"
     },
-    "@timestamp": "2022-11-28T06:20:44.749366Z",
+    "@timestamp": "2022-11-28T07:20:44.749366Z",
     "destination": {
       "address": "5.6.7.8",
       "bytes": 58449,

--- a/Fortinet/fortigate/tests/traffic_forward_FTNTFGTtz.CEF.json
+++ b/Fortinet/fortigate/tests/traffic_forward_FTNTFGTtz.CEF.json
@@ -17,7 +17,7 @@
       "dataset": "traffic:forward",
       "category": "traffic"
     },
-    "@timestamp": "2022-09-05T10:43:45.920035Z",
+    "@timestamp": "2022-09-05T12:43:45.920035Z",
     "destination": {
       "address": "172.18.67.10",
       "port": 53,

--- a/Fortinet/fortigate/tests/tunnel.json
+++ b/Fortinet/fortigate/tests/tunnel.json
@@ -18,7 +18,7 @@
       "dataset": "event:vpn",
       "category": "event"
     },
-    "@timestamp": "2019-08-27T12:27:40.000000Z",
+    "@timestamp": "2019-08-27T14:27:40.000000Z",
     "destination": {
       "bytes": 6151809
     },

--- a/Fortinet/fortigate/tests/vpn_login_failed.STANDARD.json
+++ b/Fortinet/fortigate/tests/vpn_login_failed.STANDARD.json
@@ -18,7 +18,7 @@
       "dataset": "event:vpn",
       "category": "event"
     },
-    "@timestamp": "2022-10-13T13:43:44.075328Z",
+    "@timestamp": "2022-10-13T15:43:44.075328Z",
     "fortinet": {
       "fortigate": {
         "event": {

--- a/Fortinet/fortigate/tests/vpn_na_ip.STANDARD.json
+++ b/Fortinet/fortigate/tests/vpn_na_ip.STANDARD.json
@@ -18,7 +18,7 @@
       "dataset": "event:vpn",
       "category": "event"
     },
-    "@timestamp": "2022-10-13T13:43:44.075328Z",
+    "@timestamp": "2022-10-13T15:43:44.075328Z",
     "fortinet": {
       "fortigate": {
         "event": {


### PR DESCRIPTION
Remove the usage of timezone when parsing timestamp