### PR TITLE
SentinelOne: revert fix on boolean string

### DIFF
--- a/SentinelOne/cloud_funnel2.0/_meta/fields.yml
+++ b/SentinelOne/cloud_funnel2.0/_meta/fields.yml
@@ -616,7 +616,7 @@ deepvisibility.process.parent.counters.net_conn:
 
 deepvisibility.process.target.code_signature.exists:
   name: deepvisibility.process.target.code_signature.exists
-  type: boolean
+  type: keyword
   description: ""
 
 deepvisibility.process.target.counters.child_process:
@@ -801,7 +801,7 @@ deepvisibility.process.parent.activecontent.hash.sha1:
 
 deepvisibility.process.parent.activecontent.code_signature.exists:
   name: deepvisibility.process.parent.activecontent.code_signature.exists
-  type: boolean
+  type: keyword
   description: ""
 
 deepvisibility.process.activecontent.type:
@@ -821,7 +821,7 @@ deepvisibility.process.activecontent.hash.sha1:
 
 deepvisibility.process.activecontent.code_signature.exists:
   name: deepvisibility.process.activecontent.code_signature.exists
-  type: boolean
+  type: keyword
   description: ""
 
 deepvisibility.process.ossrc.parent.activecontent.type:
@@ -841,7 +841,7 @@ deepvisibility.process.ossrc.parent.activecontent.hash.sha1:
 
 deepvisibility.process.ossrc.parent.activecontent.code_signature.exists:
   name: deepvisibility.process.ossrc.parent.activecontent.code_signature.exists
-  type: boolean
+  type: keyword
   description: ""
 
 deepvisibility.process.ossrc.activecontent.type:
@@ -861,7 +861,7 @@ deepvisibility.process.ossrc.activecontent.hash.sha1:
 
 deepvisibility.process.ossrc.activecontent.code_signature.exists:
   name: deepvisibility.process.ossrc.activecontent.code_signature.exists
-  type: boolean
+  type: keyword
   description: ""
 
 deepvisibility.driver.verdict:
@@ -952,7 +952,7 @@ deepvisibility.process.target.real_user.id:
   description: The type of the Logon
 
 deepvisibility.process.code_signature.exists:
-  type: boolean
+  type: keyword
   name: deepvisibility.process.code_signature.exists
   description: ""
 
@@ -992,7 +992,7 @@ deepvisibility.process.name:
   description: ""
 
 deepvisibility.process.parent.code_signature.exists:
-  type: boolean
+  type: keyword
   name: deepvisibility.process.parent.code_signature.exists
   description: ""
 

--- a/SentinelOne/cloud_funnel2.0/tests/commandscript.json
+++ b/SentinelOne/cloud_funnel2.0/tests/commandscript.json
@@ -83,7 +83,7 @@
           "working_directory": "C:\\Windows\\System32",
           "start": "2023-03-30T13:46:01.002000Z",
           "code_signature": {
-            "exists": true,
+            "exists": "true",
             "subject_name": "MICROSOFT WINDOWS"
           }
         },

--- a/SentinelOne/cloud_funnel2.0/tests/dns_dnsresolved.json
+++ b/SentinelOne/cloud_funnel2.0/tests/dns_dnsresolved.json
@@ -74,7 +74,7 @@
         "working_directory": "C:\\Windows\\System32",
         "start": "2023-03-21T12:38:53.356000Z",
         "code_signature": {
-          "exists": true,
+          "exists": "true",
           "subject_name": "MICROSOFT WINDOWS"
         },
         "parent": {
@@ -104,7 +104,7 @@
           "working_directory": "C:\\Windows\\System32",
           "start": "2023-03-21T10:34:33.882000Z",
           "code_signature": {
-            "exists": true,
+            "exists": "true",
             "subject_name": "MICROSOFT WINDOWS"
           }
         },

--- a/SentinelOne/cloud_funnel2.0/tests/file_filedeletion.json
+++ b/SentinelOne/cloud_funnel2.0/tests/file_filedeletion.json
@@ -76,11 +76,11 @@
         "activecontent": {
           "type": "FILE",
           "code_signature": {
-            "exists": false
+            "exists": "false"
           }
         },
         "code_signature": {
-          "exists": true,
+          "exists": "true",
           "subject_name": "MICROSOFT CORPORATION"
         },
         "parent": {
@@ -120,7 +120,7 @@
           "activecontent": {
             "type": "FILE",
             "code_signature": {
-              "exists": false
+              "exists": "false"
             }
           }
         }

