### PR TITLE
SkyHigh: expand boolean values

### DIFF
--- a/SkyhighSecurity/skyhigh_secure_web_gateway/ingest/parser.yml
+++ b/SkyhighSecurity/skyhigh_secure_web_gateway/ingest/parser.yml
@@ -156,3 +156,33 @@ stages:
       - set:
           skyhighsecurity.viruses: '{{parse_kv.message.virus_names.split(", ")}}'
         filter: '{{parse_kv.message.virus_names != null and parse_kv.message.virus_names != "-" and parse_kv.message.virus_names != ""}}'
+      - translate:
+        dictionary:
+          "t": "true"
+          "f": "false"
+        mapping:
+          parse_kv.message.dlp: skyhighsecurity.dlp
+      - translate:
+        dictionary:
+          "t": "true"
+          "f": "false"
+        mapping:
+          parse_kv.message.rbi: skyhighsecurity.rbi
+      - translate:
+        dictionary:
+          "t": "true"
+          "f": "false"
+        mapping:
+          parse_kv.message.av_scanned_up: skyhighsecurity.av_scanned_up
+      - translate:
+        dictionary:
+          "t": "true"
+          "f": "false"
+        mapping:
+          parse_kv.message.av_scanned_down: skyhighsecurity.av_scanned_down
+      - translate:
+        dictionary:
+          "t": "true"
+          "f": "false"
+        mapping:
+          parse_kv.message.ssl_scanned: skyhighsecurity.ssl_scanned

--- a/SkyhighSecurity/skyhigh_secure_web_gateway/tests/skyhigh_swg.json
+++ b/SkyhighSecurity/skyhigh_secure_web_gateway/tests/skyhigh_swg.json
@@ -72,11 +72,11 @@
     },
     "skyhighsecurity": {
       "proxy_port": 8080,
-      "dlp": "f",
-      "rbi": "f",
-      "av_scanned_down": "f",
-      "av_scanned_up": "t",
-      "ssl_scanned": "t",
+      "dlp": "false",
+      "rbi": "false",
+      "av_scanned_down": "false",
+      "av_scanned_up": "true",
+      "ssl_scanned": "true",
       "reputation": "Minimal Risk"
     },
     "related": {

--- a/SkyhighSecurity/skyhigh_secure_web_gateway/tests/skyhigh_swg_block.json
+++ b/SkyhighSecurity/skyhigh_secure_web_gateway/tests/skyhigh_swg_block.json
@@ -71,11 +71,11 @@
     },
     "skyhighsecurity": {
       "proxy_port": 80,
-      "dlp": "f",
-      "rbi": "f",
-      "av_scanned_down": "f",
-      "av_scanned_up": "f",
-      "ssl_scanned": "f",
+      "dlp": "false",
+      "rbi": "false",
+      "av_scanned_down": "false",
+      "av_scanned_up": "false",
+      "ssl_scanned": "false",
       "reputation": "Minimal Risk"
     },
     "related": {


### PR DESCRIPTION
Translate 't' and 'f' value into a more readable form (ie 'true' and 'false')