### PR TITLE
Okta: change the way to define ECS  fields

### DIFF
--- a/Okta/okta-system-logs/ingest/parser.yml
+++ b/Okta/okta-system-logs/ingest/parser.yml
@@ -28,6 +28,12 @@ stages:
           source.geo.postal_code: '{{parsed_event.message.client.geographicalContext.postalCode}}'
           source.geo.location: '{{parsed_event.message.client.geographicalContext.geolocation}}'
       - set:
+          user.id: '{{parsed_event.message.actor.id}}'
+          user.name: '{{parsed_event.message.actor.alternateId}}'
+          user.email: '{{parsed_event.message.actor.alternateId}}'
+          user.full_name: '{{parsed_event.message.actor.displayName}}'
+        filter: '{{parsed_event.message.get("actor") != None}}'
+      - set:
           user: >
             {% for target in parsed_event.message.target if target.get("type") in ["AppUser", "User"] %}{
               "id": "{{target.id}}",
@@ -36,12 +42,6 @@ stages:
               "full_name": "{{target.displayName}}"
             }{% endfor %}
         filter: '{{parsed_event.message.get("target") != None}}'
-      - set:
-          user.id: '{{parsed_event.message.actor.id}}'
-          user.name: '{{parsed_event.message.actor.alternateId}}'
-          user.email: '{{parsed_event.message.actor.alternateId}}'
-          user.full_name: '{{parsed_event.message.actor.displayName}}'
-        filter: '{{parsed_event.message.get("target") == None}}'
       - set:
           user_agent.original: '{{parsed_event.message.client.userAgent.rawUserAgent}}'
         filter: '{{parsed_event.message.client.userAgent.get("rawUserAgent") and "unknown" not in parsed_event.message.client.userAgent.rawUserAgent.lower()}}'


### PR DESCRIPTION
Look for the information about the user in the field `actor` first and then, if defined, look for this information in the field `target`.