### PR TITLE
Beats: add support for action.properties fields

### DIFF
--- a/Beats/winlogbeat/_meta/fields.yml
+++ b/Beats/winlogbeat/_meta/fields.yml
@@ -38,566 +38,566 @@ winlog.computer_name:
   name: winlog.computer_name
   type: keyword
 
-winlog.event_data:
+action.properties:
   description: The event-specific data. This field is mutually exclusive with `user_data`.
     If you are capturing event data on versions prior to Windows Vista, the parameters
     in `event_data` are named `param1`, `param2`, and so on, because event log parameters
     are unnamed in earlier versions of Windows.
-  name: winlog.event_data
+  name: action.properties
   type: object
 
-winlog.event_data.AuthenticationPackageName:
-  name: winlog.event_data.AuthenticationPackageName
+action.properties.AuthenticationPackageName:
+  name: action.properties.AuthenticationPackageName
   type: keyword
   description: ""
 
-winlog.event_data.Binary:
-  name: winlog.event_data.Binary
+action.properties.Binary:
+  name: action.properties.Binary
   type: keyword
   description: ""
 
-winlog.event_data.BitlockerUserInputTime:
-  name: winlog.event_data.BitlockerUserInputTime
+action.properties.BitlockerUserInputTime:
+  name: action.properties.BitlockerUserInputTime
   type: keyword
   description: ""
 
-winlog.event_data.BootMode:
-  name: winlog.event_data.BootMode
+action.properties.BootMode:
+  name: action.properties.BootMode
   type: keyword
   description: ""
 
-winlog.event_data.BootType:
-  name: winlog.event_data.BootType
+action.properties.BootType:
+  name: action.properties.BootType
   type: keyword
   description: ""
 
-winlog.event_data.BuildVersion:
-  name: winlog.event_data.BuildVersion
+action.properties.BuildVersion:
+  name: action.properties.BuildVersion
   type: keyword
   description: ""
 
-winlog.event_data.Company:
-  name: winlog.event_data.Company
+action.properties.Company:
+  name: action.properties.Company
   type: keyword
   description: ""
 
-winlog.event_data.CorruptionActionState:
-  name: winlog.event_data.CorruptionActionState
+action.properties.CorruptionActionState:
+  name: action.properties.CorruptionActionState
   type: keyword
   description: ""
 
-winlog.event_data.CreationUtcTime:
-  name: winlog.event_data.CreationUtcTime
+action.properties.CreationUtcTime:
+  name: action.properties.CreationUtcTime
   type: keyword
   description: ""
 
-winlog.event_data.Description:
-  name: winlog.event_data.Description
+action.properties.Description:
+  name: action.properties.Description
   type: keyword
   description: ""
 
-winlog.event_data.Detail:
-  name: winlog.event_data.Detail
+action.properties.Detail:
+  name: action.properties.Detail
   type: keyword
   description: ""
 
-winlog.event_data.DeviceName:
-  name: winlog.event_data.DeviceName
+action.properties.DeviceName:
+  name: action.properties.DeviceName
   type: keyword
   description: ""
 
-winlog.event_data.DeviceNameLength:
-  name: winlog.event_data.DeviceNameLength
+action.properties.DeviceNameLength:
+  name: action.properties.DeviceNameLength
   type: keyword
   description: ""
 
-winlog.event_data.DeviceTime:
-  name: winlog.event_data.DeviceTime
+action.properties.DeviceTime:
+  name: action.properties.DeviceTime
   type: keyword
   description: ""
 
-winlog.event_data.DeviceVersionMajor:
-  name: winlog.event_data.DeviceVersionMajor
+action.properties.DeviceVersionMajor:
+  name: action.properties.DeviceVersionMajor
   type: keyword
   description: ""
 
-winlog.event_data.DeviceVersionMinor:
-  name: winlog.event_data.DeviceVersionMinor
+action.properties.DeviceVersionMinor:
+  name: action.properties.DeviceVersionMinor
   type: keyword
   description: ""
 
