### PR TITLE
Cloudflare: add new Security fields

### DIFF
--- a/Cloudflare/firewall_events/ingest/parser.yml
+++ b/Cloudflare/firewall_events/ingest/parser.yml
@@ -35,6 +35,8 @@ stages:
           http.response.status_code: "{{json_event.message.EdgeResponseStatus}}"
           event.action: "{{json_event.message.Action}}"
           rule.id: "{{json_event.message.RuleId}}"
+          rule.description: "{{json_event.message.Description}}"
+          rule.reference: "{{json_event.message.Ref}}"
           network.protocol: "{{json_event.message.clientRequestHTTPProtocol or json_event.message.ClientRequestProtocol}}"
           rule.ruleset: "{{json_event.message.rulesetId}}"
           http.request.bytes: "{{json_event.message.ClientRequestBytes}}"

--- a/Cloudflare/http_requests/_meta/fields.yml
+++ b/Cloudflare/http_requests/_meta/fields.yml
@@ -345,9 +345,39 @@ cloudflare.ResponseHeaders:
     description: keyword key-value pairs for ResponseHeaders
     type: object
 
+cloudflare.SecurityAction:
+    name: cloudflare.SecurityAction
+    description: Rule action of the security rule that triggered a terminating action, if any.
+    type: keyword
+
+cloudflare.SecurityActions:
+    name: cloudflare.SecurityActions
+    description: Array of actions that Cloudflare security products performed on this request.
+    type: keyword
+
 cloudflare.SecurityLevel:
     name: cloudflare.SecurityLevel
     description: The security level configured at the time of this request. This is used to determine the sensitivity of the IP Reputation system.
+    type: keyword
+
+cloudflare.SecuritySources:
+    name: cloudflare.SecuritySources
+    description: Array of Cloudflare security products that matched the request.
+    type: keyword
+
+cloudflare.SecurityRuleID:
+    name: cloudflare.SecurityRuleID
+    description: Rule ID of the security rule that triggered a terminating action, if any.
+    type: keyword
+
+cloudflare.SecurityRuleIDs:
+    name: cloudflare.SecurityRuleIDs
+    description: Array of security rule IDs that matched the request.
+    type: keyword
+
+cloudflare.SecurityRuleDescription:
+    name: cloudflare.SecurityRuleDescription
+    description: Rule description of the security rule that triggered a terminating action, if any.
     type: keyword
 
 cloudflare.SmartRouteColoID:


### PR DESCRIPTION
Cloudflare is currently migrating some fields in the datasets `http_request` and `firewall_events` according to [this announcement](https://developers.cloudflare.com/logs/reference/change-notices/2023-02-01-security-fields-updates/).

Add the new Security fields to handle them.