### PR TITLE
fix(cef/tests): fix wrong value `str` for field type `float`

### DIFF
--- a/CEF/cef/tests/cisco_esa_cef.json
+++ b/CEF/cef/tests/cisco_esa_cef.json
@@ -6,10 +6,10 @@
         "dialect_uuid": "1d172ee6-cdc0-4713-9cfd-43f7d9595777"
       }
     },
-    "message": "CEF:0|Cisco|C390 Email Security Appliance|14.0.0-698|ESA_CONSOLIDATED_LOG_EVENT|Consolidated Log Event|5|deviceExternalId=123456789-54646546546 ESAMID=12356 ESAICID=123456 ESADCID=123456 ESAAMPVerdict=NOT_EVALUATED ESAASVerdict=NOT_EVALUATED ESAAVVerdict=NOT_EVALUATED ESACFVerdict=MATCH endTime=Mon Aug  1 03:34:23 2022 dvc=1.1.1.1 ESAFriendlyFrom=noreply@corp.net ESAGMVerdict=NOT_EVALUATED startTime=Mon Aug  1 03:30:36 2022 deviceOutboundInterface=OutgoingMail deviceDirection=1 ESAMailFlowPolicy=RELAY suser=noreply@corp.net cs1Label=MailPolicy cs1=RestrictionEmetteur cs2Label=SenderCountry cs2=not enabled ESAMFVerdict=NO_MATCH act=DELIVERED cs4Label=ExternalMsgID cs4='<123456@corp.net>' ESAMsgSize=3059 ESAOFVerdict=NOT_EVALUATED duser=foo@other-corp.com ESAHeloDomain=foo.bar.net ESAHeloIP=2.2.2.2 cfp1Label=SBRSScore cfp1=not enabled sourceHostName=unknown ESASenderGroup=RELAYLIST sourceAddress=2.2.2.2 msg='\\=?ISO-8859-15?Q?foo\\=20bar\\=20baz\\=20-\\=123456789?\\='\n\n"
+    "message": "CEF:0|Cisco|C390 Email Security Appliance|14.0.0-698|ESA_CONSOLIDATED_LOG_EVENT|Consolidated Log Event|5|deviceExternalId=123456789-54646546546 ESAMID=12356 ESAICID=123456 ESADCID=123456 ESAAMPVerdict=NOT_EVALUATED ESAASVerdict=NOT_EVALUATED ESAAVVerdict=NOT_EVALUATED ESACFVerdict=MATCH endTime=Mon Aug  1 03:34:23 2022 dvc=1.1.1.1 ESAFriendlyFrom=noreply@corp.net ESAGMVerdict=NOT_EVALUATED startTime=Mon Aug  1 03:30:36 2022 deviceOutboundInterface=OutgoingMail deviceDirection=1 ESAMailFlowPolicy=RELAY suser=noreply@corp.net cs1Label=MailPolicy cs1=RestrictionEmetteur cs2Label=SenderCountry cs2=not enabled ESAMFVerdict=NO_MATCH act=DELIVERED cs4Label=ExternalMsgID cs4='<123456@corp.net>' ESAMsgSize=3059 ESAOFVerdict=NOT_EVALUATED duser=foo@other-corp.com ESAHeloDomain=foo.bar.net ESAHeloIP=2.2.2.2 cfp1Label=SBRSScore cfp1= sourceHostName=unknown ESASenderGroup=RELAYLIST sourceAddress=2.2.2.2 msg='\\=?ISO-8859-15?Q?foo\\=20bar\\=20baz\\=20-\\=123456789?\\='\n\n"
   },
   "expected": {
-    "message": "CEF:0|Cisco|C390 Email Security Appliance|14.0.0-698|ESA_CONSOLIDATED_LOG_EVENT|Consolidated Log Event|5|deviceExternalId=123456789-54646546546 ESAMID=12356 ESAICID=123456 ESADCID=123456 ESAAMPVerdict=NOT_EVALUATED ESAASVerdict=NOT_EVALUATED ESAAVVerdict=NOT_EVALUATED ESACFVerdict=MATCH endTime=Mon Aug  1 03:34:23 2022 dvc=1.1.1.1 ESAFriendlyFrom=noreply@corp.net ESAGMVerdict=NOT_EVALUATED startTime=Mon Aug  1 03:30:36 2022 deviceOutboundInterface=OutgoingMail deviceDirection=1 ESAMailFlowPolicy=RELAY suser=noreply@corp.net cs1Label=MailPolicy cs1=RestrictionEmetteur cs2Label=SenderCountry cs2=not enabled ESAMFVerdict=NO_MATCH act=DELIVERED cs4Label=ExternalMsgID cs4='<123456@corp.net>' ESAMsgSize=3059 ESAOFVerdict=NOT_EVALUATED duser=foo@other-corp.com ESAHeloDomain=foo.bar.net ESAHeloIP=2.2.2.2 cfp1Label=SBRSScore cfp1=not enabled sourceHostName=unknown ESASenderGroup=RELAYLIST sourceAddress=2.2.2.2 msg='\\=?ISO-8859-15?Q?foo\\=20bar\\=20baz\\=20-\\=123456789?\\='\n\n",
+    "message": "CEF:0|Cisco|C390 Email Security Appliance|14.0.0-698|ESA_CONSOLIDATED_LOG_EVENT|Consolidated Log Event|5|deviceExternalId=123456789-54646546546 ESAMID=12356 ESAICID=123456 ESADCID=123456 ESAAMPVerdict=NOT_EVALUATED ESAASVerdict=NOT_EVALUATED ESAAVVerdict=NOT_EVALUATED ESACFVerdict=MATCH endTime=Mon Aug  1 03:34:23 2022 dvc=1.1.1.1 ESAFriendlyFrom=noreply@corp.net ESAGMVerdict=NOT_EVALUATED startTime=Mon Aug  1 03:30:36 2022 deviceOutboundInterface=OutgoingMail deviceDirection=1 ESAMailFlowPolicy=RELAY suser=noreply@corp.net cs1Label=MailPolicy cs1=RestrictionEmetteur cs2Label=SenderCountry cs2=not enabled ESAMFVerdict=NO_MATCH act=DELIVERED cs4Label=ExternalMsgID cs4='<123456@corp.net>' ESAMsgSize=3059 ESAOFVerdict=NOT_EVALUATED duser=foo@other-corp.com ESAHeloDomain=foo.bar.net ESAHeloIP=2.2.2.2 cfp1Label=SBRSScore cfp1= sourceHostName=unknown ESASenderGroup=RELAYLIST sourceAddress=2.2.2.2 msg='\\=?ISO-8859-15?Q?foo\\=20bar\\=20baz\\=20-\\=123456789?\\='\n\n",
     "event": {
       "severity": 5,
       "action": "DELIVERED",
@@ -49,7 +49,14 @@
       "name": "unknown"
     },
     "cef": {
-      "event_type": "base event"
+      "cfp1Label": "SBRSScore",
+      "cs4": "<123456@corp.net>",
+      "cs4Label": "ExternalMsgID",
+      "cs2": "not enabled",
+      "cs2Label": "SenderCountry",
+      "cs1": "RestrictionEmetteur",
+      "cs1Label": "MailPolicy",
+      "Name": "Consolidated Log Event"
     },
     "related": {
       "hosts": [


### PR DESCRIPTION
I removed the wrong value in tests files since:
- we have a dedicated format for Cisco
- the CEF format is not intended to be bullet proof against miss-usage of a field