-winlog.event_data.DriveName:
-  name: winlog.event_data.DriveName
+action.properties.DriveName:
+  name: action.properties.DriveName
   type: keyword
   description: ""
 
-winlog.event_data.DriverName:
-  name: winlog.event_data.DriverName
+action.properties.DriverName:
+  name: action.properties.DriverName
   type: keyword
   description: ""
 
-winlog.event_data.DriverNameLength:
-  name: winlog.event_data.DriverNameLength
+action.properties.DriverNameLength:
+  name: action.properties.DriverNameLength
   type: keyword
   description: ""
 
-winlog.event_data.DwordVal:
-  name: winlog.event_data.DwordVal
+action.properties.DwordVal:
+  name: action.properties.DwordVal
   type: keyword
   description: ""
 
-winlog.event_data.EntryCount:
-  name: winlog.event_data.EntryCount
+action.properties.EntryCount:
+  name: action.properties.EntryCount
   type: keyword
   description: ""
 
-winlog.event_data.ExtraInfo:
-  name: winlog.event_data.ExtraInfo
+action.properties.ExtraInfo:
+  name: action.properties.ExtraInfo
   type: keyword
   description: ""
 
-winlog.event_data.FailureName:
-  name: winlog.event_data.FailureName
+action.properties.FailureName:
+  name: action.properties.FailureName
   type: keyword
   description: ""
 
-winlog.event_data.FailureNameLength:
-  name: winlog.event_data.FailureNameLength
+action.properties.FailureNameLength:
+  name: action.properties.FailureNameLength
   type: keyword
   description: ""
 
-winlog.event_data.FileVersion:
-  name: winlog.event_data.FileVersion
+action.properties.FileVersion:
+  name: action.properties.FileVersion
   type: keyword
   description: ""
 
-winlog.event_data.FinalStatus:
-  name: winlog.event_data.FinalStatus
+action.properties.FinalStatus:
+  name: action.properties.FinalStatus
   type: keyword
   description: ""
 
-winlog.event_data.Group:
-  name: winlog.event_data.Group
+action.properties.Group:
+  name: action.properties.Group
   type: keyword
   description: ""
 
-winlog.event_data.IdleImplementation:
-  name: winlog.event_data.IdleImplementation
+action.properties.IdleImplementation:
+  name: action.properties.IdleImplementation
   type: keyword
   description: ""
 
-winlog.event_data.IdleStateCount:
-  name: winlog.event_data.IdleStateCount
+action.properties.IdleStateCount:
+  name: action.properties.IdleStateCount
   type: keyword
   description: ""
 
-winlog.event_data.ImpersonationLevel:
-  name: winlog.event_data.ImpersonationLevel
+action.properties.ImpersonationLevel:
+  name: action.properties.ImpersonationLevel
   type: keyword
   description: ""
 
-winlog.event_data.IntegrityLevel:
-  name: winlog.event_data.IntegrityLevel
+action.properties.IntegrityLevel:
+  name: action.properties.IntegrityLevel
   type: keyword
   description: ""
 
-winlog.event_data.IpAddress:
-  name: winlog.event_data.IpAddress
+action.properties.IpAddress:
+  name: action.properties.IpAddress
   type: keyword
   description: ""
 
-winlog.event_data.IpPort:
-  name: winlog.event_data.IpPort
+action.properties.IpPort:
+  name: action.properties.IpPort
   type: keyword
   description: ""
 
-winlog.event_data.KeyLength:
-  name: winlog.event_data.KeyLength
+action.properties.KeyLength:
+  name: action.properties.KeyLength
   type: keyword
   description: ""
 
-winlog.event_data.LastBootGood:
-  name: winlog.event_data.LastBootGood
+action.properties.LastBootGood:
+  name: action.properties.LastBootGood
   type: keyword
   description: ""
 
-winlog.event_data.LastShutdownGood:
-  name: winlog.event_data.LastShutdownGood
+action.properties.LastShutdownGood:
+  name: action.properties.LastShutdownGood
   type: keyword
   description: ""
 
-winlog.event_data.LmPackageName:
-  name: winlog.event_data.LmPackageName
+action.properties.LmPackageName:
+  name: action.properties.LmPackageName
   type: keyword
   description: ""
 
