### PR TITLE
fix(pfilter): change grok pattern for interface

### DIFF
--- a/OpenBSD/openbsd-packet-filter/ingest/parser.yml
+++ b/OpenBSD/openbsd-packet-filter/ingest/parser.yml
@@ -9,7 +9,7 @@ pipeline:
         pattern: "%{PACKET_FILTER},(%{PF_IPV4}|%{PF_IPV6}),(%{PF_UDP}|%{PF_TCP}|%{PF_CARP}|%{PF_ICMP})"
 
         custom_patterns:
-          PACKET_FILTER: "%{NUMBER:rulenr},%{DATA:subrulenr},%{DATA:anchorname},%{WORD:label},%{WORD:interface},%{WORD:reason},%{WORD:action},%{WORD:dir}"
+          PACKET_FILTER: "%{NUMBER:rulenr},%{DATA:subrulenr},%{DATA:anchorname},%{WORD:label},%{DATA:interface},%{WORD:reason},%{WORD:action},%{WORD:dir}"
           PF_IPV4: "4,%{WORD:tos},%{DATA:ecn},%{NUMBER:hoplimit},%{NUMBER:id},%{NUMBER:offset},%{WORD:flags},%{NUMBER:protonum},%{WORD:protoname},%{NUMBER:length},%{IPV4:src},%{IPV4:dst}"
           PF_IPV6: "6,%{DATA:class},%{DATA:flow},%{DATA:hoplimit},%{WORD:protoname},%{NUMBER:protonum},%{NUMBER:length},%{IPV6:src},%{IPV6:dst}"
           PF_UDP: "%{NUMBER:srcport},%{NUMBER:dstport},%{NUMBER:datalen}"

--- a/OpenBSD/openbsd-packet-filter/tests/test_ingest_ipv4_carp_logs.json
+++ b/OpenBSD/openbsd-packet-filter/tests/test_ingest_ipv4_carp_logs.json
@@ -6,10 +6,10 @@
         "dialect_uuid": "8510051d-c7cf-4b0c-a398-031afe91faa0"
       }
     },
-    "message": "183,,,41cbdd1cea144179a26efd069e1ee54f,vtnet9,match,block,out,4,0x0,,63,18292,0,DF,112,vrrp,72,1.2.3.4,5.6.7.8,3,255,13,2,0,1"
+    "message": "183,,,41cbdd1cea144179a26efd069e1ee54f,vtnet.9,match,block,out,4,0x0,,63,18292,0,DF,112,vrrp,72,1.2.3.4,5.6.7.8,3,255,13,2,0,1"
   },
   "expected": {
-    "message": "183,,,41cbdd1cea144179a26efd069e1ee54f,vtnet9,match,block,out,4,0x0,,63,18292,0,DF,112,vrrp,72,1.2.3.4,5.6.7.8,3,255,13,2,0,1",
+    "message": "183,,,41cbdd1cea144179a26efd069e1ee54f,vtnet.9,match,block,out,4,0x0,,63,18292,0,DF,112,vrrp,72,1.2.3.4,5.6.7.8,3,255,13,2,0,1",
     "event": {
       "reason": "match",
       "action": "block",
@@ -63,7 +63,7 @@
     "observer": {
       "egress": {
         "interface": {
-          "name": "vtnet9"
+          "name": "vtnet.9"
         }
       }
     },


### PR DESCRIPTION
# Overview

Change the GROK pattern for the interface because a customer could have an interface name like "interface.1" which was not working with a `DATA` GROK pattern.

# Tests
Tests have been ran.