### PR TITLE
Freeradius: move the value from network.name to host.name

### DIFF
--- a/FreeRADIUS/freeradius/CHANGELOG.md
+++ b/FreeRADIUS/freeradius/CHANGELOG.md
@@ -6,3 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## 2023-10-18 - 1.0.2
+
+### Fixed
+
+- move the value from network.name to host.name as the extracted information is the name of the host

--- a/FreeRADIUS/freeradius/ingest/parser.yml
+++ b/FreeRADIUS/freeradius/ingest/parser.yml
@@ -8,7 +8,7 @@ pipeline:
         output_field: message
         pattern: "%{USUAL}|%{IGNREQ}"
         custom_patterns:
-          USUAL: '\s?\(%{INT}\)\s%{DATA:event_outcome}(\s\((eap_peap\:\s)?%{GREEDYDATA:event_reason}\))?\)?:\s\[%{USER}\]\s\(from\sclient\s%{DATA:network_name}\sport\s%{INT:client_port}(\scli\s(%{MAC:client_mac}|%{IP:client_ip}|(?P<client_mac_unsplitted>[0-9A-Fa-f]{12})))?(\svia\s%{PROTOCOL})?\)'
+          USUAL: '\s?\(%{INT}\)\s%{DATA:event_outcome}(\s\((eap_peap\:\s)?%{GREEDYDATA:event_reason}\))?\)?:\s\[%{USER}\]\s\(from\sclient\s%{DATA:host_name}\sport\s%{INT:client_port}(\scli\s(%{MAC:client_mac}|%{IP:client_ip}|(?P<client_mac_unsplitted>[0-9A-Fa-f]{12})))?(\svia\s%{PROTOCOL})?\)'
           IGNREQ: '\s?%{DATA:event_outcome} (%{IP:destination_ip}|\*) port %{INT:destination_port} bound to server default from unknown client %{IP:client_ip} port %{INT:client_port} proto %{DATA:network_transport}'
           USER: "%{USER_EMAIL:user_email}|%{HOST}|%{DOM}|%{DATA:user_name}"
           HOST: "host/%{HOSTNAME:client_domain}"
@@ -31,7 +31,7 @@ stages:
           user.name: "{{ parsing.message.user_name }}"
           user.domain: "{{ parsing.message.user_domain }}"
           user.id: "{{ parsing.message.user_id }}"
-          network.name: "{{ parsing.message.network_name }}"
+          host.name: "{{ parsing.message.host_name }}"
           source.port: "{{ parsing.message.client_port }}"
           source.mac: >
             {%- if parsing.message.client_mac -%}

--- a/FreeRADIUS/freeradius/ingest/parser.yml
+++ b/FreeRADIUS/freeradius/ingest/parser.yml
@@ -8,7 +8,7 @@ pipeline:
         output_field: message
         pattern: "%{USUAL}|%{IGNREQ}"
         custom_patterns:
-          USUAL: '\s?\(%{INT}\)\s%{DATA:event_outcome}(\s\((eap_peap\:\s)?%{GREEDYDATA:event_reason}\))?\)?:\s\[%{USER}\]\s\(from\sclient\s%{DATA:host_name}\sport\s%{INT:client_port}(\scli\s(%{MAC:client_mac}|%{IP:client_ip}|(?P<client_mac_unsplitted>[0-9A-Fa-f]{12})))?(\svia\s%{PROTOCOL})?\)'
+          USUAL: '\s?\(%{INT}\)\s%{DATA:event_outcome}(\s\((eap_peap\:\s)?%{GREEDYDATA:event_reason}\))?\)?:\s\[%{USER}\]\s\(from\sclient\s%{DATA:origin}\sport\s%{INT:client_port}(\scli\s(%{MAC:client_mac}|%{IP:client_ip}|(?P<client_mac_unsplitted>[0-9A-Fa-f]{12})))?(\svia\s%{PROTOCOL})?\)'
           IGNREQ: '\s?%{DATA:event_outcome} (%{IP:destination_ip}|\*) port %{INT:destination_port} bound to server default from unknown client %{IP:client_ip} port %{INT:client_port} proto %{DATA:network_transport}'
           USER: "%{USER_EMAIL:user_email}|%{HOST}|%{DOM}|%{DATA:user_name}"
           HOST: "host/%{HOSTNAME:client_domain}"
