### PR TITLE
IBM: handle when message start with whitespaces

### DIFF
--- a/IBM/ibm-aix/ingest/parser.yml
+++ b/IBM/ibm-aix/ingest/parser.yml
@@ -6,7 +6,7 @@ pipeline:
       properties:
         input_field: "original.message"
         output_field: pre_message
-        pattern: '%{DATA:raw_message}'
+        pattern: '\s*%{DATA:raw_message}'
 
 
   - name: parsed_event

--- a/IBM/ibm-aix/tests/FILE_Pipe.json
+++ b/IBM/ibm-aix/tests/FILE_Pipe.json
@@ -6,10 +6,10 @@
         "dialect_uuid": "cfe997d3-7121-4b6f-8913-d3fa6ca30eba"
       }
     },
-    "message": "FILE_Pipe Pipin root admin OK 10 Nov 2022 09:21:53.955363 No associated roles read: 7 write: 8"
+    "message": "  FILE_Pipe Pipin root admin OK 10 Nov 2022 09:21:53.955363 No associated roles read: 7 write: 8"
   },
   "expected": {
-    "message": "FILE_Pipe Pipin root admin OK 10 Nov 2022 09:21:53.955363 No associated roles read: 7 write: 8",
+    "message": "  FILE_Pipe Pipin root admin OK 10 Nov 2022 09:21:53.955363 No associated roles read: 7 write: 8",
     "event": {
       "kind": "event",
       "category": [


### PR DESCRIPTION
fix the grok pattern to allow whitespace at the beginning of the message.