### PR TITLE
update(packet-filter): case where the log start with a space

### DIFF
--- a/OpenBSD/openbsd-packet-filter/ingest/parser.yml
+++ b/OpenBSD/openbsd-packet-filter/ingest/parser.yml
@@ -4,7 +4,7 @@ pipeline:
     external:
       name: grok.match
       properties:
-        input_field: "{{original.message}}"
+        input_field: "{{original.message.strip()}}"
         output_field: message
         pattern: "%{PACKET_FILTER},(%{PF_IPV4}|%{PF_IPV6}),(%{PF_UDP}|%{PF_TCP}|%{PF_CARP}|%{PF_ICMP})"
 


### PR DESCRIPTION
Handle the weird case where logs start with a space. I used the same technique than the `Forcepoint` Intake. (`"CEF:{{original.message.strip()}}")
Those spaces are present since with decided to remove log.original from the log. 

This update doesn't change anything for the test logs.