-winlog.event_data.LogonGuid:
-  name: winlog.event_data.LogonGuid
+action.properties.LogonGuid:
+  name: action.properties.LogonGuid
   type: keyword
   description: ""
 
-winlog.event_data.LogonId:
-  name: winlog.event_data.LogonId
+action.properties.LogonId:
+  name: action.properties.LogonId
   type: keyword
   description: ""
 
-winlog.event_data.LogonProcessName:
-  name: winlog.event_data.LogonProcessName
+action.properties.LogonProcessName:
+  name: action.properties.LogonProcessName
   type: keyword
   description: ""
 
-winlog.event_data.LogonType:
-  name: winlog.event_data.LogonType
+action.properties.LogonType:
+  name: action.properties.LogonType
   type: keyword
   description: ""
 
-winlog.event_data.MajorVersion:
-  name: winlog.event_data.MajorVersion
+action.properties.MajorVersion:
+  name: action.properties.MajorVersion
   type: keyword
   description: ""
 
-winlog.event_data.MaximumPerformancePercent:
-  name: winlog.event_data.MaximumPerformancePercent
+action.properties.MaximumPerformancePercent:
+  name: action.properties.MaximumPerformancePercent
   type: keyword
   description: ""
 
-winlog.event_data.MemberName:
-  name: winlog.event_data.MemberName
+action.properties.MemberName:
+  name: action.properties.MemberName
   type: keyword
   description: ""
 
-winlog.event_data.MemberSid:
-  name: winlog.event_data.MemberSid
+action.properties.MemberSid:
+  name: action.properties.MemberSid
   type: keyword
   description: ""
 
-winlog.event_data.MinimumPerformancePercent:
-  name: winlog.event_data.MinimumPerformancePercent
+action.properties.MinimumPerformancePercent:
+  name: action.properties.MinimumPerformancePercent
   type: keyword
   description: ""
 
-winlog.event_data.MinimumThrottlePercent:
-  name: winlog.event_data.MinimumThrottlePercent
+action.properties.MinimumThrottlePercent:
+  name: action.properties.MinimumThrottlePercent
   type: keyword
   description: ""
 
-winlog.event_data.MinorVersion:
-  name: winlog.event_data.MinorVersion
+action.properties.MinorVersion:
+  name: action.properties.MinorVersion
   type: keyword
   description: ""
 
-winlog.event_data.NewProcessId:
-  name: winlog.event_data.NewProcessId
+action.properties.NewProcessId:
+  name: action.properties.NewProcessId
   type: keyword
   description: ""
 
-winlog.event_data.NewProcessName:
-  name: winlog.event_data.NewProcessName
+action.properties.NewProcessName:
+  name: action.properties.NewProcessName
   type: keyword
   description: ""
 
-winlog.event_data.NewSchemeGuid:
-  name: winlog.event_data.NewSchemeGuid
+action.properties.NewSchemeGuid:
+  name: action.properties.NewSchemeGuid
   type: keyword
   description: ""
 
-winlog.event_data.NewTime:
-  name: winlog.event_data.NewTime
+action.properties.NewTime:
+  name: action.properties.NewTime
   type: keyword
   description: ""
 
-winlog.event_data.NominalFrequency:
-  name: winlog.event_data.NominalFrequency
+action.properties.NominalFrequency:
+  name: action.properties.NominalFrequency
   type: keyword
   description: ""
 
-winlog.event_data.Number:
-  name: winlog.event_data.Number
+action.properties.Number:
+  name: action.properties.Number
   type: keyword
   description: ""
 
-winlog.event_data.OldSchemeGuid:
-  name: winlog.event_data.OldSchemeGuid
+action.properties.OldSchemeGuid:
+  name: action.properties.OldSchemeGuid
   type: keyword
   description: ""
 
-winlog.event_data.OldTime:
-  name: winlog.event_data.OldTime
+action.properties.OldTime:
+  name: action.properties.OldTime
   type: keyword
   description: ""
 
