### PR TITLE
WatchGuard: handle when the LEEF prefix is missing

### DIFF
--- a/WatchGuard/watchguard-firebox/ingest/parser.yml
+++ b/WatchGuard/watchguard-firebox/ingest/parser.yml
@@ -3,6 +3,13 @@ pipeline:
   - name: parsed_event
     external:
       name: leef.parse-leef
+    filter: '{{original.message.startswith("LEEF")}}'
+  - name: parsed_event
+    external:
+      name: leef.parse-leef
+      properties:
+        input_field: 'LEEF:{{original.message}}'
+    filter: '{{original.message.startswith("1.0|WatchGuard")}}'
   - name: dhcp_event
     external:
       name: grok.match

--- a/WatchGuard/watchguard-firebox/tests/dpi_http_2.json
+++ b/WatchGuard/watchguard-firebox/tests/dpi_http_2.json
@@ -6,10 +6,10 @@
         "dialect_uuid": "d719e8b5-85a1-4dad-bf71-46155af56570"
       }
     },
-    "message": "LEEF:1.0|WatchGuard|XTM|12.8.2.B666661|2CFF0009|serial=000000000000\tpolicy=HTTPS-LAN-00\tdisp=Allow\tin_if=LAN\tout_if=WAN2\tgeo_dst=USA\tsrc=10.10.1.22\tsrcPort=52803\tdst=5.6.7.8\tdstPort=443\tproto=tcp\tproxy_act=HTTPS-Client-LAN\ttls_profile=TLS-Client-HTTPS\tinspect_action=HTTP-Client-LAN\tserver_ssl=TLS_AES_128_GCM_SHA256\tclient_ssl=TLS_AES_128_GCM_SHA256\ttls_version=TLS_V13\tmsg=ProxyInspect: HTTPS content inspection"
+    "message": "1.0|WatchGuard|XTM|12.8.2.B666661|2CFF0009|serial=000000000000\tpolicy=HTTPS-LAN-00\tdisp=Allow\tin_if=LAN\tout_if=WAN2\tgeo_dst=USA\tsrc=10.10.1.22\tsrcPort=52803\tdst=5.6.7.8\tdstPort=443\tproto=tcp\tproxy_act=HTTPS-Client-LAN\ttls_profile=TLS-Client-HTTPS\tinspect_action=HTTP-Client-LAN\tserver_ssl=TLS_AES_128_GCM_SHA256\tclient_ssl=TLS_AES_128_GCM_SHA256\ttls_version=TLS_V13\tmsg=ProxyInspect: HTTPS content inspection"
   },
   "expected": {
-    "message": "LEEF:1.0|WatchGuard|XTM|12.8.2.B666661|2CFF0009|serial=000000000000\tpolicy=HTTPS-LAN-00\tdisp=Allow\tin_if=LAN\tout_if=WAN2\tgeo_dst=USA\tsrc=10.10.1.22\tsrcPort=52803\tdst=5.6.7.8\tdstPort=443\tproto=tcp\tproxy_act=HTTPS-Client-LAN\ttls_profile=TLS-Client-HTTPS\tinspect_action=HTTP-Client-LAN\tserver_ssl=TLS_AES_128_GCM_SHA256\tclient_ssl=TLS_AES_128_GCM_SHA256\ttls_version=TLS_V13\tmsg=ProxyInspect: HTTPS content inspection",
+    "message": "1.0|WatchGuard|XTM|12.8.2.B666661|2CFF0009|serial=000000000000\tpolicy=HTTPS-LAN-00\tdisp=Allow\tin_if=LAN\tout_if=WAN2\tgeo_dst=USA\tsrc=10.10.1.22\tsrcPort=52803\tdst=5.6.7.8\tdstPort=443\tproto=tcp\tproxy_act=HTTPS-Client-LAN\ttls_profile=TLS-Client-HTTPS\tinspect_action=HTTP-Client-LAN\tserver_ssl=TLS_AES_128_GCM_SHA256\tclient_ssl=TLS_AES_128_GCM_SHA256\ttls_version=TLS_V13\tmsg=ProxyInspect: HTTPS content inspection",
     "event": {
       "kind": "event",
       "category": [


### PR DESCRIPTION
Handle when facing event without the prefix LEEF.