### PR TITLE
feat(Office 365): Parse ExchangeAdmin parameters

### DIFF
--- a/Office 365/o365/_meta/fields.yml
+++ b/Office 365/o365/_meta/fields.yml
@@ -83,6 +83,11 @@ office365.context.correlation.id:
   description: "The identifier to correlate user's action across Microsoft 365 services"
   type: keyword
 
+office365.exchange_admin.parameters:
+  name: office365.exchange_admin.parameters
+  description: "The parameters that were used with the cmdlet that is identified in the event.action field"
+  type: array
+
 office365.teams.action:
   name: office365.teams.action
   description: "The action taken by an invitee or the channel owner"

--- a/Office 365/o365/ingest/parser.yml
+++ b/Office 365/o365/ingest/parser.yml
@@ -27,7 +27,9 @@ pipeline:
     filter: '{{json_event.message.ClientIP != null and json_event.message.ClientIP != "" and json_event.message.ClientIP != "<null>"}}'
   - name: set_common_fields
   - name: set_office365_fields
-  - name: parse_exchange
+  - name: parse_exchange_admin
+    filter: "{{json_event.message.RecordType == 1}}"
+  - name: parse_exchange_item
     filter: "{{json_event.message.RecordType == 2}}"
   - name: parse_network_traffic
     filter: "{{json_event.message.RecordType in [15, 25]}}"
@@ -116,7 +118,24 @@ stages:
           office365.context.correlation.id: "{{json_event.message.AppAccessContext.CorrelationId}}"
         filter: '{{json_event.message.get("AppAccessContext") != None}}'
 
-  parse_exchange:
+  parse_exchange_admin:
+    actions:
+      - translate:
+        dictionary:
+          "True": "success"
+          "False": "failure"
+        mapping:
+          json_event.message.ResultStatus: action.outcome
+      - set:
+          office365.exchange_admin.parameters: >
+            [
+              {% for parameter in json_event.message.Parameters %}
+                "{{ parameter.Name }}:{{ parameter.Value }}",
+              {% endfor %}
+            ]
+        filter: '{{json_event.message.get("Parameters") != None}}'
+
+  parse_exchange_item:
     actions:
       - translate:
         dictionary:

