### PR TITLE
fix(windows): add missing patch for wrong char at the start of the json message

### DIFF
--- a/Windows/windows/ingest/parser.yml
+++ b/Windows/windows/ingest/parser.yml
@@ -1,11 +1,21 @@
 name: Microsoft Windows
 pipeline:
   - name: json
+    description: "Bypass wrong syslog configuration which adds : before the json message"
+    external:
+      name: json.parse-json
+      properties:
+        input_field: "{{original.message.replace(':{', '{')}}"
+        output_field: event
+    filter: '{{original.message.startswith(":{")}}'
+
+  - name: json
     external:
       name: json.parse-json
       properties:
         input_field: "{{original.message}}"
         output_field: event
+    filter: '{{original.message.startswith(":{") == False}}'
 
   - name: parsed_message_kv
     description: "Extract fields from Message field"

--- a/Windows/windows/tests/wrong-startswith.json
+++ b/Windows/windows/tests/wrong-startswith.json
@@ -1,0 +1,37 @@
+{
+  "input": {
+    "event": {
+      "sekoiaio": {
+        "intake": {
+          "dialect": "Windows",
+          "dialect_uuid": "9281438c-f7c3-4001-9bcc-45fd108ba1be"
+        }
+      }
+    },
+    "message": ":{\n  \"EventTime\": \"2023-09-19 12:02:19\",\n  \"Hostname\": \"mycorp.net\",\n  \"EventReceivedTime\": \"2023-09-19 12:02:20\",\n  \"SourceModuleName\": \"eventlog\",\n  \"SourceModuleType\": \"im_msvistalog\"\n}\n\n\n"
+  },
+  "expected": {
+    "message": ":{\n  \"EventTime\": \"2023-09-19 12:02:19\",\n  \"Hostname\": \"mycorp.net\",\n  \"EventReceivedTime\": \"2023-09-19 12:02:20\",\n  \"SourceModuleName\": \"eventlog\",\n  \"SourceModuleType\": \"im_msvistalog\"\n}\n\n\n",
+    "log": {
+      "hostname": "mycorp.net"
+    },
+    "host": {
+      "hostname": "mycorp.net",
+      "name": "mycorp.net"
+    },
+    "os": {
+      "family": "windows",
+      "platform": "windows"
+    },
+    "action": {
+      "properties": [
+        null
+      ]
+    },
+    "related": {
+      "hosts": [
+        "mycorp.net"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Imports the patch from Logstash for syslog configurations which adds a `:` before the json