-winlog.event_data.OriginalFileName:
-  name: winlog.event_data.OriginalFileName
+action.properties.OriginalFileName:
+  name: action.properties.OriginalFileName
   type: keyword
   description: ""
 
-winlog.event_data.Path:
-  name: winlog.event_data.Path
+action.properties.Path:
+  name: action.properties.Path
   type: keyword
   description: ""
 
-winlog.event_data.PerformanceImplementation:
-  name: winlog.event_data.PerformanceImplementation
+action.properties.PerformanceImplementation:
+  name: action.properties.PerformanceImplementation
   type: keyword
   description: ""
 
-winlog.event_data.PreviousCreationUtcTime:
-  name: winlog.event_data.PreviousCreationUtcTime
+action.properties.PreviousCreationUtcTime:
+  name: action.properties.PreviousCreationUtcTime
   type: keyword
   description: ""
 
-winlog.event_data.PreviousTime:
-  name: winlog.event_data.PreviousTime
+action.properties.PreviousTime:
+  name: action.properties.PreviousTime
   type: keyword
   description: ""
 
-winlog.event_data.PrivilegeList:
-  name: winlog.event_data.PrivilegeList
+action.properties.PrivilegeList:
+  name: action.properties.PrivilegeList
   type: keyword
   description: ""
 
-winlog.event_data.ProcessId:
-  name: winlog.event_data.ProcessId
+action.properties.ProcessId:
+  name: action.properties.ProcessId
   type: keyword
   description: ""
 
-winlog.event_data.ProcessName:
-  name: winlog.event_data.ProcessName
+action.properties.ProcessName:
+  name: action.properties.ProcessName
   type: keyword
   description: ""
 
-winlog.event_data.ProcessPath:
-  name: winlog.event_data.ProcessPath
+action.properties.ProcessPath:
+  name: action.properties.ProcessPath
   type: keyword
   description: ""
 
-winlog.event_data.ProcessPid:
-  name: winlog.event_data.ProcessPid
+action.properties.ProcessPid:
+  name: action.properties.ProcessPid
   type: keyword
   description: ""
 
-winlog.event_data.Product:
-  name: winlog.event_data.Product
+action.properties.Product:
+  name: action.properties.Product
   type: keyword
   description: ""
 
-winlog.event_data.PuaCount:
-  name: winlog.event_data.PuaCount
+action.properties.PuaCount:
+  name: action.properties.PuaCount
   type: keyword
   description: ""
 
-winlog.event_data.PuaPolicyId:
-  name: winlog.event_data.PuaPolicyId
+action.properties.PuaPolicyId:
+  name: action.properties.PuaPolicyId
   type: keyword
   description: ""
 
-winlog.event_data.QfeVersion:
-  name: winlog.event_data.QfeVersion
+action.properties.QfeVersion:
+  name: action.properties.QfeVersion
   type: keyword
   description: ""
 
-winlog.event_data.Reason:
-  name: winlog.event_data.Reason
+action.properties.Reason:
+  name: action.properties.Reason
   type: keyword
   description: ""
 
-winlog.event_data.SchemaVersion:
-  name: winlog.event_data.SchemaVersion
+action.properties.SchemaVersion:
+  name: action.properties.SchemaVersion
   type: keyword
   description: ""
 
-winlog.event_data.ScriptBlockText:
-  name: winlog.event_data.ScriptBlockText
+action.properties.ScriptBlockText:
+  name: action.properties.ScriptBlockText
   type: keyword
   description: ""
 
-winlog.event_data.ServiceName:
-  name: winlog.event_data.ServiceName
+action.properties.ServiceName:
+  name: action.properties.ServiceName
   type: keyword
   description: ""
 
-winlog.event_data.ServiceVersion:
-  name: winlog.event_data.ServiceVersion
+action.properties.ServiceVersion:
+  name: action.properties.ServiceVersion
   type: keyword
   description: ""
 
-winlog.event_data.ShutdownActionType:
-  name: winlog.event_data.ShutdownActionType
+action.properties.ShutdownActionType:
+  name: action.properties.ShutdownActionType
   type: keyword
   description: ""
 