--- a/Office 365/o365/tests/inbox_rule.json
+++ b/Office 365/o365/tests/inbox_rule.json
@@ -1,0 +1,77 @@
+{
+  "input": {
+    "sekoiaio": {
+      "intake": {
+        "dialect": "Office 365",
+        "dialect_uuid": "caa13404-9243-493b-943e-9848cadb1f99"
+      }
+    },
+    "message": "{\"CreationTime\":\"2023-05-24T15:10:53\",\"Id\":\"9cf2a1f7-90bc-494b-2784-08db5c691133\",\"Operation\":\"New-InboxRule\",\"OrganizationId\":\"49c2f50d-d36c-4b88-8511-55ce3ea9e53f\",\"RecordType\":1,\"ResultStatus\":\"True\",\"UserKey\":\"100320028D9C5197\",\"UserType\":2,\"Version\":1,\"Workload\":\"Exchange\",\"ClientIP\":\"240.157.135.119:63070\",\"ObjectId\":\"EURPR07A010.PROD.OUTLOOK.COM/Microsoft Exchange Hosted Organizations/example.onmicrosoft.com/bc1b1df3-f861-4aec-bf7c-40ce5b5566c1\\\\RULE_NAME\",\"UserId\":\"RobertP@example.onmicrosoft.com\",\"AppId\":\"00000002-0000-0ff1-ce00-000000000000\",\"ClientAppId\":\"\",\"ExternalAccess\":false,\"OrganizationName\":\"example.onmicrosoft.com\",\"OriginatingServer\":\"AM0PR07MB5763 (15.20.6411.029)\",\"Parameters\":[{\"Name\":\"ForwardTo\",\"Value\":\"bob@example.org\"},{\"Name\":\"Force\",\"Value\":\"False\"},{\"Name\":\"AlwaysDeleteOutlookRulesBlob\",\"Value\":\"False\"},{\"Name\":\"RedirectTo\",\"Value\":\"joe@example.org\"},{\"Name\":\"From\",\"Value\":\"alice@example.org\"},{\"Name\":\"Name\",\"Value\":\"RULE_NAME\"},{\"Name\":\"DeleteMessage\",\"Value\":\"True\"},{\"Name\":\"FromAddressContainsWords\",\"Value\":\"@example.org\"},{\"Name\":\"MarkAsRead\",\"Value\":\"True\"},{\"Name\":\"StopProcessingRules\",\"Value\":\"True\"},{\"Name\":\"SubjectOrBodyContainsWords\",\"Value\":\"keyword\"},{\"Name\":\"MoveToFolder\",\"Value\":\"Historique des conversations\"}],\"SessionId\":\"984c0958-0631-4b90-b116-15094fc36847\"}\r\n\r"
+  },
+  "expected": {
+    "message": "{\"CreationTime\":\"2023-05-24T15:10:53\",\"Id\":\"9cf2a1f7-90bc-494b-2784-08db5c691133\",\"Operation\":\"New-InboxRule\",\"OrganizationId\":\"49c2f50d-d36c-4b88-8511-55ce3ea9e53f\",\"RecordType\":1,\"ResultStatus\":\"True\",\"UserKey\":\"100320028D9C5197\",\"UserType\":2,\"Version\":1,\"Workload\":\"Exchange\",\"ClientIP\":\"240.157.135.119:63070\",\"ObjectId\":\"EURPR07A010.PROD.OUTLOOK.COM/Microsoft Exchange Hosted Organizations/example.onmicrosoft.com/bc1b1df3-f861-4aec-bf7c-40ce5b5566c1\\\\RULE_NAME\",\"UserId\":\"RobertP@example.onmicrosoft.com\",\"AppId\":\"00000002-0000-0ff1-ce00-000000000000\",\"ClientAppId\":\"\",\"ExternalAccess\":false,\"OrganizationName\":\"example.onmicrosoft.com\",\"OriginatingServer\":\"AM0PR07MB5763 (15.20.6411.029)\",\"Parameters\":[{\"Name\":\"ForwardTo\",\"Value\":\"bob@example.org\"},{\"Name\":\"Force\",\"Value\":\"False\"},{\"Name\":\"AlwaysDeleteOutlookRulesBlob\",\"Value\":\"False\"},{\"Name\":\"RedirectTo\",\"Value\":\"joe@example.org\"},{\"Name\":\"From\",\"Value\":\"alice@example.org\"},{\"Name\":\"Name\",\"Value\":\"RULE_NAME\"},{\"Name\":\"DeleteMessage\",\"Value\":\"True\"},{\"Name\":\"FromAddressContainsWords\",\"Value\":\"@example.org\"},{\"Name\":\"MarkAsRead\",\"Value\":\"True\"},{\"Name\":\"StopProcessingRules\",\"Value\":\"True\"},{\"Name\":\"SubjectOrBodyContainsWords\",\"Value\":\"keyword\"},{\"Name\":\"MoveToFolder\",\"Value\":\"Historique des conversations\"}],\"SessionId\":\"984c0958-0631-4b90-b116-15094fc36847\"}\r\n\r",
+    "event": {
+      "action": "New-InboxRule",
+      "kind": "event",
+      "code": "1"
+    },
+    "@timestamp": "2023-05-24T15:10:53Z",
+    "service": {
+      "name": "Exchange"
+    },
+    "user": {
+      "name": "RobertP@example.onmicrosoft.com",
+      "id": "100320028D9C5197",
+      "email": "RobertP@example.onmicrosoft.com"
+    },
+    "organization": {
+      "id": "49c2f50d-d36c-4b88-8511-55ce3ea9e53f"
+    },
+    "action": {
+      "id": 1,
+      "name": "New-InboxRule",
+      "target": "user",
+      "outcome": "success"
+    },
+    "source": {
+      "ip": "240.157.135.119",
+      "port": 63070,
+      "address": "240.157.135.119"
+    },
+    "office365": {
+      "record_type": 1,
+      "result_status": "True",
+      "user_type": {
+        "code": 2,
+        "name": "Admin"
+      },
+      "audit": {
+        "object_id": "EURPR07A010.PROD.OUTLOOK.COM/Microsoft Exchange Hosted Organizations/example.onmicrosoft.com/bc1b1df3-f861-4aec-bf7c-40ce5b5566c1\\RULE_NAME"
+      },
+      "exchange_admin": {
+        "parameters": [
+          "ForwardTo:bob@example.org",
+          "Force:False",
+          "AlwaysDeleteOutlookRulesBlob:False",
+          "RedirectTo:joe@example.org",
+          "From:alice@example.org",
+          "Name:RULE_NAME",
+          "DeleteMessage:True",
+          "FromAddressContainsWords:@example.org",
+          "MarkAsRead:True",
+          "StopProcessingRules:True",
+          "SubjectOrBodyContainsWords:keyword",
+          "MoveToFolder:Historique des conversations"
+        ]
+      }
+    },
+    "related": {
+      "ip": [
+        "240.157.135.119"
+      ],
+      "user": [
+        "RobertP@example.onmicrosoft.com"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
I have closed #535 and will split it in several PRs.

The [_ExchangeAdmin_](https://learn.microsoft.com/en-us/office/office-365-management-api/office-365-management-activity-api-schema#exchange-admin-schema) event type has a _Parameters_ field which is an array of Name-Value pairs, e.g.:
```json
  "Parameters": [
    {
      "Name": "ForwardTo",
      "Value": "bob@example.org"
    },
    {
      "Name": "Force",
      "Value": "False"
    },
```
This PR parses and reformats this as
```json
    "office365": {
      "exchange_admin": {
        "parameters": [
          "ForwardTo:bob@example.org",
          "RedirectTo:joe@example.org",
```

* The use of an `office365.exchange_admin` namespace mimics what already exists for instance with `office365.teams` and `office365.defender`.
* The array of `key:value` strings mimics what exists in some `sekoiaio.tags` fields. It's a way to avoid an unbounded dictionary (the number of distinct keys is [in the hundreds](https://learn.microsoft.com/en-us/powershell/module/exchange/?view=exchange-ps) I believe, and picking only a handful of interesting keys seems impractical).

I have tested this new parsing with a custom format intake and it works pretty well for Sigma rules, e.g.:
```yaml
detection:
  selection:
    office365.exchange_admin.parameters|re: 'Name:[^0-9A-Za-z]+'
  condition: selection
```
```yaml
detection:
  selection:
    office365.exchange_admin.parameters|all:
      - MoveToFolder:Historique des conversations
      - StopProcessingRules:True
      - MarkAsRead:True
  condition: selection
```