### PR TITLE
Fix access logs events for Ubika

### DIFF
--- a/Ubika/ubika_waap/CHANGELOG.md
+++ b/Ubika/ubika_waap/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2023-06-21 - 1.0.1
+
+### Fixed
+
+- Fixed parsing of access log events
+
 ## 2023-06-13 - 1.0.0
 
 ### Added

--- a/Ubika/ubika_waap/_meta/smart-descriptions.json
+++ b/Ubika/ubika_waap/_meta/smart-descriptions.json
@@ -32,7 +32,7 @@
         "field": "url.original"
       },
       {
-        "field": "event.type",
+        "field": "event.type.0",
         "value": "access"
       }
     ]

--- a/Ubika/ubika_waap/ingest/parser.yml
+++ b/Ubika/ubika_waap/ingest/parser.yml
@@ -4,8 +4,9 @@ pipeline:
     external:
       name: grok.match
       properties:
-        # <date> <observer_name> <tunnel_uuid> - - - <payload>
-        pattern: "%{TIMESTAMP_ISO8601:timestamp} %{USERNAME:observer} %{USERNAME:tunnel_uuid} - - - %{GREEDYDATA:payload}"
+        # For security events: <date> <observer_name> <tunnel_uuid> - - - <payload>
+        # For access logs: <date> <observer_name> <tunnel_uuid>: - - - <payload>
+        pattern: "%{TIMESTAMP_ISO8601:timestamp} %{USERNAME:observer} %{USERNAME:tunnel_uuid}(:?) - - - %{GREEDYDATA:payload}"
 
   # Security Events
   - name: parse_event

--- a/Ubika/ubika_waap/tests/test_access_event.json
+++ b/Ubika/ubika_waap/tests/test_access_event.json
@@ -6,10 +6,10 @@
         "dialect_uuid": "6dbdd199-77ae-4705-a5de-5c2722fa020e"
       }
     },
-    "message": "2023-05-23T14:24:09.190263+02:00 waf01.example.org ad97ec2b41c342ebbb1fec1fc283fff3 - - - 5.6.7.8 - - [23/May/2023:14:24:09 +0200] \"GET /path/ape/logo.png HTTP/1.1\" 404 1245 \"https://referer.example.com/\" \"Mozilla/5.0 (iPad; CPU OS 16_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/113.0.5672.121 Mobile/15E148 Safari/604.1\""
+    "message": "2023-05-23T14:24:09.190263+02:00 waf01.example.org ad97ec2b41c342ebbb1fec1fc283fff3: - - - 5.6.7.8 - - [23/May/2023:14:24:09 +0200] \"GET /path/ape/logo.png HTTP/1.1\" 404 1245 \"https://referer.example.com/\" \"Mozilla/5.0 (iPad; CPU OS 16_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/113.0.5672.121 Mobile/15E148 Safari/604.1\""
   },
   "expected": {
-    "message": "2023-05-23T14:24:09.190263+02:00 waf01.example.org ad97ec2b41c342ebbb1fec1fc283fff3 - - - 5.6.7.8 - - [23/May/2023:14:24:09 +0200] \"GET /path/ape/logo.png HTTP/1.1\" 404 1245 \"https://referer.example.com/\" \"Mozilla/5.0 (iPad; CPU OS 16_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/113.0.5672.121 Mobile/15E148 Safari/604.1\"",
+    "message": "2023-05-23T14:24:09.190263+02:00 waf01.example.org ad97ec2b41c342ebbb1fec1fc283fff3: - - - 5.6.7.8 - - [23/May/2023:14:24:09 +0200] \"GET /path/ape/logo.png HTTP/1.1\" 404 1245 \"https://referer.example.com/\" \"Mozilla/5.0 (iPad; CPU OS 16_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/113.0.5672.121 Mobile/15E148 Safari/604.1\"",
     "event": {
       "dataset": "ubika-waf",
       "module": "ubika.waf",

--- a/Ubika/ubika_waap/tests/test_bot_mitigation_event.json
+++ b/Ubika/ubika_waap/tests/test_bot_mitigation_event.json
@@ -14,12 +14,8 @@
       "dataset": "ubika-waf",
       "module": "ubika.waf",
       "kind": "alert",
-      "category": [
-        "threat"
-      ],
-      "type": [
-        "indicator"
-      ]
+      "category": ["threat"],
+      "type": ["indicator"]
     },
     "observer": {
       "vendor": "Ubika",
@@ -73,13 +69,8 @@
       }
     },
     "related": {
-      "ip": [
-        "1.2.3.4",
-        "5.6.7.8"
-      ],
-      "hosts": [
-        "example.org"
-      ]
+      "ip": ["1.2.3.4", "5.6.7.8"],
+      "hosts": ["example.org"]
     }
   }
 }

--- a/Ubika/ubika_waap/tests/test_security_log_event.json
+++ b/Ubika/ubika_waap/tests/test_security_log_event.json
@@ -14,12 +14,8 @@
       "dataset": "ubika-waf",
       "module": "ubika.waf",
       "kind": "alert",
-      "category": [
-        "threat"
-      ],
-      "type": [
-        "indicator"
-      ]
+      "category": ["threat"],
+      "type": ["indicator"]
     },
     "observer": {
       "vendor": "Ubika",
@@ -78,13 +74,8 @@
       "id": "fbfb5aec58e3ff3bea900f646351cc30"
     },
     "related": {
-      "ip": [
-        "1.2.3.4",
-        "5.6.7.8"
-      ],
-      "hosts": [
-        "example.org"
-      ]
+      "ip": ["1.2.3.4", "5.6.7.8"],
+      "hosts": ["example.org"]
     }
   }
 }

--- a/Ubika/ubika_waap/tests/test_wam_log_event.json
+++ b/Ubika/ubika_waap/tests/test_wam_log_event.json
@@ -14,12 +14,8 @@
       "dataset": "ubika-waf",
       "module": "ubika.waf",
       "kind": "alert",
-      "category": [
-        "threat"
-      ],
-      "type": [
-        "indicator"
-      ]
+      "category": ["threat"],
+      "type": ["indicator"]
     },
     "observer": {
       "vendor": "Ubika",
@@ -71,12 +67,8 @@
       }
     },
     "related": {
-      "ip": [
-        "1.2.3.4"
-      ],
-      "hosts": [
-        "example.org"
-      ]
+      "ip": ["1.2.3.4"],
+      "hosts": ["example.org"]
     }
   }
 }


### PR DESCRIPTION
It seems that a colon can actually appear in a separator, but only for access log events. Improving parsing pattern to allow this.