### PR TITLE
Aruba: fix the name

### DIFF
--- a/Aruba Network/aruba-os/_meta/manifest.yml
+++ b/Aruba Network/aruba-os/_meta/manifest.yml
@@ -1,5 +1,5 @@
 uuid: d6d15297-e977-4584-9bb3-f0290b99f014
-name: ArubaOS
+name: ArubaOS Switch
 slug: aruba-os
 
 description: >-


### PR DESCRIPTION
add Switch to the name of the format