@@ -31,7 +31,6 @@ stages:
           user.name: "{{ parsing.message.user_name }}"
           user.domain: "{{ parsing.message.user_domain }}"
           user.id: "{{ parsing.message.user_id }}"
-          host.name: "{{ parsing.message.host_name }}"
           source.port: "{{ parsing.message.client_port }}"
           source.mac: >
             {%- if parsing.message.client_mac -%}
@@ -49,3 +48,11 @@ stages:
       - set:
           source.ip: "{{ parsing.message.client_ip }}"
         filter: "{{ parsing.message.client_ip | is_ipaddress }}"
+
+      - set:
+          network.name: "{{ parsing.message.origin }}"
+        filter: "{{ parsing.message.origin != null and parsing.message.origin.lower() in ['ccsma', 'wlan', 'lan'] }}"
+
+      - set:
+          host.name: "{{ parsing.message.origin }}"
+        filter: "{{ parsing.message.origin != null and parsing.message.origin.lower() not in ['ccsma', 'wlan', 'lan'] }}"

--- a/FreeRADIUS/freeradius/tests/test_invalid_user.json
+++ b/FreeRADIUS/freeradius/tests/test_invalid_user.json
@@ -26,15 +26,15 @@
       "name": "john.doe",
       "domain": "example.org "
     },
