### PR TITLE
Sophos: Fix User targeted

### DIFF
--- a/Sophos/sophos-analysis-threat-center/ingest/parser.yml
+++ b/Sophos/sophos-analysis-threat-center/ingest/parser.yml
@@ -79,7 +79,7 @@ stages:
           event.ingested: "{{parsed_ingestion_date.date}}"
 
           user.name: "{{parse_json.message.meta_username}}"
-          destination.user.name: "{{parse_json.message.target_username}}"
+          user.target.name: "{{parse_json.message.target_username}}"
 
           registry.path: "{{parse_json.message.path}}"
           registry.key: "{{parse_json.message.key}}"

--- a/Sophos/sophos-analysis-threat-center/tests/ioc_view_query3.json
+++ b/Sophos/sophos-analysis-threat-center/tests/ioc_view_query3.json
@@ -19,14 +19,10 @@
     },
     "@timestamp": "2025-12-12T10:00:51Z",
     "user": {
-      "name": "AC000TEST0011"
-    },
-    "destination": {
-      "user": {
+      "name": "AC000TEST0011",
+      "target": {
         "name": "Administrateur"
-      },
-      "domain": "AC000-TEST0011",
-      "address": "AC000-TEST0011"
+      }
     },
     "registry": {
       "data": {
@@ -61,6 +57,10 @@
     },
     "process": {
       "name": "IOC worker name"
+    },
+    "destination": {
+      "domain": "AC000-TEST0011",
+      "address": "AC000-TEST0011"
     },
     "server": {
       "domain": "TEST/1.2.3.4"
@@ -112,16 +112,15 @@
       }
     },
     "related": {
-      "user": [
-        "AC000TEST0011",
-        "Administrateur"
-      ],
       "hosts": [
         "AC000-TEST0011",
         "TEST/1.2.3.4"
       ],
       "ip": [
         "1.2.3.4"
+      ],
+      "user": [
+        "AC000TEST0011"
       ]
     }
   }

--- a/Sophos/sophos-analysis-threat-center/tests/ioc_view_query4.json
+++ b/Sophos/sophos-analysis-threat-center/tests/ioc_view_query4.json
@@ -69,7 +69,9 @@
       "domain": "TEST/1.2.3.4"
     },
     "file": {
-      "path": "C:\\Program Files (x86)\\TEST.EXE"
+      "path": "C:\\Program Files (x86)\\TEST.EXE",
+      "name": "TEST.EXE",
+      "directory": "C:\\Program Files (x86)"
     },
     "sophos": {
       "threat_center": {

--- a/Sophos/sophos-analysis-threat-center/tests/ioc_view_query4.json
+++ b/Sophos/sophos-analysis-threat-center/tests/ioc_view_query4.json
@@ -16,12 +16,10 @@
       "reason": "A user account was locked out.",
       "ingested": "2025-12-12T13:59:11.487000Z"
     },
-    "destination": {
-      "user": {
+    "user": {
+      "target": {
         "name": "Administrateur"
-      },
-      "domain": "AC000-TEST0011",
-      "address": "AC000-TEST0011"
+      }
     },
     "registry": {
       "data": {
@@ -59,6 +57,10 @@
       "code_signature": {
         "exists": true
       }
+    },
+    "destination": {
+      "domain": "AC000-TEST0011",
+      "address": "AC000-TEST0011"
     },
     "threat": {
       "indicator": {
@@ -119,9 +121,6 @@
       "hash": [
         "94256542e235681ba64a20bc50910dd745d52347",
         "d4baeeb9180a4284b33fa3602d86c"
-      ],
-      "user": [
-        "Administrateur"
       ],
       "hosts": [
         "AC000-TEST0011",


### PR DESCRIPTION
- Use `user.target` to hold all information about the targeted user
- update tests according to the finalizer on `file`