-winlog.event_data.ShutdownEventCode:
-  name: winlog.event_data.ShutdownEventCode
+action.properties.ShutdownEventCode:
+  name: action.properties.ShutdownEventCode
   type: keyword
   description: ""
 
-winlog.event_data.ShutdownReason:
-  name: winlog.event_data.ShutdownReason
+action.properties.ShutdownReason:
+  name: action.properties.ShutdownReason
   type: keyword
   description: ""
 
-winlog.event_data.Signature:
-  name: winlog.event_data.Signature
+action.properties.Signature:
+  name: action.properties.Signature
   type: keyword
   description: ""
 
-winlog.event_data.SignatureStatus:
-  name: winlog.event_data.SignatureStatus
+action.properties.SignatureStatus:
+  name: action.properties.SignatureStatus
   type: keyword
   description: ""
 
-winlog.event_data.Signed:
-  name: winlog.event_data.Signed
+action.properties.Signed:
+  name: action.properties.Signed
   type: keyword
   description: ""
 
-winlog.event_data.StartTime:
-  name: winlog.event_data.StartTime
+action.properties.StartTime:
+  name: action.properties.StartTime
   type: keyword
   description: ""
 
-winlog.event_data.State:
-  name: winlog.event_data.State
+action.properties.State:
+  name: action.properties.State
   type: keyword
   description: ""
 
-winlog.event_data.Status:
-  name: winlog.event_data.Status
+action.properties.Status:
+  name: action.properties.Status
   type: keyword
   description: ""
 
-winlog.event_data.StopTime:
-  name: winlog.event_data.StopTime
+action.properties.StopTime:
+  name: action.properties.StopTime
   type: keyword
   description: ""
 
-winlog.event_data.SubjectDomainName:
-  name: winlog.event_data.SubjectDomainName
+action.properties.SubjectDomainName:
+  name: action.properties.SubjectDomainName
   type: keyword
   description: ""
 
-winlog.event_data.SubjectLogonId:
-  name: winlog.event_data.SubjectLogonId
+action.properties.SubjectLogonId:
+  name: action.properties.SubjectLogonId
   type: keyword
   description: ""
 
-winlog.event_data.SubjectUserName:
-  name: winlog.event_data.SubjectUserName
+action.properties.SubjectUserName:
+  name: action.properties.SubjectUserName
   type: keyword
   description: ""
 
-winlog.event_data.SubjectUserSid:
-  name: winlog.event_data.SubjectUserSid
+action.properties.SubjectUserSid:
+  name: action.properties.SubjectUserSid
   type: keyword
   description: ""
 
-winlog.event_data.TSId:
-  name: winlog.event_data.TSId
+action.properties.TSId:
+  name: action.properties.TSId
   type: keyword
   description: ""
 
-winlog.event_data.TargetDomainName:
-  name: winlog.event_data.TargetDomainName
+action.properties.TargetDomainName:
+  name: action.properties.TargetDomainName
   type: keyword
   description: ""
 
-winlog.event_data.TargetInfo:
-  name: winlog.event_data.TargetInfo
+action.properties.TargetInfo:
+  name: action.properties.TargetInfo
   type: keyword
   description: ""
 
-winlog.event_data.TargetLogonGuid:
-  name: winlog.event_data.TargetLogonGuid
+action.properties.TargetLogonGuid:
+  name: action.properties.TargetLogonGuid
   type: keyword
   description: ""
 
-winlog.event_data.TargetLogonId:
-  name: winlog.event_data.TargetLogonId
+action.properties.TargetLogonId:
+  name: action.properties.TargetLogonId
   type: keyword
   description: ""
 
-winlog.event_data.TargetServerName:
-  name: winlog.event_data.TargetServerName
+action.properties.TargetServerName:
+  name: action.properties.TargetServerName
   type: keyword
   description: ""
 
-winlog.event_data.TargetUserName:
-  name: winlog.event_data.TargetUserName
+action.properties.TargetUserName:
+  name: action.properties.TargetUserName
   type: keyword
   description: ""
 
