### PR TITLE
Sophos: fix typo

### DIFF
--- a/Sophos/sophos firewall/_meta/smart-descriptions.json
+++ b/Sophos/sophos firewall/_meta/smart-descriptions.json
@@ -116,7 +116,7 @@
       },
       {
         "field": "source.ip"
-      },
+      }
     ],
     "relationships": [
       {


### PR DESCRIPTION
 fix typo that invalidated the smart-descriptions file as a json document