--- a/SentinelOne/cloud_funnel2.0/tests/group_groupcreation.json
+++ b/SentinelOne/cloud_funnel2.0/tests/group_groupcreation.json
@@ -63,7 +63,7 @@
             "sha1": "8b3d7f4397dd79d66b753745a676da89439ed38e"
           },
           "code_signature": {
-            "exists": false
+            "exists": "false"
           }
         },
         "parent": {

--- a/SentinelOne/cloud_funnel2.0/tests/indicators_behavioralindicators.json
+++ b/SentinelOne/cloud_funnel2.0/tests/indicators_behavioralindicators.json
@@ -59,7 +59,7 @@
         "activecontent": {
           "type": "FILE",
           "code_signature": {
-            "exists": false
+            "exists": "false"
           }
         },
         "parent": {
@@ -74,7 +74,7 @@
           "activecontent": {
             "type": "FILE",
             "code_signature": {
-              "exists": false
+              "exists": "false"
             }
           }
         }

--- a/SentinelOne/cloud_funnel2.0/tests/linux_process_processcreation.json
+++ b/SentinelOne/cloud_funnel2.0/tests/linux_process_processcreation.json
@@ -94,7 +94,7 @@
           },
           "start": "2023-04-12T14:24:34.590000Z",
           "code_signature": {
-            "exists": false
+            "exists": "false"
           }
         }
       }

--- a/SentinelOne/cloud_funnel2.0/tests/logins_login_failure.json
+++ b/SentinelOne/cloud_funnel2.0/tests/logins_login_failure.json
@@ -74,7 +74,7 @@
         "working_directory": "C:\\Windows\\System32",
         "start": "2023-03-21T10:33:50.438000Z",
         "code_signature": {
-          "exists": true,
+          "exists": "true",
           "subject_name": "MICROSOFT WINDOWS"
         },
         "parent": {

--- a/SentinelOne/cloud_funnel2.0/tests/logins_login_success.json
+++ b/SentinelOne/cloud_funnel2.0/tests/logins_login_success.json
@@ -74,7 +74,7 @@
         "working_directory": "C:\\Windows\\System32",
         "start": "2023-04-04T09:47:38.531000Z",
         "code_signature": {
-          "exists": true,
+          "exists": "true",
           "subject_name": "MICROSOFT WINDOWS"
         },
         "parent": {

--- a/SentinelOne/cloud_funnel2.0/tests/process_processcreation.json
+++ b/SentinelOne/cloud_funnel2.0/tests/process_processcreation.json
@@ -74,7 +74,7 @@
         "working_directory": "C:\\Windows\\System32",
         "start": "2023-03-21T13:39:25.779000Z",
         "code_signature": {
-          "exists": true,
+          "exists": "true",
           "subject_name": "MICROSOFT WINDOWS"
         },
         "parent": {
@@ -104,7 +104,7 @@
           "working_directory": "C:\\Windows\\System32",
           "start": "2023-03-21T10:34:33.882000Z",
           "code_signature": {
-            "exists": true,
+            "exists": "true",
             "subject_name": "MICROSOFT WINDOWS"
           }
         },
@@ -133,7 +133,7 @@
           },
           "start": "2023-03-21T13:39:25.867000Z",
           "code_signature": {
-            "exists": true,
+            "exists": "true",
             "subject_name": "MICROSOFT WINDOWS"
           }
         },

--- a/SentinelOne/cloud_funnel2.0/tests/registry_binary.json
+++ b/SentinelOne/cloud_funnel2.0/tests/registry_binary.json
@@ -59,7 +59,7 @@
         "activecontent": {
           "type": "FILE",
           "code_signature": {
-            "exists": false
+            "exists": "false"
           }
         },
         "parent": {
@@ -74,7 +74,7 @@
           "activecontent": {
             "type": "FILE",
             "code_signature": {
-              "exists": false
+              "exists": "false"
             }
           }
         }

--- a/SentinelOne/cloud_funnel2.0/tests/registry_security.json
+++ b/SentinelOne/cloud_funnel2.0/tests/registry_security.json
@@ -74,7 +74,7 @@
         "working_directory": "C:\\WindowsAzure\\GuestAgent_2.7.41491.1075_2023-03-16_134252",
         "start": "2023-03-24T09:44:16.550000Z",
         "code_signature": {
-          "exists": true,
+          "exists": "true",
           "subject_name": "MICROSOFT WINDOWS"
         },
         "parent": {

--- a/SentinelOne/cloud_funnel2.0/tests/scheduledtask_taskregister.json
+++ b/SentinelOne/cloud_funnel2.0/tests/scheduledtask_taskregister.json
@@ -77,7 +77,7 @@
         "working_directory": "C:\\Windows\\System32",
         "start": "2023-03-24T14:37:13.169000Z",
         "code_signature": {
-          "exists": true,
+          "exists": "true",
           "subject_name": "MICROSOFT WINDOWS"
         },
         "parent": {

--- a/SentinelOne/cloud_funnel2.0/tests/scheduledtask_taskstart.json
+++ b/SentinelOne/cloud_funnel2.0/tests/scheduledtask_taskstart.json
@@ -83,11 +83,11 @@
             "sha1": "4baee77d42bd0b2fa2660852eeac7962aa27a2f1"
           },
           "code_signature": {
-            "exists": true
+            "exists": "true"
           }
         },
         "code_signature": {
-          "exists": true,
+          "exists": "true",
           "subject_name": "MICROSOFT WINDOWS"
         },
         "parent": {


### PR DESCRIPTION
Change back to `keyword` the type of boolean string in the taxonomy.