### PR TITLE
Update the gitignore to ignore the .DS_Store for macusers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 .idea/
 __pycache__
+.DS_Store


### PR DESCRIPTION
Hi @gaelmuller, @squioc. I hope you are doing well ?
I suggest to add `.DS_Store` to `.gitignore` for Mac OS users. 