### PR TITLE
fix(Cloudflare/gateway_network): set destination.domain if SNI present

### DIFF
--- a/Cloudflare/gateway_network/ingest/parser.yml
+++ b/Cloudflare/gateway_network/ingest/parser.yml
@@ -15,7 +15,11 @@ stages:
           "@timestamp": '{{json_event.message.Datetime}}'
           cloud.account.id: '{{json_event.message.AccountID}}'
       - set:
+          destination.domain: '{{json_event.message.SNI}}'
+        filter: '{{json_event.message.SNI is not in [""]}}'
+      - set:
           destination.ip: '{{json_event.message.DestinationIP}}'
+          destination.address: '{{json_event.message.DestinationIP}}'
         filter: '{{json_event.message.DestinationIP | is_ipaddress}}'
 
       - set:

--- a/Cloudflare/gateway_network/tests/test_network.json
+++ b/Cloudflare/gateway_network/tests/test_network.json
@@ -28,6 +28,7 @@
       }
     },
     "destination": {
+      "domain": "www.twitter.com",
       "ip": "104.244.42.193",
       "port": 443,
       "address": "104.244.42.193"
@@ -54,6 +55,9 @@
       }
     },
     "related": {
+      "hosts": [
+        "www.twitter.com"
+      ],
       "ip": [
         "104.244.42.193",
         "15.188.186.81"

--- a/Cloudflare/gateway_network/tests/test_network_no_sni.json
+++ b/Cloudflare/gateway_network/tests/test_network_no_sni.json
@@ -1,0 +1,58 @@
+{
+  "input": {
+    "sekoiaio": {
+      "intake": {
+        "dialect": "Cloudflare Gateway Network",
+        "dialect_uuid": "d14567dd-56b1-42f8-aa64-fb65d4b0a4cf"
+      }
+    },
+    "message": "{\"AccountID\":\"1d1e650b3385b95db72bba7cfb1287e9\",\"Action\":\"allowedOnNoRuleMatch\",\"Datetime\":\"2023-02-24T16:33:05Z\",\"DestinationIP\":\"104.244.42.193\",\"DestinationPort\":443,\"DeviceID\":\"\",\"DeviceName\":\"\",\"Email\":\"\",\"OverrideIP\":\"\",\"OverridePort\":0,\"PolicyID\":\"\",\"PolicyName\":\"\",\"SNI\":\"\",\"SessionID\":\"1725de7a2d0000215517735400000001\",\"SourceIP\":\"15.188.186.81\",\"SourcePort\":34080,\"Transport\":\"tcp\",\"UserID\":\"\"}"
+  },
+  "expected": {
+    "message": "{\"AccountID\":\"1d1e650b3385b95db72bba7cfb1287e9\",\"Action\":\"allowedOnNoRuleMatch\",\"Datetime\":\"2023-02-24T16:33:05Z\",\"DestinationIP\":\"104.244.42.193\",\"DestinationPort\":443,\"DeviceID\":\"\",\"DeviceName\":\"\",\"Email\":\"\",\"OverrideIP\":\"\",\"OverridePort\":0,\"PolicyID\":\"\",\"PolicyName\":\"\",\"SNI\":\"\",\"SessionID\":\"1725de7a2d0000215517735400000001\",\"SourceIP\":\"15.188.186.81\",\"SourcePort\":34080,\"Transport\":\"tcp\",\"UserID\":\"\"}",
+    "event": {
+      "action": "allowedOnNoRuleMatch",
+      "category": [
+        "network"
+      ],
+      "dataset": "gateway_network",
+      "kind": "event",
+      "type": [
+        "allowed"
+      ]
+    },
+    "@timestamp": "2023-02-24T16:33:05Z",
+    "cloud": {
+      "account": {
+        "id": "1d1e650b3385b95db72bba7cfb1287e9"
+      }
+    },
+    "destination": {
+      "ip": "104.244.42.193",
+      "port": 443,
+      "address": "104.244.42.193"
+    },
+    "observer": {
+      "type": "proxy",
+      "vendor": "Cloudflare"
+    },
+    "network": {
+      "transport": "tcp"
+    },
+    "source": {
+      "ip": "15.188.186.81",
+      "port": 34080,
+      "address": "15.188.186.81"
+    },
+    "cloudflare": {
+      "OverridePort": 0,
+      "SessionID": "1725de7a2d0000215517735400000001"
+    },
+    "related": {
+      "ip": [
+        "104.244.42.193",
+        "15.188.186.81"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
To make pivoting and IOC detection easier, this PR copies the SNI (`tls.client.server_name`) to `destination.domain` .

This is in line with the ECS specification:
> **tls.client.server_name:** Also called an SNI, [...]. When this value is available, it should get copied to `destination.domain`.
https://www.elastic.co/guide/en/ecs/current/ecs-tls.html#field-tls-client-server-name

Note: I explicitely force `destination.address` to be the same as `destination.ip` event if `destination.domain` is present because this seems more exact in this context (these logs are similar to firewall logs, not proxy logs).
