### PR TITLE
Sophos: fix the extraction of ml_score_data

### DIFF
--- a/Sophos/sophos-analysis-threat-center/CHANGELOG.md
+++ b/Sophos/sophos-analysis-threat-center/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2023-09-20 - 1.0.2
+
+### Changed
+
+- Fix extraction of ml_score_data
+
+## 2023-09-19 - 1.0.1
+
+### Added
+
+- Extract ml_score_data, global_rep, pua_score, process identifier
+
 ## 2023-07-11 - 1.0.0
 
 ### Added

--- a/Sophos/sophos-analysis-threat-center/ingest/parser.yml
+++ b/Sophos/sophos-analysis-threat-center/ingest/parser.yml
@@ -45,7 +45,7 @@ pipeline:
       properties:
         input_field: "{{parse_json.message.ml_score_data}}"
         output_field: message
-    filter: '{{parse_json.message.get("ml_score_data") != None }}'
+    filter: '{{parse_json.message.get("ml_score_data") not in [None, ""] }}'
 
   - name: parsed_password_date
     external:


### PR DESCRIPTION
Handle when ml_score_data is an empty string