### PR TITLE
fix(Microsoft365Defender): add process.executable

### DIFF
--- a/Microsoft/microsoft-365-defender/ingest/parser.yml
+++ b/Microsoft/microsoft-365-defender/ingest/parser.yml
@@ -130,6 +130,7 @@ stages:
           process.start: "{{json_event.message.properties.ProcessCreationTime or json_event.message.properties.InitiatingProcessCreationTime}}"
           process.name: "{{json_event.message.properties.InitiatingProcessFileName | basename}}"
           process.command_line: "{{json_event.message.properties.ProcessCommandLine or json_event.message.properties.InitiatingProcessCommandLine}}"
+          process.executable: "{{json_event.message.properties.InitiatingProcessFolderPath}}"
           process.working_directory: "{{json_event.message.properties.InitiatingProcessFolderPath | dirname}}"
           process.user.domain: "{{json_event.message.properties.InitiatingProcessAccountDomain}}"
           process.user.name: "{{json_event.message.properties.InitiatingProcessAccountName}}"

--- a/Microsoft/microsoft-365-defender/tests/test_device_event.json
+++ b/Microsoft/microsoft-365-defender/tests/test_device_event.json
@@ -61,6 +61,7 @@
         "--use-crash-handler-with-id=\"\\\\.\\pipe\\crashpad_11111_XXXXXXXXXXXXXXXX\""
       ],
       "command_line": "\"software_reporter_tool.exe\" --use-crash-handler-with-id=\"\\\\.\\pipe\\crashpad_11111_XXXXXXXXXXXXXXXX\" --sandboxed-process-id=2 --init-done-notifier=804 --sandbox-mojo-pipe-token=********** --mojo-platform-channel-handle=780 --engine=2",
+      "executable": "c:\\users\\USER\\appdata\\local\\google\\chrome\\user data\\swreporter\\102.286.200\\software_reporter_tool.exe",
       "hash": {
         "md5": "51a9cac9c4e8da44ffd7502be17604ee",
         "sha1": "44543e0c6f30415c670c1322e61ca68602d58708",

--- a/Microsoft/microsoft-365-defender/tests/test_device_file_event.json
+++ b/Microsoft/microsoft-365-defender/tests/test_device_file_event.json
@@ -67,6 +67,7 @@
         "/updateSource:ODU"
       ],
       "command_line": "OneDriveSetup.exe /update /restart /updateSource:ODU /peruser /childprocess /extractFilesWithLessThreadCount /renameReplaceOneDriveExe /renameReplaceODSUExe /removeNonCurrentVersions /enableODSUReportingMode ",
+      "executable": "c:\\users\\USER\\appdata\\local\\microsoft\\onedrive\\update\\onedrivesetup.exe",
       "hash": {
         "md5": "9a3af3a9ce0217bccce1d161e0b6bfde",
         "sha1": "8f6ebe4a51ce4b5f76f4d896a6e289e69f91a264",

--- a/Microsoft/microsoft-365-defender/tests/test_device_image_load_event.json
+++ b/Microsoft/microsoft-365-defender/tests/test_device_image_load_event.json
@@ -60,6 +60,7 @@
         "usa\""
       ],
       "command_line": "\"autosync.exe\" /c C:\\PROGRA~2\\adobe\\8.1\\Client\\bin\\fra\\adobe.cfg /c \" usa\"",
+      "executable": "c:\\program files (x86)\\adobe\\8.1\\client\\bin\\autosync.exe",
       "hash": {
         "md5": "4617605c67d2a4f8ff7f86042d40011d",
         "sha1": "1181891a21a785f05de6f40a3c635534ade13262",

--- a/Microsoft/microsoft-365-defender/tests/test_device_logon_events.json
+++ b/Microsoft/microsoft-365-defender/tests/test_device_logon_events.json
@@ -46,6 +46,7 @@
         "-SpecialSession"
       ],
       "command_line": "WinLogon.exe -SpecialSession",
+      "executable": "C:\\Windows\\System32",
       "hash": {
         "md5": "f597fa958fd63accc90cb469e7ddc2a5",
         "sha1": "0c8b6c1f8c1d248000192e2569735848051b3ce1"

--- a/Microsoft/microsoft-365-defender/tests/test_device_network_events.json
+++ b/Microsoft/microsoft-365-defender/tests/test_device_network_events.json
@@ -63,6 +63,7 @@
         "\"C:\\Users\\USER\\MyDocument.xslx"
       ],
       "command_line": "\"EXCEL.EXE\" \"C:\\Users\\USER\\MyDocument.xslx",
+      "executable": "c:\\program files\\microsoft office\\root\\office16\\excel.exe",
       "hash": {
         "md5": "4d5b7b6c06159d6b967f2c2c73f10145",
         "sha1": "2b684979d6174bad69d895c7d8a852e7b206b95f",

--- a/Microsoft/microsoft-365-defender/tests/test_device_process_events.json
+++ b/Microsoft/microsoft-365-defender/tests/test_device_process_events.json
@@ -81,6 +81,7 @@
         "subject_name": "OsVendor"
       },
       "command_line": "\"MpCmdRun.exe\" Scan -ScheduleJob -RestrictPrivileges -DailyScan -ScanTrigger 54",
+      "executable": "c:\\programdata\\microsoft\\windows defender\\platform\\4.18.2301.6-0\\msmpeng.exe",
       "hash": {
         "md5": "5d5608654828cf052ba013b3c37cbb61",
         "sha1": "5bfbb0f965e2761d75a51faacc9db6a146a7c5ae",

--- a/Microsoft/microsoft-365-defender/tests/test_device_registry_events.json
+++ b/Microsoft/microsoft-365-defender/tests/test_device_registry_events.json
@@ -58,6 +58,7 @@
         "1"
       ],
       "command_line": "\"omadmclient.exe\" /serverid \"1F2E9005-CEAB-4280-83A7-8429D26DE773\" /lookuptype 1 /initiator 0",
+      "executable": "c:\\windows\\system32\\omadmclient.exe",
       "hash": {
         "md5": "655381bd34fa7f6421e3740f1fc3c1b1",
         "sha1": "9df2bc8901233492b2488de8742a35d3d5c46c12",

--- a/Microsoft/microsoft-365-defender/tests/test_local_ip.json
+++ b/Microsoft/microsoft-365-defender/tests/test_local_ip.json
@@ -57,6 +57,7 @@
         "--use-crash-handler-with-id=\"\\\\.\\pipe\\crashpad_11111_XXXXXXXXXXXXXXXX\""
       ],
       "command_line": "\"software_reporter_tool.exe\" --use-crash-handler-with-id=\"\\\\.\\pipe\\crashpad_11111_XXXXXXXXXXXXXXXX\" --sandboxed-process-id=2 --init-done-notifier=804 --sandbox-mojo-pipe-token=********** --mojo-platform-channel-handle=780 --engine=2",
+      "executable": "c:\\users\\USER\\appdata\\local\\google\\chrome\\user data\\swreporter\\102.286.200\\software_reporter_tool.exe",
       "hash": {
         "md5": "51a9cac9c4e8da44ffd7502be17604ee",
         "sha1": "44543e0c6f30415c670c1322e61ca68602d58708",


### PR DESCRIPTION
Hi!
This PR adds the field `process.executable`, which we use for a lot of endpoint rules, but is currently not set in the M365 Defender format.