### PR TITLE
Populate hash fields according to event code

### DIFF
--- a/Beats/winlogbeat/ingest/parser.yml
+++ b/Beats/winlogbeat/ingest/parser.yml
@@ -15,6 +15,7 @@ pipeline:
         value_sep: "="
         item_sep: ","
   - name: fields
+
 stages:
   fields:
     actions:
@@ -88,11 +89,22 @@ stages:
           winlog.activity_id: "{{json.event.winlog.activity_id | lower}}"
         filter: '{{json.event.winlog.get("activity_id") != None}}'
       - set:
-          process.hash.md5: "{{parse_kv_hashes.hash.MD5}}"
-          process.hash.sha1: "{{parse_kv_hashes.hash.SHA1}}"
-          process.hash.sha256: "{{parse_kv_hashes.hash.SHA256}}"
-          process.hash.sha384: "{{parse_kv_hashes.hash.SHA384}}"
-          process.hash.sha512: "{{parse_kv_hashes.hash.SHA512}}"
-          process.hash.ssdeep: "{{parse_kv_hashes.hash.SSDEEP}}"
-          process.hash.tlsh: "{{parse_kv_hashes.hash.TLSH}}"
-        filter: "{{parse_kv_hashes.hash != None}}"
+          process.hash.md5: "{{parse_kv_hashes.hash.MD5| lower }}"
+          process.hash.sha1: "{{parse_kv_hashes.hash.SHA1 | lower }}"
+          process.hash.sha256: "{{parse_kv_hashes.hash.SHA256 | lower }}"
+          process.hash.sha384: "{{parse_kv_hashes.hash.SHA384 | lower }}"
+          process.hash.sha512: "{{parse_kv_hashes.hash.SHA512 | lower }}"
+          process.hash.ssdeep: "{{parse_kv_hashes.hash.SSDEEP | lower }}"
+          process.hash.tlsh: "{{parse_kv_hashes.hash.TLSH | lower }}"
+          process.pe.imphash: "{{parse_kv_hashes.hash.IMPHASH | lower}}"
+        filter: "{{parse_kv_hashes.hash != None and json.event.event.code in ['1','23','24', '25', '26']}}"
+      - set:
+          file.hash.md5: "{{parse_kv_hashes.hash.MD5| lower }}"
+          file.hash.sha1: "{{parse_kv_hashes.hash.SHA1 | lower }}"
+          file.hash.sha256: "{{parse_kv_hashes.hash.SHA256 | lower }}"
+          file.hash.sha384: "{{parse_kv_hashes.hash.SHA384 | lower }}"
+          file.hash.sha512: "{{parse_kv_hashes.hash.SHA512 | lower }}"
+          file.hash.ssdeep: "{{parse_kv_hashes.hash.SSDEEP | lower }}"
+          file.hash.tlsh: "{{parse_kv_hashes.hash.TLSH | lower }}"
+          file.pe.imphash: "{{parse_kv_hashes.hash.IMPHASH | lower}}"
+        filter: "{{parse_kv_hashes.hash != None and json.event.event.code in ['6','7','15']}}"