-winlog.event_data.TargetUserSid:
-  name: winlog.event_data.TargetUserSid
+action.properties.TargetUserSid:
+  name: action.properties.TargetUserSid
   type: keyword
   description: ""
 
-winlog.event_data.TerminalSessionId:
-  name: winlog.event_data.TerminalSessionId
+action.properties.TerminalSessionId:
+  name: action.properties.TerminalSessionId
   type: keyword
   description: ""
 
-winlog.event_data.TokenElevationType:
-  name: winlog.event_data.TokenElevationType
+action.properties.TokenElevationType:
+  name: action.properties.TokenElevationType
   type: keyword
   description: ""
 
-winlog.event_data.TransmittedServices:
-  name: winlog.event_data.TransmittedServices
+action.properties.TransmittedServices:
+  name: action.properties.TransmittedServices
   type: keyword
   description: ""
 
-winlog.event_data.UserSid:
-  name: winlog.event_data.UserSid
+action.properties.UserSid:
+  name: action.properties.UserSid
   type: keyword
   description: ""
 
-winlog.event_data.Version:
-  name: winlog.event_data.Version
+action.properties.Version:
+  name: action.properties.Version
   type: keyword
   description: ""
 
-winlog.event_data.Workstation:
-  name: winlog.event_data.Workstation
+action.properties.Workstation:
+  name: action.properties.Workstation
   type: keyword
   description: ""
 
-winlog.event_data.param1:
-  name: winlog.event_data.param1
+action.properties.param1:
+  name: action.properties.param1
   type: keyword
   description: ""
 
-winlog.event_data.param2:
-  name: winlog.event_data.param2
+action.properties.param2:
+  name: action.properties.param2
   type: keyword
   description: ""
 
-winlog.event_data.param3:
-  name: winlog.event_data.param3
+action.properties.param3:
+  name: action.properties.param3
   type: keyword
   description: ""
 
-winlog.event_data.param4:
-  name: winlog.event_data.param4
+action.properties.param4:
+  name: action.properties.param4
   type: keyword
   description: ""
 
-winlog.event_data.param5:
-  name: winlog.event_data.param5
+action.properties.param5:
+  name: action.properties.param5
   type: keyword
   description: ""
 
-winlog.event_data.param6:
-  name: winlog.event_data.param6
+action.properties.param6:
+  name: action.properties.param6
   type: keyword
   description: ""
 
-winlog.event_data.param7:
-  name: winlog.event_data.param7
+action.properties.param7:
+  name: action.properties.param7
   type: keyword
   description: ""
 
-winlog.event_data.param8:
-  name: winlog.event_data.param8
+action.properties.param8:
+  name: action.properties.param8
   type: keyword
   description: ""
 

--- a/Beats/winlogbeat/ingest/parser.yml
+++ b/Beats/winlogbeat/ingest/parser.yml
@@ -12,6 +12,7 @@ stages:
       - set:
           '@timestamp': '{{json.event["@timestamp"]}}'
           action: '{{json.event.action}}'
+          action.properties: '{{json.event.winlog.event_data}}'
           agent: '{{json.event.agent}}'
           as: "{{json_event.event.as}}"
           beat: '{{json.event.beat}}'
@@ -57,6 +58,3 @@ stages:
       - set:
           winlog.activity_id: '{{json.event.winlog.activity_id | lower}}'
         filter: '{{json.event.winlog.get("activity_id") != None}}'
-      - set:
-          action.properties: '{{json.event.winlog.event_data}}'
-        filter: '{{json.event.winlog.get("event_data") != None}}'

--- a/Beats/winlogbeat/ingest/parser.yml
+++ b/Beats/winlogbeat/ingest/parser.yml
@@ -57,3 +57,6 @@ stages:
       - set:
           winlog.activity_id: '{{json.event.winlog.activity_id | lower}}'
         filter: '{{json.event.winlog.get("activity_id") != None}}'
+      - set:
+          action.properties: '{{json.event.winlog.event_data}}'
+        filter: '{{json.event.winlog.get("event_data") != None}}'

