### PR TITLE
Tests: ignore sekoia.intake.parsing_duration_ms

### DIFF
--- a/utils/test_formats.py
+++ b/utils/test_formats.py
@@ -81,6 +81,7 @@ def build_fixed_expectation(parsed_message):
     pop_field(new_expectation, "sekoiaio.intake.parsing_status")
     pop_field(new_expectation, "sekoiaio.intake.dialect")
     pop_field(new_expectation, "sekoiaio.intake.dialect_uuid")
+    pop_field(new_expectation, "sekoiaio.intake.parsing_duration_ms")
     pop_field(new_expectation, "event.id")
     pop_field(new_expectation, "event.outcome")
     pop_field(new_expectation, "ecs.version")


### PR DESCRIPTION
Ignore sekoia.intake.parsing_duration_ms from tests