--- a/Beats/winlogbeat/tests/event_process_create_1.json
+++ b/Beats/winlogbeat/tests/event_process_create_1.json
@@ -89,12 +89,13 @@
       },
       "working_directory": "C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\",
       "pe": {
-        "original_file_name": "Teams.exe"
+        "original_file_name": "Teams.exe",
+        "imphash": "00590c8fdc1f372f8db1d3f49d342d34"
       },
       "hash": {
-        "md5": "89B717809A5A49D19E7E06746982BF0B",
-        "sha1": "68D25B5F5A57CF5DC0D63644338C04EA906D472B",
-        "sha256": "2024533463DF3C945A74C774858285915FFB4E083031B51B8135BBBF5E8FC5EE"
+        "md5": "89b717809a5a49d19e7e06746982bf0b",
+        "sha1": "68d25b5f5a57cf5dc0d63644338c04ea906d472b",
+        "sha256": "2024533463df3c945a74c774858285915ffb4e083031b51b8135bbbf5e8fc5ee"
       }
     },
     "winlog": {
@@ -123,9 +124,9 @@
     },
     "related": {
       "hash": [
-        "2024533463DF3C945A74C774858285915FFB4E083031B51B8135BBBF5E8FC5EE",
-        "68D25B5F5A57CF5DC0D63644338C04EA906D472B",
-        "89B717809A5A49D19E7E06746982BF0B",
+        "2024533463df3c945a74c774858285915ffb4e083031b51b8135bbbf5e8fc5ee",
+        "68d25b5f5a57cf5dc0d63644338c04ea906d472b",
+        "89b717809a5a49d19e7e06746982bf0b",
         "bddeaca04a56e79e76ded95babeaa07f36b3935e"
       ],
       "ip": [

--- a/Beats/winlogbeat/tests/event_process_create_2.json
+++ b/Beats/winlogbeat/tests/event_process_create_2.json
@@ -1,203 +1,203 @@
 {
-    "input": {
-      "sekoiaio": {
-        "intake": {
-          "dialect": "Elastic Winlogbeat",
-          "dialect_uuid": "c10307ea-5dd1-45c6-85aa-2a6a900df99b"
-        }
-      },
-      "message": "{\n  \"winlog\": {\n    \"event_data\": {\n      \"IntegrityLevel\": \"Low\",\n      \"Product\": \"Microsoft Teams\",\n      \"Description\": \"Microsoft Teams\",\n      \"LogonId\": \"0x1234abc\",\n      \"TerminalSessionId\": \"1\",\n      \"FileVersion\": \"1.6.00.27573\",\n      \"LogonGuid\": \"{abcdef01-b1c2-d3c4-1234-123400000000}\",\n      \"Company\": \"Microsoft Corporation\",\n      \"ParentUser\": \"COMPANY\\\\asmithee\"\n    },\n    \"task\": \"Process Create (rule: ProcessCreate)\",\n    \"channel\": \"Microsoft-Windows-Sysmon/Operational\",\n    \"user\": {\n      \"name\": \"Syst\u00e8me\",\n      \"identifier\": \"S-1-2-3\",\n      \"type\": \"User\",\n      \"domain\": \"DOMAIN\"\n    },\n    \"api\": \"wineventlog\",\n    \"provider_guid\": \"{a0b1c2d3-1234-abcd-e4f5-0123456789ab}\",\n    \"process\": {\n      \"thread\": {\n        \"id\": 7248\n      },\n      \"pid\": 5624\n    },\n    \"event_id\": \"1\",\n    \"version\": 5,\n    \"computer_name\": \"PC01234567.company.com\",\n    \"record_id\": 67177799,\n    \"opcode\": \"Informations\",\n    \"provider_name\": \"Microsoft-Windows-Sysmon\"\n  },\n  \"message\": \"Process Create:\\nRuleName: technique_id=T1036,technique_name=Masquerading\\nUtcTime: 2023-10-17 12:05:25.091\\nProcessGuid: {1c03cf6e-7885-652e-190c-00000000fa00}\\nProcessId: 27804\\nImage: C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\\nFileVersion: 1.6.00.27573\\nDescription: Microsoft Teams\\nProduct: Microsoft Teams\\nCompany: Microsoft Corporation\\nOriginalFileName: Teams.exe\\nCommandLine: \\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\\\" --type=renderer --enable-wer --user-data-dir=\\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Roaming\\\\Microsoft\\\\Teams\\\" --ms-teams-less-cors=522133263 --app-user-model-id=com.squirrel.Teams.Teams --app-path=\\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\resources\\\\app.test\\\" --autoplay-policy=no-user-gesture-required --disable-background-timer-throttling --lang=fr --device-scale-factor=1.25 --num-raster-threads=4 --enable-main-frame-before-activation --renderer-client-id=196 --launch-time-ticks=17880973283 --mojo-platform-channel-handle=2520 --field-trial-handle=1808,i,7578868639254466484,17758186584081941877,131072 --enable-features=ContextBridgeMutability,SharedArrayBuffer,WinUseBrowserSpellChecker,WinUseHybridSpellChecker --disable-features=CalculateNativeWinOcclusion,ExtraCookieValidityChecks,ForcedColors,SpareRendererForSitePerProcess,WinRetrieveSuggestionsOnlyOnDemand /prefetch:1\\nCurrentDirectory: C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\\\nUser: COMPANY\\\\asmithee\\nLogonGuid: {abcdef01-b1c2-d3c4-1234-123400000000}\\nLogonId: 0x1234ABC\\nTerminalSessionId: 1\\nIntegrityLevel: Low\\nHashes: SHA1=68D25B5F5A57CF5DC0D63644338C04EA906D472B,MD5=89B717809A5A49D19E7E06746982BF0B,SHA256=2024533463DF3C945A74C774858285915FFB4E083031B51B8135BBBF5E8FC5EE,IMPHASH=00590C8FDC1F372F8DB1D3F49D342D34\\nParentProcessGuid: {1c03cf6e-331c-652e-b001-00000000fa00}\\nParentProcessId: 17772\\nParentImage: C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\\nParentCommandLine: \\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\\\" --system-initiated\\nParentUser: COMPANY\\\\asmithee\",\n  \"hash\": {\n    \"sha256\": \"2024533463df3c945a74c774858285915ffb4e083031b51b8135bbbf5e8fc5ee\",\n    \"sha1\": \"68d25b5f5a57cf5dc0d63644338c04ea906d472b\",\n    \"md5\": \"89b717809a5a49d19e7e06746982bf0b\",\n    \"imphash\": \"00590c8fdc1f372f8db1d3f49d342d34\"\n  },\n  \"event_ingest_logstash\": \"2023-10-17T12:05:27.363678Z\",\n  \"fields.gdp-logstash\": \"6\",\n  \"user\": {\n    \"name\": \"asmithee\",\n    \"id\": \"S-1-2-3\",\n    \"domain\": \"COMPANY\"\n  },\n  \"event\": {\n    \"created\": \"2023-10-17T12:05:26.268Z\",\n    \"kind\": \"event\",\n    \"provider\": \"Microsoft-Windows-Sysmon\",\n    \"category\": [\n      \"process\"\n    ],\n    \"code\": \"1\",\n    \"module\": \"sysmon\",\n    \"action\": \"Process Create (rule: ProcessCreate)\",\n    \"type\": [\n      \"start\",\n      \"process_start\"\n    ]\n  },\n  \"process\": {\n    \"name\": \"Teams.exe\",\n    \"args\": [\n      \"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\",\n      \"--type=renderer\",\n      \"--enable-wer\",\n      \"--user-data-dir=C:\\\\Users\\\\asmithee\\\\AppData\\\\Roaming\\\\Microsoft\\\\Teams\",\n      \"--ms-teams-less-cors=522133263\",\n      \"--app-user-model-id=com.squirrel.Teams.Teams\",\n      \"--app-path=C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\resources\\\\app.test\",\n      \"--autoplay-policy=no-user-gesture-required\",\n      \"--disable-background-timer-throttling\",\n      \"--lang=fr\",\n      \"--device-scale-factor=1.25\",\n      \"--num-raster-threads=4\",\n      \"--enable-main-frame-before-activation\",\n      \"--renderer-client-id=196\",\n      \"--launch-time-ticks=17880973283\",\n      \"--mojo-platform-channel-handle=2520\",\n      \"--field-trial-handle=1808,i,7578868639254466484,17758186584081941877,131072\",\n      \"--enable-features=ContextBridgeMutability,SharedArrayBuffer,WinUseBrowserSpellChecker,WinUseHybridSpellChecker\",\n      \"--disable-features=CalculateNativeWinOcclusion,ExtraCookieValidityChecks,ForcedColors,SpareRendererForSitePerProcess,WinRetrieveSuggestionsOnlyOnDemand\",\n      \"/prefetch:1\"\n    ],\n    \"hash\": {\n      \"sha256\": \"2024533463df3c945a74c774858285915ffb4e083031b51b8135bbbf5e8fc5ee\",\n      \"sha1\": \"68d25b5f5a57cf5dc0d63644338c04ea906d472b\",\n      \"md5\": \"89b717809a5a49d19e7e06746982bf0b\"\n    },\n    \"entity_id\": \"{abcdef01-2345-6789-abcd-000000000000}\",\n    \"command_line\": \"\\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\\\" --type=renderer --enable-wer --user-data-dir=\\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Roaming\\\\Microsoft\\\\Teams\\\" --ms-teams-less-cors=522133263 --app-user-model-id=com.squirrel.Teams.Teams --app-path=\\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\resources\\\\app.test\\\" --autoplay-policy=no-user-gesture-required --disable-background-timer-throttling --lang=fr --device-scale-factor=1.25 --num-raster-threads=4 --enable-main-frame-before-activation --renderer-client-id=196 --launch-time-ticks=17880973283 --mojo-platform-channel-handle=2520 --field-trial-handle=1808,i,7578868639254466484,17758186584081941877,131072 --enable-features=ContextBridgeMutability,SharedArrayBuffer,WinUseBrowserSpellChecker,WinUseHybridSpellChecker --disable-features=CalculateNativeWinOcclusion,ExtraCookieValidityChecks,ForcedColors,SpareRendererForSitePerProcess,WinRetrieveSuggestionsOnlyOnDemand /prefetch:1\",\n    \"pe\": {\n      \"description\": \"Microsoft Teams\",\n      \"company\": \"Microsoft Corporation\",\n      \"file_version\": \"1.6.00.27573\",\n      \"imphash\": \"00590c8fdc1f372f8db1d3f49d342d34\",\n      \"original_file_name\": \"Teams.exe\",\n      \"product\": \"Microsoft Teams\"\n    },\n    \"parent\": {\n      \"name\": \"Teams.exe\",\n      \"args\": [\n        \"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\",\n        \"--system-initiated\"\n      ],\n      \"entity_id\": \"{abcdef01-2345-6789-abcd-000000000000}\",\n      \"command_line\": \"\\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\\\" --system-initiated\",\n      \"pid\": 17772,\n      \"executable\": \"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\"\n    },\n    \"pid\": 27804,\n    \"working_directory\": \"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\\",\n    \"executable\": \"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\"\n  },\n  \"@version\": \"1\",\n  \"log\": {\n    \"level\": \"information\"\n  },\n  \"rule\": {\n    \"name\": \"technique_id=T1036,technique_name=Masquerading\"\n  },\n  \"related\": {\n    \"hash\": [\n      \"68d25b5f5a57cf5dc0d63644338c04ea906d472b\",\n      \"89b717809a5a49d19e7e06746982bf0b\",\n      \"2024533463df3c945a74c774858285915ffb4e083031b51b8135bbbf5e8fc5ee\",\n      \"00590c8fdc1f372f8db1d3f49d342d34\"\n    ],\n    \"user\": \"asmithee\"\n  },\n  \"ecs\": {\n    \"version\": \"1.12.0\"\n  },\n  \"@timestamp\": \"2023-10-17T12:05:25.091Z\",\n  \"fields\": {\n    \"gdp-version-sysmon\": 13.33,\n    \"gdp-version-winlogbeat\": 2.8,\n    \"gdp-indice\": \"l-desk\",\n    \"gdp-sousparc\": \"prod\",\n    \"gdp-config\": \"desktop\",\n    \"gdp-version\": \"1.16\",\n    \"gdp-parc\": \"defaut\"\n  },\n  \"host\": {\n    \"id\": \"a0b1c2d3-0123-abcd-0a1b-abcd0123ef45\",\n    \"name\": \"PC01234567.company.com\",\n    \"mac\": [\n      \"00:11:22:33:44:55\",\n      \"aa:bb:cc:dd:ee:ff\",\n      \"a0:b1:c2:d3:e4:f5\",\n      \"66:77:88:99:00:11\",\n      \"01:23:45:67:89:ab\",\n      \"ab:cd:ef:01:23:45\"\n    ],\n    \"os\": {\n      \"platform\": \"windows\",\n      \"name\": \"Windows 10 Enterprise\",\n      \"version\": \"10.0\",\n      \"kernel\": \"10.0.19041.3570 (WinBuild.160101.0800)\",\n      \"build\": \"19044.3570\",\n      \"type\": \"windows\",\n      \"family\": \"windows\"\n    },\n    \"hostname\": \"PC01234567\",\n    \"architecture\": \"x86_64\",\n    \"ip\": [\n      \"a123::b234:c345:d456:e567\",\n      \"8.8.8.8\",\n      \"abcd::ef01:2345:6789:abcd\",\n      \"1.2.3.4\",\n      \"a0b1::c2d3:e4f5:0123:abcd\",\n      \"10.20.30.40\",\n      \"aabb::ccdd:eeff:0011:2233\",\n      \"0.0.0.0\",\n      \"1122::3344:5566:7788:9900\",\n      \"5.6.7.8\",\n      \"0011::2233:4455:6677:8899\",\n      \"40.30.20.10\"\n    ]\n  },\n  \"tags\": [\n    \"beats_input_codec_plain_applied\"\n  ],\n  \"agent\": {\n    \"id\": \"001234567-abcd-ef01-2345-6789abcdef01\",\n    \"name\": \"WB-DK-PC01234567\",\n    \"version\": \"7.17.1\",\n    \"ephemeral_id\": \"a0b1c2d3-0123-4567-abcd-e4f5a6b7c8d9\",\n    \"hostname\": \"PC01234567\",\n    \"type\": \"winlogbeat\"\n  }\n}"
+  "input": {
+    "sekoiaio": {
+      "intake": {
+        "dialect": "Elastic Winlogbeat",
+        "dialect_uuid": "c10307ea-5dd1-45c6-85aa-2a6a900df99b"
+      }
     },
-    "expected": {
-      "message": "{\n  \"winlog\": {\n    \"event_data\": {\n      \"IntegrityLevel\": \"Low\",\n      \"Product\": \"Microsoft Teams\",\n      \"Description\": \"Microsoft Teams\",\n      \"LogonId\": \"0x1234abc\",\n      \"TerminalSessionId\": \"1\",\n      \"FileVersion\": \"1.6.00.27573\",\n      \"LogonGuid\": \"{abcdef01-b1c2-d3c4-1234-123400000000}\",\n      \"Company\": \"Microsoft Corporation\",\n      \"ParentUser\": \"COMPANY\\\\asmithee\"\n    },\n    \"task\": \"Process Create (rule: ProcessCreate)\",\n    \"channel\": \"Microsoft-Windows-Sysmon/Operational\",\n    \"user\": {\n      \"name\": \"Syst\u00e8me\",\n      \"identifier\": \"S-1-2-3\",\n      \"type\": \"User\",\n      \"domain\": \"DOMAIN\"\n    },\n    \"api\": \"wineventlog\",\n    \"provider_guid\": \"{a0b1c2d3-1234-abcd-e4f5-0123456789ab}\",\n    \"process\": {\n      \"thread\": {\n        \"id\": 7248\n      },\n      \"pid\": 5624\n    },\n    \"event_id\": \"1\",\n    \"version\": 5,\n    \"computer_name\": \"PC01234567.company.com\",\n    \"record_id\": 67177799,\n    \"opcode\": \"Informations\",\n    \"provider_name\": \"Microsoft-Windows-Sysmon\"\n  },\n  \"message\": \"Process Create:\\nRuleName: technique_id=T1036,technique_name=Masquerading\\nUtcTime: 2023-10-17 12:05:25.091\\nProcessGuid: {1c03cf6e-7885-652e-190c-00000000fa00}\\nProcessId: 27804\\nImage: C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\\nFileVersion: 1.6.00.27573\\nDescription: Microsoft Teams\\nProduct: Microsoft Teams\\nCompany: Microsoft Corporation\\nOriginalFileName: Teams.exe\\nCommandLine: \\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\\\" --type=renderer --enable-wer --user-data-dir=\\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Roaming\\\\Microsoft\\\\Teams\\\" --ms-teams-less-cors=522133263 --app-user-model-id=com.squirrel.Teams.Teams --app-path=\\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\resources\\\\app.test\\\" --autoplay-policy=no-user-gesture-required --disable-background-timer-throttling --lang=fr --device-scale-factor=1.25 --num-raster-threads=4 --enable-main-frame-before-activation --renderer-client-id=196 --launch-time-ticks=17880973283 --mojo-platform-channel-handle=2520 --field-trial-handle=1808,i,7578868639254466484,17758186584081941877,131072 --enable-features=ContextBridgeMutability,SharedArrayBuffer,WinUseBrowserSpellChecker,WinUseHybridSpellChecker --disable-features=CalculateNativeWinOcclusion,ExtraCookieValidityChecks,ForcedColors,SpareRendererForSitePerProcess,WinRetrieveSuggestionsOnlyOnDemand /prefetch:1\\nCurrentDirectory: C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\\\nUser: COMPANY\\\\asmithee\\nLogonGuid: {abcdef01-b1c2-d3c4-1234-123400000000}\\nLogonId: 0x1234ABC\\nTerminalSessionId: 1\\nIntegrityLevel: Low\\nHashes: SHA1=68D25B5F5A57CF5DC0D63644338C04EA906D472B,MD5=89B717809A5A49D19E7E06746982BF0B,SHA256=2024533463DF3C945A74C774858285915FFB4E083031B51B8135BBBF5E8FC5EE,IMPHASH=00590C8FDC1F372F8DB1D3F49D342D34\\nParentProcessGuid: {1c03cf6e-331c-652e-b001-00000000fa00}\\nParentProcessId: 17772\\nParentImage: C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\\nParentCommandLine: \\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\\\" --system-initiated\\nParentUser: COMPANY\\\\asmithee\",\n  \"hash\": {\n    \"sha256\": \"2024533463df3c945a74c774858285915ffb4e083031b51b8135bbbf5e8fc5ee\",\n    \"sha1\": \"68d25b5f5a57cf5dc0d63644338c04ea906d472b\",\n    \"md5\": \"89b717809a5a49d19e7e06746982bf0b\",\n    \"imphash\": \"00590c8fdc1f372f8db1d3f49d342d34\"\n  },\n  \"event_ingest_logstash\": \"2023-10-17T12:05:27.363678Z\",\n  \"fields.gdp-logstash\": \"6\",\n  \"user\": {\n    \"name\": \"asmithee\",\n    \"id\": \"S-1-2-3\",\n    \"domain\": \"COMPANY\"\n  },\n  \"event\": {\n    \"created\": \"2023-10-17T12:05:26.268Z\",\n    \"kind\": \"event\",\n    \"provider\": \"Microsoft-Windows-Sysmon\",\n    \"category\": [\n      \"process\"\n    ],\n    \"code\": \"1\",\n    \"module\": \"sysmon\",\n    \"action\": \"Process Create (rule: ProcessCreate)\",\n    \"type\": [\n      \"start\",\n      \"process_start\"\n    ]\n  },\n  \"process\": {\n    \"name\": \"Teams.exe\",\n    \"args\": [\n      \"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\",\n      \"--type=renderer\",\n      \"--enable-wer\",\n      \"--user-data-dir=C:\\\\Users\\\\asmithee\\\\AppData\\\\Roaming\\\\Microsoft\\\\Teams\",\n      \"--ms-teams-less-cors=522133263\",\n      \"--app-user-model-id=com.squirrel.Teams.Teams\",\n      \"--app-path=C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\resources\\\\app.test\",\n      \"--autoplay-policy=no-user-gesture-required\",\n      \"--disable-background-timer-throttling\",\n      \"--lang=fr\",\n      \"--device-scale-factor=1.25\",\n      \"--num-raster-threads=4\",\n      \"--enable-main-frame-before-activation\",\n      \"--renderer-client-id=196\",\n      \"--launch-time-ticks=17880973283\",\n      \"--mojo-platform-channel-handle=2520\",\n      \"--field-trial-handle=1808,i,7578868639254466484,17758186584081941877,131072\",\n      \"--enable-features=ContextBridgeMutability,SharedArrayBuffer,WinUseBrowserSpellChecker,WinUseHybridSpellChecker\",\n      \"--disable-features=CalculateNativeWinOcclusion,ExtraCookieValidityChecks,ForcedColors,SpareRendererForSitePerProcess,WinRetrieveSuggestionsOnlyOnDemand\",\n      \"/prefetch:1\"\n    ],\n    \"hash\": {\n      \"sha256\": \"2024533463df3c945a74c774858285915ffb4e083031b51b8135bbbf5e8fc5ee\",\n      \"sha1\": \"68d25b5f5a57cf5dc0d63644338c04ea906d472b\",\n      \"md5\": \"89b717809a5a49d19e7e06746982bf0b\"\n    },\n    \"entity_id\": \"{abcdef01-2345-6789-abcd-000000000000}\",\n    \"command_line\": \"\\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\\\" --type=renderer --enable-wer --user-data-dir=\\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Roaming\\\\Microsoft\\\\Teams\\\" --ms-teams-less-cors=522133263 --app-user-model-id=com.squirrel.Teams.Teams --app-path=\\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\resources\\\\app.test\\\" --autoplay-policy=no-user-gesture-required --disable-background-timer-throttling --lang=fr --device-scale-factor=1.25 --num-raster-threads=4 --enable-main-frame-before-activation --renderer-client-id=196 --launch-time-ticks=17880973283 --mojo-platform-channel-handle=2520 --field-trial-handle=1808,i,7578868639254466484,17758186584081941877,131072 --enable-features=ContextBridgeMutability,SharedArrayBuffer,WinUseBrowserSpellChecker,WinUseHybridSpellChecker --disable-features=CalculateNativeWinOcclusion,ExtraCookieValidityChecks,ForcedColors,SpareRendererForSitePerProcess,WinRetrieveSuggestionsOnlyOnDemand /prefetch:1\",\n    \"pe\": {\n      \"description\": \"Microsoft Teams\",\n      \"company\": \"Microsoft Corporation\",\n      \"file_version\": \"1.6.00.27573\",\n      \"imphash\": \"00590c8fdc1f372f8db1d3f49d342d34\",\n      \"original_file_name\": \"Teams.exe\",\n      \"product\": \"Microsoft Teams\"\n    },\n    \"parent\": {\n      \"name\": \"Teams.exe\",\n      \"args\": [\n        \"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\",\n        \"--system-initiated\"\n      ],\n      \"entity_id\": \"{abcdef01-2345-6789-abcd-000000000000}\",\n      \"command_line\": \"\\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\\\" --system-initiated\",\n      \"pid\": 17772,\n      \"executable\": \"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\"\n    },\n    \"pid\": 27804,\n    \"working_directory\": \"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\\",\n    \"executable\": \"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\"\n  },\n  \"@version\": \"1\",\n  \"log\": {\n    \"level\": \"information\"\n  },\n  \"rule\": {\n    \"name\": \"technique_id=T1036,technique_name=Masquerading\"\n  },\n  \"related\": {\n    \"hash\": [\n      \"68d25b5f5a57cf5dc0d63644338c04ea906d472b\",\n      \"89b717809a5a49d19e7e06746982bf0b\",\n      \"2024533463df3c945a74c774858285915ffb4e083031b51b8135bbbf5e8fc5ee\",\n      \"00590c8fdc1f372f8db1d3f49d342d34\"\n    ],\n    \"user\": \"asmithee\"\n  },\n  \"ecs\": {\n    \"version\": \"1.12.0\"\n  },\n  \"@timestamp\": \"2023-10-17T12:05:25.091Z\",\n  \"fields\": {\n    \"gdp-version-sysmon\": 13.33,\n    \"gdp-version-winlogbeat\": 2.8,\n    \"gdp-indice\": \"l-desk\",\n    \"gdp-sousparc\": \"prod\",\n    \"gdp-config\": \"desktop\",\n    \"gdp-version\": \"1.16\",\n    \"gdp-parc\": \"defaut\"\n  },\n  \"host\": {\n    \"id\": \"a0b1c2d3-0123-abcd-0a1b-abcd0123ef45\",\n    \"name\": \"PC01234567.company.com\",\n    \"mac\": [\n      \"00:11:22:33:44:55\",\n      \"aa:bb:cc:dd:ee:ff\",\n      \"a0:b1:c2:d3:e4:f5\",\n      \"66:77:88:99:00:11\",\n      \"01:23:45:67:89:ab\",\n      \"ab:cd:ef:01:23:45\"\n    ],\n    \"os\": {\n      \"platform\": \"windows\",\n      \"name\": \"Windows 10 Enterprise\",\n      \"version\": \"10.0\",\n      \"kernel\": \"10.0.19041.3570 (WinBuild.160101.0800)\",\n      \"build\": \"19044.3570\",\n      \"type\": \"windows\",\n      \"family\": \"windows\"\n    },\n    \"hostname\": \"PC01234567\",\n    \"architecture\": \"x86_64\",\n    \"ip\": [\n      \"a123::b234:c345:d456:e567\",\n      \"8.8.8.8\",\n      \"abcd::ef01:2345:6789:abcd\",\n      \"1.2.3.4\",\n      \"a0b1::c2d3:e4f5:0123:abcd\",\n      \"10.20.30.40\",\n      \"aabb::ccdd:eeff:0011:2233\",\n      \"0.0.0.0\",\n      \"1122::3344:5566:7788:9900\",\n      \"5.6.7.8\",\n      \"0011::2233:4455:6677:8899\",\n      \"40.30.20.10\"\n    ]\n  },\n  \"tags\": [\n    \"beats_input_codec_plain_applied\"\n  ],\n  \"agent\": {\n    \"id\": \"001234567-abcd-ef01-2345-6789abcdef01\",\n    \"name\": \"WB-DK-PC01234567\",\n    \"version\": \"7.17.1\",\n    \"ephemeral_id\": \"a0b1c2d3-0123-4567-abcd-e4f5a6b7c8d9\",\n    \"hostname\": \"PC01234567\",\n    \"type\": \"winlogbeat\"\n  }\n}",
-      "event": {
-        "action": "Process Create (rule: ProcessCreate)",
-        "category": [
-          "process"
-        ],
-        "code": "1",
-        "kind": "event",
-        "module": "sysmon",
-        "provider": "Microsoft-Windows-Sysmon",
-        "type": [
-          "start",
-          "process_start"
-        ],
-        "original": "Process Create:\nRuleName: technique_id=T1036,technique_name=Masquerading\nUtcTime: 2023-10-17 12:05:25.091\nProcessGuid: {1c03cf6e-7885-652e-190c-00000000fa00}\nProcessId: 27804\nImage: C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\Teams.exe\nFileVersion: 1.6.00.27573\nDescription: Microsoft Teams\nProduct: Microsoft Teams\nCompany: Microsoft Corporation\nOriginalFileName: Teams.exe\nCommandLine: \"C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\Teams.exe\" --type=renderer --enable-wer --user-data-dir=\"C:\\Users\\asmithee\\AppData\\Roaming\\Microsoft\\Teams\" --ms-teams-less-cors=522133263 --app-user-model-id=com.squirrel.Teams.Teams --app-path=\"C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\resources\\app.test\" --autoplay-policy=no-user-gesture-required --disable-background-timer-throttling --lang=fr --device-scale-factor=1.25 --num-raster-threads=4 --enable-main-frame-before-activation --renderer-client-id=196 --launch-time-ticks=17880973283 --mojo-platform-channel-handle=2520 --field-trial-handle=1808,i,7578868639254466484,17758186584081941877,131072 --enable-features=ContextBridgeMutability,SharedArrayBuffer,WinUseBrowserSpellChecker,WinUseHybridSpellChecker --disable-features=CalculateNativeWinOcclusion,ExtraCookieValidityChecks,ForcedColors,SpareRendererForSitePerProcess,WinRetrieveSuggestionsOnlyOnDemand /prefetch:1\nCurrentDirectory: C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\\nUser: COMPANY\\asmithee\nLogonGuid: {abcdef01-b1c2-d3c4-1234-123400000000}\nLogonId: 0x1234ABC\nTerminalSessionId: 1\nIntegrityLevel: Low\nHashes: SHA1=68D25B5F5A57CF5DC0D63644338C04EA906D472B,MD5=89B717809A5A49D19E7E06746982BF0B,SHA256=2024533463DF3C945A74C774858285915FFB4E083031B51B8135BBBF5E8FC5EE,IMPHASH=00590C8FDC1F372F8DB1D3F49D342D34\nParentProcessGuid: {1c03cf6e-331c-652e-b001-00000000fa00}\nParentProcessId: 17772\nParentImage: C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\Teams.exe\nParentCommandLine: \"C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\Teams.exe\" --system-initiated\nParentUser: COMPANY\\asmithee",
-        "hash": "3a94cc250153d9666fad8106848c0359d8b887d6"
+    "message": "{\n  \"winlog\": {\n    \"event_data\": {\n      \"IntegrityLevel\": \"Low\",\n      \"Product\": \"Microsoft Teams\",\n      \"Description\": \"Microsoft Teams\",\n      \"LogonId\": \"0x1234abc\",\n      \"TerminalSessionId\": \"1\",\n      \"FileVersion\": \"1.6.00.27573\",\n      \"LogonGuid\": \"{abcdef01-b1c2-d3c4-1234-123400000000}\",\n      \"Company\": \"Microsoft Corporation\",\n      \"ParentUser\": \"COMPANY\\\\asmithee\"\n    },\n    \"task\": \"Process Create (rule: ProcessCreate)\",\n    \"channel\": \"Microsoft-Windows-Sysmon/Operational\",\n    \"user\": {\n      \"name\": \"Syst\u00e8me\",\n      \"identifier\": \"S-1-2-3\",\n      \"type\": \"User\",\n      \"domain\": \"DOMAIN\"\n    },\n    \"api\": \"wineventlog\",\n    \"provider_guid\": \"{a0b1c2d3-1234-abcd-e4f5-0123456789ab}\",\n    \"process\": {\n      \"thread\": {\n        \"id\": 7248\n      },\n      \"pid\": 5624\n    },\n    \"event_id\": \"1\",\n    \"version\": 5,\n    \"computer_name\": \"PC01234567.company.com\",\n    \"record_id\": 67177799,\n    \"opcode\": \"Informations\",\n    \"provider_name\": \"Microsoft-Windows-Sysmon\"\n  },\n  \"message\": \"Process Create:\\nRuleName: technique_id=T1036,technique_name=Masquerading\\nUtcTime: 2023-10-17 12:05:25.091\\nProcessGuid: {1c03cf6e-7885-652e-190c-00000000fa00}\\nProcessId: 27804\\nImage: C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\\nFileVersion: 1.6.00.27573\\nDescription: Microsoft Teams\\nProduct: Microsoft Teams\\nCompany: Microsoft Corporation\\nOriginalFileName: Teams.exe\\nCommandLine: \\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\\\" --type=renderer --enable-wer --user-data-dir=\\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Roaming\\\\Microsoft\\\\Teams\\\" --ms-teams-less-cors=522133263 --app-user-model-id=com.squirrel.Teams.Teams --app-path=\\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\resources\\\\app.test\\\" --autoplay-policy=no-user-gesture-required --disable-background-timer-throttling --lang=fr --device-scale-factor=1.25 --num-raster-threads=4 --enable-main-frame-before-activation --renderer-client-id=196 --launch-time-ticks=17880973283 --mojo-platform-channel-handle=2520 --field-trial-handle=1808,i,7578868639254466484,17758186584081941877,131072 --enable-features=ContextBridgeMutability,SharedArrayBuffer,WinUseBrowserSpellChecker,WinUseHybridSpellChecker --disable-features=CalculateNativeWinOcclusion,ExtraCookieValidityChecks,ForcedColors,SpareRendererForSitePerProcess,WinRetrieveSuggestionsOnlyOnDemand /prefetch:1\\nCurrentDirectory: C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\\\nUser: COMPANY\\\\asmithee\\nLogonGuid: {abcdef01-b1c2-d3c4-1234-123400000000}\\nLogonId: 0x1234ABC\\nTerminalSessionId: 1\\nIntegrityLevel: Low\\nHashes: SHA1=68D25B5F5A57CF5DC0D63644338C04EA906D472B,MD5=89B717809A5A49D19E7E06746982BF0B,SHA256=2024533463DF3C945A74C774858285915FFB4E083031B51B8135BBBF5E8FC5EE,IMPHASH=00590C8FDC1F372F8DB1D3F49D342D34\\nParentProcessGuid: {1c03cf6e-331c-652e-b001-00000000fa00}\\nParentProcessId: 17772\\nParentImage: C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\\nParentCommandLine: \\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\\\" --system-initiated\\nParentUser: COMPANY\\\\asmithee\",\n  \"hash\": {\n    \"sha256\": \"2024533463df3c945a74c774858285915ffb4e083031b51b8135bbbf5e8fc5ee\",\n    \"sha1\": \"68d25b5f5a57cf5dc0d63644338c04ea906d472b\",\n    \"md5\": \"89b717809a5a49d19e7e06746982bf0b\",\n    \"imphash\": \"00590c8fdc1f372f8db1d3f49d342d34\"\n  },\n  \"event_ingest_logstash\": \"2023-10-17T12:05:27.363678Z\",\n  \"fields.gdp-logstash\": \"6\",\n  \"user\": {\n    \"name\": \"asmithee\",\n    \"id\": \"S-1-2-3\",\n    \"domain\": \"COMPANY\"\n  },\n  \"event\": {\n    \"created\": \"2023-10-17T12:05:26.268Z\",\n    \"kind\": \"event\",\n    \"provider\": \"Microsoft-Windows-Sysmon\",\n    \"category\": [\n      \"process\"\n    ],\n    \"code\": \"1\",\n    \"module\": \"sysmon\",\n    \"action\": \"Process Create (rule: ProcessCreate)\",\n    \"type\": [\n      \"start\",\n      \"process_start\"\n    ]\n  },\n  \"process\": {\n    \"name\": \"Teams.exe\",\n    \"args\": [\n      \"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\",\n      \"--type=renderer\",\n      \"--enable-wer\",\n      \"--user-data-dir=C:\\\\Users\\\\asmithee\\\\AppData\\\\Roaming\\\\Microsoft\\\\Teams\",\n      \"--ms-teams-less-cors=522133263\",\n      \"--app-user-model-id=com.squirrel.Teams.Teams\",\n      \"--app-path=C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\resources\\\\app.test\",\n      \"--autoplay-policy=no-user-gesture-required\",\n      \"--disable-background-timer-throttling\",\n      \"--lang=fr\",\n      \"--device-scale-factor=1.25\",\n      \"--num-raster-threads=4\",\n      \"--enable-main-frame-before-activation\",\n      \"--renderer-client-id=196\",\n      \"--launch-time-ticks=17880973283\",\n      \"--mojo-platform-channel-handle=2520\",\n      \"--field-trial-handle=1808,i,7578868639254466484,17758186584081941877,131072\",\n      \"--enable-features=ContextBridgeMutability,SharedArrayBuffer,WinUseBrowserSpellChecker,WinUseHybridSpellChecker\",\n      \"--disable-features=CalculateNativeWinOcclusion,ExtraCookieValidityChecks,ForcedColors,SpareRendererForSitePerProcess,WinRetrieveSuggestionsOnlyOnDemand\",\n      \"/prefetch:1\"\n    ],\n    \"hash\": {\n      \"sha256\": \"2024533463df3c945a74c774858285915ffb4e083031b51b8135bbbf5e8fc5ee\",\n      \"sha1\": \"68d25b5f5a57cf5dc0d63644338c04ea906d472b\",\n      \"md5\": \"89b717809a5a49d19e7e06746982bf0b\"\n    },\n    \"entity_id\": \"{abcdef01-2345-6789-abcd-000000000000}\",\n    \"command_line\": \"\\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\\\" --type=renderer --enable-wer --user-data-dir=\\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Roaming\\\\Microsoft\\\\Teams\\\" --ms-teams-less-cors=522133263 --app-user-model-id=com.squirrel.Teams.Teams --app-path=\\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\resources\\\\app.test\\\" --autoplay-policy=no-user-gesture-required --disable-background-timer-throttling --lang=fr --device-scale-factor=1.25 --num-raster-threads=4 --enable-main-frame-before-activation --renderer-client-id=196 --launch-time-ticks=17880973283 --mojo-platform-channel-handle=2520 --field-trial-handle=1808,i,7578868639254466484,17758186584081941877,131072 --enable-features=ContextBridgeMutability,SharedArrayBuffer,WinUseBrowserSpellChecker,WinUseHybridSpellChecker --disable-features=CalculateNativeWinOcclusion,ExtraCookieValidityChecks,ForcedColors,SpareRendererForSitePerProcess,WinRetrieveSuggestionsOnlyOnDemand /prefetch:1\",\n    \"pe\": {\n      \"description\": \"Microsoft Teams\",\n      \"company\": \"Microsoft Corporation\",\n      \"file_version\": \"1.6.00.27573\",\n      \"imphash\": \"00590c8fdc1f372f8db1d3f49d342d34\",\n      \"original_file_name\": \"Teams.exe\",\n      \"product\": \"Microsoft Teams\"\n    },\n    \"parent\": {\n      \"name\": \"Teams.exe\",\n      \"args\": [\n        \"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\",\n        \"--system-initiated\"\n      ],\n      \"entity_id\": \"{abcdef01-2345-6789-abcd-000000000000}\",\n      \"command_line\": \"\\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\\\" --system-initiated\",\n      \"pid\": 17772,\n      \"executable\": \"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\"\n    },\n    \"pid\": 27804,\n    \"working_directory\": \"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\\",\n    \"executable\": \"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\"\n  },\n  \"@version\": \"1\",\n  \"log\": {\n    \"level\": \"information\"\n  },\n  \"rule\": {\n    \"name\": \"technique_id=T1036,technique_name=Masquerading\"\n  },\n  \"related\": {\n    \"hash\": [\n      \"68d25b5f5a57cf5dc0d63644338c04ea906d472b\",\n      \"89b717809a5a49d19e7e06746982bf0b\",\n      \"2024533463df3c945a74c774858285915ffb4e083031b51b8135bbbf5e8fc5ee\",\n      \"00590c8fdc1f372f8db1d3f49d342d34\"\n    ],\n    \"user\": \"asmithee\"\n  },\n  \"ecs\": {\n    \"version\": \"1.12.0\"\n  },\n  \"@timestamp\": \"2023-10-17T12:05:25.091Z\",\n  \"fields\": {\n    \"gdp-version-sysmon\": 13.33,\n    \"gdp-version-winlogbeat\": 2.8,\n    \"gdp-indice\": \"l-desk\",\n    \"gdp-sousparc\": \"prod\",\n    \"gdp-config\": \"desktop\",\n    \"gdp-version\": \"1.16\",\n    \"gdp-parc\": \"defaut\"\n  },\n  \"host\": {\n    \"id\": \"a0b1c2d3-0123-abcd-0a1b-abcd0123ef45\",\n    \"name\": \"PC01234567.company.com\",\n    \"mac\": [\n      \"00:11:22:33:44:55\",\n      \"aa:bb:cc:dd:ee:ff\",\n      \"a0:b1:c2:d3:e4:f5\",\n      \"66:77:88:99:00:11\",\n      \"01:23:45:67:89:ab\",\n      \"ab:cd:ef:01:23:45\"\n    ],\n    \"os\": {\n      \"platform\": \"windows\",\n      \"name\": \"Windows 10 Enterprise\",\n      \"version\": \"10.0\",\n      \"kernel\": \"10.0.19041.3570 (WinBuild.160101.0800)\",\n      \"build\": \"19044.3570\",\n      \"type\": \"windows\",\n      \"family\": \"windows\"\n    },\n    \"hostname\": \"PC01234567\",\n    \"architecture\": \"x86_64\",\n    \"ip\": [\n      \"a123::b234:c345:d456:e567\",\n      \"8.8.8.8\",\n      \"abcd::ef01:2345:6789:abcd\",\n      \"1.2.3.4\",\n      \"a0b1::c2d3:e4f5:0123:abcd\",\n      \"10.20.30.40\",\n      \"aabb::ccdd:eeff:0011:2233\",\n      \"0.0.0.0\",\n      \"1122::3344:5566:7788:9900\",\n      \"5.6.7.8\",\n      \"0011::2233:4455:6677:8899\",\n      \"40.30.20.10\"\n    ]\n  },\n  \"tags\": [\n    \"beats_input_codec_plain_applied\"\n  ],\n  \"agent\": {\n    \"id\": \"001234567-abcd-ef01-2345-6789abcdef01\",\n    \"name\": \"WB-DK-PC01234567\",\n    \"version\": \"7.17.1\",\n    \"ephemeral_id\": \"a0b1c2d3-0123-4567-abcd-e4f5a6b7c8d9\",\n    \"hostname\": \"PC01234567\",\n    \"type\": \"winlogbeat\"\n  }\n}"
+  },
+  "expected": {
+    "message": "{\n  \"winlog\": {\n    \"event_data\": {\n      \"IntegrityLevel\": \"Low\",\n      \"Product\": \"Microsoft Teams\",\n      \"Description\": \"Microsoft Teams\",\n      \"LogonId\": \"0x1234abc\",\n      \"TerminalSessionId\": \"1\",\n      \"FileVersion\": \"1.6.00.27573\",\n      \"LogonGuid\": \"{abcdef01-b1c2-d3c4-1234-123400000000}\",\n      \"Company\": \"Microsoft Corporation\",\n      \"ParentUser\": \"COMPANY\\\\asmithee\"\n    },\n    \"task\": \"Process Create (rule: ProcessCreate)\",\n    \"channel\": \"Microsoft-Windows-Sysmon/Operational\",\n    \"user\": {\n      \"name\": \"Syst\u00e8me\",\n      \"identifier\": \"S-1-2-3\",\n      \"type\": \"User\",\n      \"domain\": \"DOMAIN\"\n    },\n    \"api\": \"wineventlog\",\n    \"provider_guid\": \"{a0b1c2d3-1234-abcd-e4f5-0123456789ab}\",\n    \"process\": {\n      \"thread\": {\n        \"id\": 7248\n      },\n      \"pid\": 5624\n    },\n    \"event_id\": \"1\",\n    \"version\": 5,\n    \"computer_name\": \"PC01234567.company.com\",\n    \"record_id\": 67177799,\n    \"opcode\": \"Informations\",\n    \"provider_name\": \"Microsoft-Windows-Sysmon\"\n  },\n  \"message\": \"Process Create:\\nRuleName: technique_id=T1036,technique_name=Masquerading\\nUtcTime: 2023-10-17 12:05:25.091\\nProcessGuid: {1c03cf6e-7885-652e-190c-00000000fa00}\\nProcessId: 27804\\nImage: C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\\nFileVersion: 1.6.00.27573\\nDescription: Microsoft Teams\\nProduct: Microsoft Teams\\nCompany: Microsoft Corporation\\nOriginalFileName: Teams.exe\\nCommandLine: \\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\\\" --type=renderer --enable-wer --user-data-dir=\\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Roaming\\\\Microsoft\\\\Teams\\\" --ms-teams-less-cors=522133263 --app-user-model-id=com.squirrel.Teams.Teams --app-path=\\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\resources\\\\app.test\\\" --autoplay-policy=no-user-gesture-required --disable-background-timer-throttling --lang=fr --device-scale-factor=1.25 --num-raster-threads=4 --enable-main-frame-before-activation --renderer-client-id=196 --launch-time-ticks=17880973283 --mojo-platform-channel-handle=2520 --field-trial-handle=1808,i,7578868639254466484,17758186584081941877,131072 --enable-features=ContextBridgeMutability,SharedArrayBuffer,WinUseBrowserSpellChecker,WinUseHybridSpellChecker --disable-features=CalculateNativeWinOcclusion,ExtraCookieValidityChecks,ForcedColors,SpareRendererForSitePerProcess,WinRetrieveSuggestionsOnlyOnDemand /prefetch:1\\nCurrentDirectory: C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\\\nUser: COMPANY\\\\asmithee\\nLogonGuid: {abcdef01-b1c2-d3c4-1234-123400000000}\\nLogonId: 0x1234ABC\\nTerminalSessionId: 1\\nIntegrityLevel: Low\\nHashes: SHA1=68D25B5F5A57CF5DC0D63644338C04EA906D472B,MD5=89B717809A5A49D19E7E06746982BF0B,SHA256=2024533463DF3C945A74C774858285915FFB4E083031B51B8135BBBF5E8FC5EE,IMPHASH=00590C8FDC1F372F8DB1D3F49D342D34\\nParentProcessGuid: {1c03cf6e-331c-652e-b001-00000000fa00}\\nParentProcessId: 17772\\nParentImage: C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\\nParentCommandLine: \\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\\\" --system-initiated\\nParentUser: COMPANY\\\\asmithee\",\n  \"hash\": {\n    \"sha256\": \"2024533463df3c945a74c774858285915ffb4e083031b51b8135bbbf5e8fc5ee\",\n    \"sha1\": \"68d25b5f5a57cf5dc0d63644338c04ea906d472b\",\n    \"md5\": \"89b717809a5a49d19e7e06746982bf0b\",\n    \"imphash\": \"00590c8fdc1f372f8db1d3f49d342d34\"\n  },\n  \"event_ingest_logstash\": \"2023-10-17T12:05:27.363678Z\",\n  \"fields.gdp-logstash\": \"6\",\n  \"user\": {\n    \"name\": \"asmithee\",\n    \"id\": \"S-1-2-3\",\n    \"domain\": \"COMPANY\"\n  },\n  \"event\": {\n    \"created\": \"2023-10-17T12:05:26.268Z\",\n    \"kind\": \"event\",\n    \"provider\": \"Microsoft-Windows-Sysmon\",\n    \"category\": [\n      \"process\"\n    ],\n    \"code\": \"1\",\n    \"module\": \"sysmon\",\n    \"action\": \"Process Create (rule: ProcessCreate)\",\n    \"type\": [\n      \"start\",\n      \"process_start\"\n    ]\n  },\n  \"process\": {\n    \"name\": \"Teams.exe\",\n    \"args\": [\n      \"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\",\n      \"--type=renderer\",\n      \"--enable-wer\",\n      \"--user-data-dir=C:\\\\Users\\\\asmithee\\\\AppData\\\\Roaming\\\\Microsoft\\\\Teams\",\n      \"--ms-teams-less-cors=522133263\",\n      \"--app-user-model-id=com.squirrel.Teams.Teams\",\n      \"--app-path=C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\resources\\\\app.test\",\n      \"--autoplay-policy=no-user-gesture-required\",\n      \"--disable-background-timer-throttling\",\n      \"--lang=fr\",\n      \"--device-scale-factor=1.25\",\n      \"--num-raster-threads=4\",\n      \"--enable-main-frame-before-activation\",\n      \"--renderer-client-id=196\",\n      \"--launch-time-ticks=17880973283\",\n      \"--mojo-platform-channel-handle=2520\",\n      \"--field-trial-handle=1808,i,7578868639254466484,17758186584081941877,131072\",\n      \"--enable-features=ContextBridgeMutability,SharedArrayBuffer,WinUseBrowserSpellChecker,WinUseHybridSpellChecker\",\n      \"--disable-features=CalculateNativeWinOcclusion,ExtraCookieValidityChecks,ForcedColors,SpareRendererForSitePerProcess,WinRetrieveSuggestionsOnlyOnDemand\",\n      \"/prefetch:1\"\n    ],\n    \"hash\": {\n      \"sha256\": \"2024533463df3c945a74c774858285915ffb4e083031b51b8135bbbf5e8fc5ee\",\n      \"sha1\": \"68d25b5f5a57cf5dc0d63644338c04ea906d472b\",\n      \"md5\": \"89b717809a5a49d19e7e06746982bf0b\"\n    },\n    \"entity_id\": \"{abcdef01-2345-6789-abcd-000000000000}\",\n    \"command_line\": \"\\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\\\" --type=renderer --enable-wer --user-data-dir=\\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Roaming\\\\Microsoft\\\\Teams\\\" --ms-teams-less-cors=522133263 --app-user-model-id=com.squirrel.Teams.Teams --app-path=\\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\resources\\\\app.test\\\" --autoplay-policy=no-user-gesture-required --disable-background-timer-throttling --lang=fr --device-scale-factor=1.25 --num-raster-threads=4 --enable-main-frame-before-activation --renderer-client-id=196 --launch-time-ticks=17880973283 --mojo-platform-channel-handle=2520 --field-trial-handle=1808,i,7578868639254466484,17758186584081941877,131072 --enable-features=ContextBridgeMutability,SharedArrayBuffer,WinUseBrowserSpellChecker,WinUseHybridSpellChecker --disable-features=CalculateNativeWinOcclusion,ExtraCookieValidityChecks,ForcedColors,SpareRendererForSitePerProcess,WinRetrieveSuggestionsOnlyOnDemand /prefetch:1\",\n    \"pe\": {\n      \"description\": \"Microsoft Teams\",\n      \"company\": \"Microsoft Corporation\",\n      \"file_version\": \"1.6.00.27573\",\n      \"imphash\": \"00590c8fdc1f372f8db1d3f49d342d34\",\n      \"original_file_name\": \"Teams.exe\",\n      \"product\": \"Microsoft Teams\"\n    },\n    \"parent\": {\n      \"name\": \"Teams.exe\",\n      \"args\": [\n        \"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\",\n        \"--system-initiated\"\n      ],\n      \"entity_id\": \"{abcdef01-2345-6789-abcd-000000000000}\",\n      \"command_line\": \"\\\"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\\\" --system-initiated\",\n      \"pid\": 17772,\n      \"executable\": \"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\"\n    },\n    \"pid\": 27804,\n    \"working_directory\": \"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\\",\n    \"executable\": \"C:\\\\Users\\\\asmithee\\\\AppData\\\\Local\\\\Microsoft\\\\Teams\\\\current\\\\Teams.exe\"\n  },\n  \"@version\": \"1\",\n  \"log\": {\n    \"level\": \"information\"\n  },\n  \"rule\": {\n    \"name\": \"technique_id=T1036,technique_name=Masquerading\"\n  },\n  \"related\": {\n    \"hash\": [\n      \"68d25b5f5a57cf5dc0d63644338c04ea906d472b\",\n      \"89b717809a5a49d19e7e06746982bf0b\",\n      \"2024533463df3c945a74c774858285915ffb4e083031b51b8135bbbf5e8fc5ee\",\n      \"00590c8fdc1f372f8db1d3f49d342d34\"\n    ],\n    \"user\": \"asmithee\"\n  },\n  \"ecs\": {\n    \"version\": \"1.12.0\"\n  },\n  \"@timestamp\": \"2023-10-17T12:05:25.091Z\",\n  \"fields\": {\n    \"gdp-version-sysmon\": 13.33,\n    \"gdp-version-winlogbeat\": 2.8,\n    \"gdp-indice\": \"l-desk\",\n    \"gdp-sousparc\": \"prod\",\n    \"gdp-config\": \"desktop\",\n    \"gdp-version\": \"1.16\",\n    \"gdp-parc\": \"defaut\"\n  },\n  \"host\": {\n    \"id\": \"a0b1c2d3-0123-abcd-0a1b-abcd0123ef45\",\n    \"name\": \"PC01234567.company.com\",\n    \"mac\": [\n      \"00:11:22:33:44:55\",\n      \"aa:bb:cc:dd:ee:ff\",\n      \"a0:b1:c2:d3:e4:f5\",\n      \"66:77:88:99:00:11\",\n      \"01:23:45:67:89:ab\",\n      \"ab:cd:ef:01:23:45\"\n    ],\n    \"os\": {\n      \"platform\": \"windows\",\n      \"name\": \"Windows 10 Enterprise\",\n      \"version\": \"10.0\",\n      \"kernel\": \"10.0.19041.3570 (WinBuild.160101.0800)\",\n      \"build\": \"19044.3570\",\n      \"type\": \"windows\",\n      \"family\": \"windows\"\n    },\n    \"hostname\": \"PC01234567\",\n    \"architecture\": \"x86_64\",\n    \"ip\": [\n      \"a123::b234:c345:d456:e567\",\n      \"8.8.8.8\",\n      \"abcd::ef01:2345:6789:abcd\",\n      \"1.2.3.4\",\n      \"a0b1::c2d3:e4f5:0123:abcd\",\n      \"10.20.30.40\",\n      \"aabb::ccdd:eeff:0011:2233\",\n      \"0.0.0.0\",\n      \"1122::3344:5566:7788:9900\",\n      \"5.6.7.8\",\n      \"0011::2233:4455:6677:8899\",\n      \"40.30.20.10\"\n    ]\n  },\n  \"tags\": [\n    \"beats_input_codec_plain_applied\"\n  ],\n  \"agent\": {\n    \"id\": \"001234567-abcd-ef01-2345-6789abcdef01\",\n    \"name\": \"WB-DK-PC01234567\",\n    \"version\": \"7.17.1\",\n    \"ephemeral_id\": \"a0b1c2d3-0123-4567-abcd-e4f5a6b7c8d9\",\n    \"hostname\": \"PC01234567\",\n    \"type\": \"winlogbeat\"\n  }\n}",
+    "event": {
+      "action": "Process Create (rule: ProcessCreate)",
+      "category": [
+        "process"
+      ],
+      "code": "1",
+      "kind": "event",
+      "module": "sysmon",
+      "provider": "Microsoft-Windows-Sysmon",
+      "type": [
+        "start",
+        "process_start"
+      ],
+      "original": "Process Create:\nRuleName: technique_id=T1036,technique_name=Masquerading\nUtcTime: 2023-10-17 12:05:25.091\nProcessGuid: {1c03cf6e-7885-652e-190c-00000000fa00}\nProcessId: 27804\nImage: C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\Teams.exe\nFileVersion: 1.6.00.27573\nDescription: Microsoft Teams\nProduct: Microsoft Teams\nCompany: Microsoft Corporation\nOriginalFileName: Teams.exe\nCommandLine: \"C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\Teams.exe\" --type=renderer --enable-wer --user-data-dir=\"C:\\Users\\asmithee\\AppData\\Roaming\\Microsoft\\Teams\" --ms-teams-less-cors=522133263 --app-user-model-id=com.squirrel.Teams.Teams --app-path=\"C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\resources\\app.test\" --autoplay-policy=no-user-gesture-required --disable-background-timer-throttling --lang=fr --device-scale-factor=1.25 --num-raster-threads=4 --enable-main-frame-before-activation --renderer-client-id=196 --launch-time-ticks=17880973283 --mojo-platform-channel-handle=2520 --field-trial-handle=1808,i,7578868639254466484,17758186584081941877,131072 --enable-features=ContextBridgeMutability,SharedArrayBuffer,WinUseBrowserSpellChecker,WinUseHybridSpellChecker --disable-features=CalculateNativeWinOcclusion,ExtraCookieValidityChecks,ForcedColors,SpareRendererForSitePerProcess,WinRetrieveSuggestionsOnlyOnDemand /prefetch:1\nCurrentDirectory: C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\\nUser: COMPANY\\asmithee\nLogonGuid: {abcdef01-b1c2-d3c4-1234-123400000000}\nLogonId: 0x1234ABC\nTerminalSessionId: 1\nIntegrityLevel: Low\nHashes: SHA1=68D25B5F5A57CF5DC0D63644338C04EA906D472B,MD5=89B717809A5A49D19E7E06746982BF0B,SHA256=2024533463DF3C945A74C774858285915FFB4E083031B51B8135BBBF5E8FC5EE,IMPHASH=00590C8FDC1F372F8DB1D3F49D342D34\nParentProcessGuid: {1c03cf6e-331c-652e-b001-00000000fa00}\nParentProcessId: 17772\nParentImage: C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\Teams.exe\nParentCommandLine: \"C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\Teams.exe\" --system-initiated\nParentUser: COMPANY\\asmithee",
+      "hash": "3a94cc250153d9666fad8106848c0359d8b887d6"
+    },
+    "@timestamp": "2023-10-17T12:05:25.091000Z",
+    "action": {
+      "properties": {
+        "IntegrityLevel": "Low",
+        "Product": "Microsoft Teams",
+        "Description": "Microsoft Teams",
+        "LogonId": "0x1234abc",
+        "TerminalSessionId": "1",
+        "FileVersion": "1.6.00.27573",
+        "LogonGuid": "{abcdef01-b1c2-d3c4-1234-123400000000}",
+        "Company": "Microsoft Corporation",
+        "ParentUser": "COMPANY\\asmithee"
       },
-      "@timestamp": "2023-10-17T12:05:25.091000Z",
-      "action": {
-        "properties": {
-          "IntegrityLevel": "Low",
-          "Product": "Microsoft Teams",
-          "Description": "Microsoft Teams",
-          "LogonId": "0x1234abc",
-          "TerminalSessionId": "1",
-          "FileVersion": "1.6.00.27573",
-          "LogonGuid": "{abcdef01-b1c2-d3c4-1234-123400000000}",
-          "Company": "Microsoft Corporation",
-          "ParentUser": "COMPANY\\asmithee"
-        },
-        "id": 1
+      "id": 1
+    },
+    "agent": {
+      "id": "001234567-abcd-ef01-2345-6789abcdef01",
+      "name": "WB-DK-PC01234567",
+      "version": "7.17.1",
+      "ephemeral_id": "a0b1c2d3-0123-4567-abcd-e4f5a6b7c8d9",
+      "type": "winlogbeat"
+    },
+    "host": {
+      "id": "a0b1c2d3-0123-abcd-0a1b-abcd0123ef45",
+      "name": "PC01234567.company.com",
+      "mac": [
+        "00:11:22:33:44:55",
+        "aa:bb:cc:dd:ee:ff",
+        "a0:b1:c2:d3:e4:f5",
+        "66:77:88:99:00:11",
+        "01:23:45:67:89:ab",
+        "ab:cd:ef:01:23:45"
+      ],
+      "os": {
+        "platform": "windows",
+        "name": "Windows 10 Enterprise",
+        "version": "10.0",
+        "kernel": "10.0.19041.3570 (WinBuild.160101.0800)",
+        "build": "19044.3570",
+        "type": "windows",
+        "family": "windows"
       },
-      "agent": {
-        "id": "001234567-abcd-ef01-2345-6789abcdef01",
-        "name": "WB-DK-PC01234567",
-        "version": "7.17.1",
-        "ephemeral_id": "a0b1c2d3-0123-4567-abcd-e4f5a6b7c8d9",
-        "type": "winlogbeat"
+      "hostname": "PC01234567",
+      "architecture": "x86_64",
+      "ip": [
+        "a123::b234:c345:d456:e567",
+        "8.8.8.8",
+        "abcd::ef01:2345:6789:abcd",
+        "1.2.3.4",
+        "a0b1::c2d3:e4f5:123:abcd",
+        "10.20.30.40",
+        "aabb::ccdd:eeff:11:2233",
+        "0.0.0.0",
+        "1122::3344:5566:7788:9900",
+        "5.6.7.8",
+        "11::2233:4455:6677:8899",
+        "40.30.20.10"
+      ]
+    },
+    "log": {
+      "level": "information"
+    },
+    "process": {
+      "name": "Teams.exe",
+      "args": [
+        "C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\Teams.exe",
+        "--type=renderer",
+        "--enable-wer",
+        "--user-data-dir=C:\\Users\\asmithee\\AppData\\Roaming\\Microsoft\\Teams",
+        "--ms-teams-less-cors=522133263",
+        "--app-user-model-id=com.squirrel.Teams.Teams",
+        "--app-path=C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\resources\\app.test",
+        "--autoplay-policy=no-user-gesture-required",
+        "--disable-background-timer-throttling",
+        "--lang=fr",
+        "--device-scale-factor=1.25",
+        "--num-raster-threads=4",
+        "--enable-main-frame-before-activation",
+        "--renderer-client-id=196",
+        "--launch-time-ticks=17880973283",
+        "--mojo-platform-channel-handle=2520",
+        "--field-trial-handle=1808,i,7578868639254466484,17758186584081941877,131072",
+        "--enable-features=ContextBridgeMutability,SharedArrayBuffer,WinUseBrowserSpellChecker,WinUseHybridSpellChecker",
+        "--disable-features=CalculateNativeWinOcclusion,ExtraCookieValidityChecks,ForcedColors,SpareRendererForSitePerProcess,WinRetrieveSuggestionsOnlyOnDemand",
+        "/prefetch:1"
+      ],
+      "hash": {
+        "sha256": "2024533463df3c945a74c774858285915ffb4e083031b51b8135bbbf5e8fc5ee",
+        "sha1": "68d25b5f5a57cf5dc0d63644338c04ea906d472b",
+        "md5": "89b717809a5a49d19e7e06746982bf0b"
       },
-      "host": {
-        "id": "a0b1c2d3-0123-abcd-0a1b-abcd0123ef45",
-        "name": "PC01234567.company.com",
-        "mac": [
-          "00:11:22:33:44:55",
-          "aa:bb:cc:dd:ee:ff",
-          "a0:b1:c2:d3:e4:f5",
-          "66:77:88:99:00:11",
-          "01:23:45:67:89:ab",
-          "ab:cd:ef:01:23:45"
-        ],
-        "os": {
-          "platform": "windows",
-          "name": "Windows 10 Enterprise",
-          "version": "10.0",
-          "kernel": "10.0.19041.3570 (WinBuild.160101.0800)",
-          "build": "19044.3570",
-          "type": "windows",
-          "family": "windows"
-        },
-        "hostname": "PC01234567",
-        "architecture": "x86_64",
-        "ip": [
-          "a123::b234:c345:d456:e567",
-          "8.8.8.8",
-          "abcd::ef01:2345:6789:abcd",
-          "1.2.3.4",
-          "a0b1::c2d3:e4f5:123:abcd",
-          "10.20.30.40",
-          "aabb::ccdd:eeff:11:2233",
-          "0.0.0.0",
-          "1122::3344:5566:7788:9900",
-          "5.6.7.8",
-          "11::2233:4455:6677:8899",
-          "40.30.20.10"
-        ]
+      "entity_id": "{abcdef01-2345-6789-abcd-000000000000}",
+      "command_line": "\"C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\Teams.exe\" --type=renderer --enable-wer --user-data-dir=\"C:\\Users\\asmithee\\AppData\\Roaming\\Microsoft\\Teams\" --ms-teams-less-cors=522133263 --app-user-model-id=com.squirrel.Teams.Teams --app-path=\"C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\resources\\app.test\" --autoplay-policy=no-user-gesture-required --disable-background-timer-throttling --lang=fr --device-scale-factor=1.25 --num-raster-threads=4 --enable-main-frame-before-activation --renderer-client-id=196 --launch-time-ticks=17880973283 --mojo-platform-channel-handle=2520 --field-trial-handle=1808,i,7578868639254466484,17758186584081941877,131072 --enable-features=ContextBridgeMutability,SharedArrayBuffer,WinUseBrowserSpellChecker,WinUseHybridSpellChecker --disable-features=CalculateNativeWinOcclusion,ExtraCookieValidityChecks,ForcedColors,SpareRendererForSitePerProcess,WinRetrieveSuggestionsOnlyOnDemand /prefetch:1",
+      "pe": {
+        "description": "Microsoft Teams",
+        "company": "Microsoft Corporation",
+        "file_version": "1.6.00.27573",
+        "imphash": "00590c8fdc1f372f8db1d3f49d342d34",
+        "original_file_name": "Teams.exe",
+        "product": "Microsoft Teams"
       },
-      "log": {
-        "level": "information"
-      },
-      "process": {
+      "parent": {
         "name": "Teams.exe",
         "args": [
           "C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\Teams.exe",
-          "--type=renderer",
-          "--enable-wer",
-          "--user-data-dir=C:\\Users\\asmithee\\AppData\\Roaming\\Microsoft\\Teams",
-          "--ms-teams-less-cors=522133263",
-          "--app-user-model-id=com.squirrel.Teams.Teams",
-          "--app-path=C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\resources\\app.test",
-          "--autoplay-policy=no-user-gesture-required",
-          "--disable-background-timer-throttling",
-          "--lang=fr",
-          "--device-scale-factor=1.25",
-          "--num-raster-threads=4",
-          "--enable-main-frame-before-activation",
-          "--renderer-client-id=196",
-          "--launch-time-ticks=17880973283",
-          "--mojo-platform-channel-handle=2520",
-          "--field-trial-handle=1808,i,7578868639254466484,17758186584081941877,131072",
-          "--enable-features=ContextBridgeMutability,SharedArrayBuffer,WinUseBrowserSpellChecker,WinUseHybridSpellChecker",
-          "--disable-features=CalculateNativeWinOcclusion,ExtraCookieValidityChecks,ForcedColors,SpareRendererForSitePerProcess,WinRetrieveSuggestionsOnlyOnDemand",
-          "/prefetch:1"
+          "--system-initiated"
         ],
-        "hash": {
-          "sha256": "2024533463df3c945a74c774858285915ffb4e083031b51b8135bbbf5e8fc5ee",
-          "sha1": "68d25b5f5a57cf5dc0d63644338c04ea906d472b",
-          "md5": "89b717809a5a49d19e7e06746982bf0b"
-        },
         "entity_id": "{abcdef01-2345-6789-abcd-000000000000}",
-        "command_line": "\"C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\Teams.exe\" --type=renderer --enable-wer --user-data-dir=\"C:\\Users\\asmithee\\AppData\\Roaming\\Microsoft\\Teams\" --ms-teams-less-cors=522133263 --app-user-model-id=com.squirrel.Teams.Teams --app-path=\"C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\resources\\app.test\" --autoplay-policy=no-user-gesture-required --disable-background-timer-throttling --lang=fr --device-scale-factor=1.25 --num-raster-threads=4 --enable-main-frame-before-activation --renderer-client-id=196 --launch-time-ticks=17880973283 --mojo-platform-channel-handle=2520 --field-trial-handle=1808,i,7578868639254466484,17758186584081941877,131072 --enable-features=ContextBridgeMutability,SharedArrayBuffer,WinUseBrowserSpellChecker,WinUseHybridSpellChecker --disable-features=CalculateNativeWinOcclusion,ExtraCookieValidityChecks,ForcedColors,SpareRendererForSitePerProcess,WinRetrieveSuggestionsOnlyOnDemand /prefetch:1",
-        "pe": {
-          "description": "Microsoft Teams",
-          "company": "Microsoft Corporation",
-          "file_version": "1.6.00.27573",
-          "imphash": "00590c8fdc1f372f8db1d3f49d342d34",
-          "original_file_name": "Teams.exe",
-          "product": "Microsoft Teams"
-        },
-        "parent": {
-          "name": "Teams.exe",
-          "args": [
-            "C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\Teams.exe",
-            "--system-initiated"
-          ],
-          "entity_id": "{abcdef01-2345-6789-abcd-000000000000}",
-          "command_line": "\"C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\Teams.exe\" --system-initiated",
-          "pid": 17772,
-          "executable": "C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\Teams.exe"
-        },
-        "pid": 27804,
-        "working_directory": "C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\",
+        "command_line": "\"C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\Teams.exe\" --system-initiated",
+        "pid": 17772,
         "executable": "C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\Teams.exe"
       },
+      "pid": 27804,
+      "working_directory": "C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\",
+      "executable": "C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\Teams.exe"
+    },
+    "user": {
+      "name": "asmithee",
+      "id": "S-1-2-3",
+      "domain": "COMPANY"
+    },
+    "winlog": {
+      "task": "Process Create (rule: ProcessCreate)",
+      "channel": "Microsoft-Windows-Sysmon/Operational",
       "user": {
-        "name": "asmithee",
-        "id": "S-1-2-3",
-        "domain": "COMPANY"
+        "name": "Syst\u00e8me",
+        "identifier": "S-1-2-3",
+        "type": "User",
+        "domain": "DOMAIN"
       },
-      "winlog": {
-        "task": "Process Create (rule: ProcessCreate)",
-        "channel": "Microsoft-Windows-Sysmon/Operational",
-        "user": {
-          "name": "Syst\u00e8me",
-          "identifier": "S-1-2-3",
-          "type": "User",
-          "domain": "DOMAIN"
+      "api": "wineventlog",
+      "provider_guid": "{a0b1c2d3-1234-abcd-e4f5-0123456789ab}",
+      "process": {
+        "thread": {
+          "id": 7248
         },
-        "api": "wineventlog",
-        "provider_guid": "{a0b1c2d3-1234-abcd-e4f5-0123456789ab}",
-        "process": {
-          "thread": {
-            "id": 7248
-          },
-          "pid": 5624
-        },
-        "event_id": "1",
-        "version": 5,
-        "computer_name": "PC01234567.company.com",
-        "record_id": "67177799",
-        "opcode": "Informations",
-        "provider_name": "Microsoft-Windows-Sysmon"
+        "pid": 5624
       },
-      "related": {
-        "hash": [
-          "2024533463df3c945a74c774858285915ffb4e083031b51b8135bbbf5e8fc5ee",
-          "3a94cc250153d9666fad8106848c0359d8b887d6",
-          "68d25b5f5a57cf5dc0d63644338c04ea906d472b",
-          "89b717809a5a49d19e7e06746982bf0b"
-        ],
-        "ip": [
-          "0.0.0.0",
-          "1.2.3.4",
-          "10.20.30.40",
-          "1122::3344:5566:7788:9900",
-          "11::2233:4455:6677:8899",
-          "40.30.20.10",
-          "5.6.7.8",
-          "8.8.8.8",
-          "a0b1::c2d3:e4f5:123:abcd",
-          "a123::b234:c345:d456:e567",
-          "aabb::ccdd:eeff:11:2233",
-          "abcd::ef01:2345:6789:abcd"
-        ],
-        "hosts": [
-          "PC01234567"
-        ],
-        "user": [
-          "asmithee"
-        ]
-      }
+      "event_id": "1",
+      "version": 5,
+      "computer_name": "PC01234567.company.com",
+      "record_id": "67177799",
+      "opcode": "Informations",
+      "provider_name": "Microsoft-Windows-Sysmon"
+    },
+    "related": {
+      "hash": [
+        "2024533463df3c945a74c774858285915ffb4e083031b51b8135bbbf5e8fc5ee",
+        "3a94cc250153d9666fad8106848c0359d8b887d6",
+        "68d25b5f5a57cf5dc0d63644338c04ea906d472b",
+        "89b717809a5a49d19e7e06746982bf0b"
+      ],
+      "ip": [
+        "0.0.0.0",
+        "1.2.3.4",
+        "10.20.30.40",
+        "1122::3344:5566:7788:9900",
+        "11::2233:4455:6677:8899",
+        "40.30.20.10",
+        "5.6.7.8",
+        "8.8.8.8",
+        "a0b1::c2d3:e4f5:123:abcd",
+        "a123::b234:c345:d456:e567",
+        "aabb::ccdd:eeff:11:2233",
+        "abcd::ef01:2345:6789:abcd"
+      ],
+      "hosts": [
+        "PC01234567"
+      ],
+      "user": [
+        "asmithee"
+      ]
     }
   }
+}


### PR DESCRIPTION
- According to elastic, process.hash should only be populated with events code in ['1','23','24', '25', '26']. Otherwise, with event_code in ['6','7','15'], it should be on file.hash fields (c.f. [ECS sysmon parser](https://github.com/elastic/beats/blob/main/x-pack/winlogbeat/module/sysmon/test/testdata/ingest/sysmon-9.01.golden.json), only module using hashes)
- Populating of imphash accordingly to the taxonomy