--- a/Beats/winlogbeat/tests/test_filtering.json
+++ b/Beats/winlogbeat/tests/test_filtering.json
@@ -45,23 +45,6 @@
       "api": "wineventlog",
       "channel": "Security",
       "computer_name": "vm204d.example.org",
-      "event_data": {
-        "Application": "System",
-        "DestAddress": "5.6.7.8",
-        "DestPort": "445",
-        "Direction": "%%14592",
-        "FilterOrigin": "Unknown",
-        "FilterRTID": "71694",
-        "InterfaceIndex": "9",
-        "LayerName": "%%14610",
-        "LayerRTID": "44",
-        "ProcessID": "4",
-        "Protocol": "6",
-        "RemoteMachineID": "S-1-0-0",
-        "RemoteUserID": "S-1-0-0",
-        "SourceAddress": "1.2.3.4",
-        "SourcePort": "58499"
-      },
       "event_id": "5156",
       "keywords": [
         "Audit Success"
@@ -78,6 +61,25 @@
       "record_id": "614833249",
       "task": "Filtering Platform Connection",
       "version": 1
+    },
+    "action": {
+      "properties": {
+        "Application": "System",
+        "DestAddress": "5.6.7.8",
+        "DestPort": "445",
+        "Direction": "%%14592",
+        "FilterOrigin": "Unknown",
+        "FilterRTID": "71694",
+        "InterfaceIndex": "9",
+        "LayerName": "%%14610",
+        "LayerRTID": "44",
+        "ProcessID": "4",
+        "Protocol": "6",
+        "RemoteMachineID": "S-1-0-0",
+        "RemoteUserID": "S-1-0-0",
+        "SourceAddress": "1.2.3.4",
+        "SourcePort": "58499"
+      }
     },
     "related": {
       "hash": [

--- a/Beats/winlogbeat/tests/test_logon.json
+++ b/Beats/winlogbeat/tests/test_logon.json
@@ -46,13 +46,6 @@
       "api": "wineventlog",
       "channel": "Security",
       "computer_name": "vm-exc-msg-3.example.org",
-      "event_data": {
-        "PrivilegeList": "SeSecurityPrivilege\n\t\t\tSeBackupPrivilege\n\t\t\tSeRestorePrivilege\n\t\t\tSeTakeOwnershipPrivilege\n\t\t\tSeDebugPrivilege\n\t\t\tSeSystemEnvironmentPrivilege\n\t\t\tSeLoadDriverPrivilege\n\t\t\tSeImpersonatePrivilege\n\t\t\tSeDelegateSessionUserImpersonatePrivilege",
-        "SubjectDomainName": "EXAMPLE",
-        "SubjectLogonId": "0xc5d72273",
-        "SubjectUserName": "VM-EXC-MSG-4$",
-        "SubjectUserSid": "S-1-5-21-776561741-920026266-725345543-17198"
-      },
       "event_id": "4672",
       "keywords": [
         "Audit Success"
@@ -68,6 +61,15 @@
       "provider_name": "Microsoft-Windows-Security-Auditing",
       "record_id": "1842784185",
       "task": "Special Logon"
+    },
+    "action": {
+      "properties": {
+        "PrivilegeList": "SeSecurityPrivilege\n\t\t\tSeBackupPrivilege\n\t\t\tSeRestorePrivilege\n\t\t\tSeTakeOwnershipPrivilege\n\t\t\tSeDebugPrivilege\n\t\t\tSeSystemEnvironmentPrivilege\n\t\t\tSeLoadDriverPrivilege\n\t\t\tSeImpersonatePrivilege\n\t\t\tSeDelegateSessionUserImpersonatePrivilege",
+        "SubjectDomainName": "EXAMPLE",
+        "SubjectLogonId": "0xc5d72273",
+        "SubjectUserName": "VM-EXC-MSG-4$",
+        "SubjectUserSid": "S-1-5-21-776561741-920026266-725345543-17198"
+      }
     },
     "related": {
       "hash": [


### PR DESCRIPTION
rename winlog.event_data.* fields into action.properties.* in the winlogbeat format