-    "host": {
-      "name": "WLAN"
-    },
     "source": {
       "port": 9815,
       "mac": "00-11-22-33-44-55"
     },
     "freeradius": {
       "outcome": "Invalid user"
+    },
+    "network": {
+      "name": "WLAN"
     },
     "related": {
       "user": [

--- a/FreeRADIUS/freeradius/tests/test_invalid_user.json
+++ b/FreeRADIUS/freeradius/tests/test_invalid_user.json
@@ -26,7 +26,7 @@
       "name": "john.doe",
       "domain": "example.org "
     },
-    "network": {
+    "host": {
       "name": "WLAN"
     },
     "source": {

--- a/FreeRADIUS/freeradius/tests/test_login_incorrect1.json
+++ b/FreeRADIUS/freeradius/tests/test_login_incorrect1.json
@@ -24,7 +24,7 @@
     "user": {
       "name": "test"
     },
-    "network": {
+    "host": {
       "name": "LAN"
     },
     "source": {

--- a/FreeRADIUS/freeradius/tests/test_login_incorrect1.json
+++ b/FreeRADIUS/freeradius/tests/test_login_incorrect1.json
@@ -24,14 +24,14 @@
     "user": {
       "name": "test"
     },
-    "host": {
-      "name": "LAN"
-    },
     "source": {
       "port": 0
     },
     "freeradius": {
       "outcome": "Login incorrect"
+    },
+    "network": {
+      "name": "LAN"
     },
     "related": {
       "user": [

--- a/FreeRADIUS/freeradius/tests/test_login_incorrect2.json
+++ b/FreeRADIUS/freeradius/tests/test_login_incorrect2.json
@@ -25,7 +25,7 @@
       "name": "username",
       "domain": "domain"
     },
-    "network": {
+    "host": {
       "name": "RX-WIFI-CISCO-5520-491"
     },
     "source": {

--- a/FreeRADIUS/freeradius/tests/test_login_ok1.json
+++ b/FreeRADIUS/freeradius/tests/test_login_ok1.json
@@ -20,9 +20,6 @@
       ],
       "dataset": "freeradius.authentication"
     },
-    "host": {
-      "name": "WLAN"
-    },
     "source": {
       "port": 9815,
       "mac": "00-11-22-33-44-55",
@@ -34,6 +31,9 @@
     },
     "freeradius": {
       "outcome": "Login OK"
+    },
+    "network": {
+      "name": "WLAN"
     },
     "related": {
       "hosts": [

--- a/FreeRADIUS/freeradius/tests/test_login_ok1.json
+++ b/FreeRADIUS/freeradius/tests/test_login_ok1.json
@@ -20,7 +20,7 @@
       ],
       "dataset": "freeradius.authentication"
     },
-    "network": {
+    "host": {
       "name": "WLAN"
     },
     "source": {

--- a/FreeRADIUS/freeradius/tests/test_login_ok2.json
+++ b/FreeRADIUS/freeradius/tests/test_login_ok2.json
@@ -25,14 +25,16 @@
       "name": "john.doe",
       "domain": "example.org"
     },
-    "network": {
-      "name": "abcdef",
-      "protocol": "TLS"
+    "host": {
+      "name": "abcdef"
     },
     "source": {
       "port": 2010,
       "ip": "1.2.3.4",
       "address": "1.2.3.4"
+    },
+    "network": {
+      "protocol": "TLS"
     },
     "freeradius": {
       "outcome": "Login OK"

--- a/FreeRADIUS/freeradius/tests/test_login_ok3.json
+++ b/FreeRADIUS/freeradius/tests/test_login_ok3.json
@@ -23,7 +23,7 @@
     "user": {
       "name": "nagios_check"
     },
-    "network": {
+    "host": {
       "name": "abcdef"
     },
     "source": {

--- a/FreeRADIUS/freeradius/tests/test_login_ok4.json
+++ b/FreeRADIUS/freeradius/tests/test_login_ok4.json
@@ -24,7 +24,7 @@
       "name": "UR12345678",
       "domain": "MYDOM"
     },
-    "network": {
+    "host": {
       "name": "test"
     },
     "source": {

--- a/FreeRADIUS/freeradius/tests/test_login_ok5.json
+++ b/FreeRADIUS/freeradius/tests/test_login_ok5.json
@@ -20,9 +20,8 @@
       ],
       "dataset": "freeradius.authentication"
     },
-    "network": {
-      "name": "test",
-      "protocol": "TLS"
+    "host": {
+      "name": "test"
     },
     "source": {
       "port": 8,
@@ -32,6 +31,9 @@
       "top_level_domain": "org",
       "subdomain": "hostname.test",
       "registered_domain": "example.org"
+    },
+    "network": {
+      "protocol": "TLS"
     },
     "freeradius": {
       "outcome": "Login OK"

--- a/FreeRADIUS/freeradius/tests/test_login_ok6.json
+++ b/FreeRADIUS/freeradius/tests/test_login_ok6.json
@@ -23,14 +23,14 @@
     "user": {
       "name": "username"
     },
-    "host": {
-      "name": "ccsma"
-    },
     "source": {
       "port": 0
     },
     "freeradius": {
       "outcome": "Login OK"
+    },
+    "network": {
+      "name": "ccsma"
     },
     "related": {
       "user": [

--- a/FreeRADIUS/freeradius/tests/test_login_ok6.json
+++ b/FreeRADIUS/freeradius/tests/test_login_ok6.json
@@ -23,7 +23,7 @@
     "user": {
       "name": "username"
     },
-    "network": {
+    "host": {
       "name": "ccsma"
     },
     "source": {

--- a/FreeRADIUS/freeradius/tests/test_login_ok7.json
+++ b/FreeRADIUS/freeradius/tests/test_login_ok7.json
@@ -24,7 +24,7 @@
       "name": "username",
       "domain": "domain"
     },
-    "network": {
+    "host": {
       "name": "RX-WIFI-CISCO-5520"
     },
     "source": {

--- a/FreeRADIUS/freeradius/tests/test_login_ok8.json
+++ b/FreeRADIUS/freeradius/tests/test_login_ok8.json
@@ -20,9 +20,8 @@
       ],
       "dataset": "freeradius.authentication"
     },
-    "network": {
-      "name": "RX-WIFI-CISCO-5520",
-      "protocol": "TLS"
+    "host": {
+      "name": "RX-WIFI-CISCO-5520"
     },
     "source": {
       "port": 8,
@@ -32,6 +31,9 @@
       "top_level_domain": "org",
       "subdomain": "username",
       "registered_domain": "example.org"
+    },
+    "network": {
+      "protocol": "TLS"
     },
     "freeradius": {
       "outcome": "Login OK"


### PR DESCRIPTION
move the value from `network.name` to `host.name` as the value represents the name of the host