### PR TITLE
Add OAuth client app ID (Azure AD, Office 365)

### DIFF
--- a/Azure/azure-ad/_meta/fields.yml
+++ b/Azure/azure-ad/_meta/fields.yml
@@ -130,6 +130,11 @@ azuread.properties.activity:
   name: azuread.properties.activity
   type: keyword
 
+azuread.properties.appId:
+  description: appId
+  name: azuread.properties.appId
+  type: keyword
+
 azuread.properties.appDisplayName:
   description: appDisplayName
   name: azuread.properties.appDisplayName

--- a/Azure/azure-ad/ingest/parser.yml
+++ b/Azure/azure-ad/ingest/parser.yml
@@ -59,6 +59,7 @@ stages:
           azuread.properties.riskEventTypes: "{{parsed_event.message.properties.riskEventTypes}}"
           azuread.properties.riskEventTypes_v2: "{{parsed_event.message.properties.riskEventTypes_v2}}"
           azuread.properties.authenticationProtocol: "{{parsed_event.message.properties.authenticationProtocol}}"
+          azuread.properties.appId: "{{parsed_event.message.properties.appId}}"
           azuread.properties.appDisplayName: "{{parsed_event.message.properties.appDisplayName}}"
           azuread.properties.source: "{{parsed_event.message.properties.source}}"
           azuread.properties.detectionTimingType: "{{parsed_event.message.properties.detectionTimingType}}"

--- a/Azure/azure-ad/tests/empty_geolocalisation.json
+++ b/Azure/azure-ad/tests/empty_geolocalisation.json
@@ -30,6 +30,7 @@
       "operationVersion": "1.0",
       "properties": {
         "appDisplayName": "Office 365 Exchange Online",
+        "appId": "00000002-0000-0ff1-ce00-000000000000",
         "authenticationProtocol": "ropc",
         "correlationId": "7ee10819-f631-4ab1-8edb-4efb7286baba",
         "id": "b2fdcc8f-954d-4d88-a035-58daefab4f00",

--- a/Azure/azure-ad/tests/sign-in_activity.json
+++ b/Azure/azure-ad/tests/sign-in_activity.json
@@ -31,6 +31,7 @@
       "operationVersion": "1.0",
       "properties": {
         "appDisplayName": "Office365 Shell WCSS-Client",
+        "appId": "89bee1f7-5e6e-4d8a-9f3d-ecd601259da7",
         "authenticationProtocol": "none",
         "correlationId": "e68960e2-8996-448c-ba7a-e54eeb8ff2ed",
         "id": "22253f56-6fc4-45f2-b148-d7fe15504900",

--- a/Azure/azure-ad/tests/sign-in_activity2.json
+++ b/Azure/azure-ad/tests/sign-in_activity2.json
@@ -30,6 +30,7 @@
       "operationVersion": "1.0",
       "properties": {
         "appDisplayName": "Microsoft App Access Panel",
+        "appId": "0000000c-0000-0000-c000-000000000000",
         "authenticationProtocol": "none",
         "correlationId": "467c1340-0762-40d2-b6fb-339235633ebb",
         "id": "8795994f-0bb8-46d7-8797-8c9c385d5900",

--- a/Azure/azure-ad/tests/sign-in_activity3.json
+++ b/Azure/azure-ad/tests/sign-in_activity3.json
@@ -30,6 +30,7 @@
       "operationVersion": "1.0",
       "properties": {
         "appDisplayName": "Microsoft Authentication Broker",
+        "appId": "93f63260-ad9a-4087-b7e0-d9010cb919dd",
         "authenticationProtocol": "none",
         "correlationId": "93f63260-ad9a-4087-b7e0-d9010cb919dd",
         "id": "93f63260-ad9a-4087-b7e0-d9010cb919dd",

--- a/Azure/azure-ad/tests/sign-in_activity3.json
+++ b/Azure/azure-ad/tests/sign-in_activity3.json
@@ -16,53 +16,36 @@
       ]
     },
     "@timestamp": "2023-08-16T15:32:05.577260Z",
-    "service": {
-      "type": "ldap",
-      "name": "Azure Active Directory"
-    },
     "action": {
       "name": "Sign-in activity"
     },
     "azuread": {
-      "resourceId": "/tenants/93f63260-ad9a-4087-b7e0-d9010cb919dd/providers/Microsoft.aadiam",
-      "operationName": "Sign-in activity",
-      "operationVersion": "1.0",
-      "category": "SignInLogs",
-      "tenantId": "93f63260-ad9a-4087-b7e0-d9010cb919dd",
-      "durationMs": 0,
-      "correlationId": "93f63260-ad9a-4087-b7e0-d9010cb919dd",
-      "identity": "John DOE",
       "Level": 4,
       "callerIpAddress": "1.2.3.4",
+      "category": "SignInLogs",
+      "correlationId": "93f63260-ad9a-4087-b7e0-d9010cb919dd",
+      "durationMs": 0,
+      "identity": "John DOE",
+      "operationName": "Sign-in activity",
+      "operationVersion": "1.0",
       "properties": {
-        "id": "93f63260-ad9a-4087-b7e0-d9010cb919dd",
+        "appDisplayName": "Microsoft Authentication Broker",
+        "authenticationProtocol": "none",
         "correlationId": "93f63260-ad9a-4087-b7e0-d9010cb919dd",
-        "riskState": "none",
+        "id": "93f63260-ad9a-4087-b7e0-d9010cb919dd",
         "riskDetail": "none",
-        "riskLevelAggregated": "none",
-        "riskLevelDuringSignIn": "none",
         "riskEventTypes": [],
         "riskEventTypes_v2": [],
+        "riskLevelAggregated": "none",
+        "riskLevelDuringSignIn": "none",
+        "riskState": "none",
         "status": {
-          "errorCode": "0",
-          "additionalDetails": "MFA completed in Azure AD"
-        },
-        "authenticationProtocol": "none",
-        "appDisplayName": "Microsoft Authentication Broker"
-      }
-    },
-    "source": {
-      "ip": "1.2.3.4",
-      "geo": {
-        "city_name": "Paris",
-        "region_name": "Paris",
-        "country_iso_code": "FR",
-        "location": {
-          "lon": 2.351828,
-          "lat": 48.856578
+          "additionalDetails": "MFA completed in Azure AD",
+          "errorCode": "0"
         }
       },
-      "address": "1.2.3.4"
+      "resourceId": "/tenants/93f63260-ad9a-4087-b7e0-d9010cb919dd/providers/Microsoft.aadiam",
+      "tenantId": "93f63260-ad9a-4087-b7e0-d9010cb919dd"
     },
     "error": {
       "code": "0",
@@ -73,25 +56,42 @@
         "type": "Ios"
       }
     },
-    "user": {
-      "full_name": "John DOE",
-      "email": "john.doe@example.org"
-    },
-    "user_agent": {
-      "original": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148",
-      "device": {
-        "name": "iPhone"
-      },
-      "name": "Mobile Safari UI/WKWebView",
-      "os": {
-        "name": "iOS",
-        "version": "16.6"
-      }
-    },
     "related": {
       "ip": [
         "1.2.3.4"
       ]
+    },
+    "service": {
+      "name": "Azure Active Directory",
+      "type": "ldap"
+    },
+    "source": {
+      "address": "1.2.3.4",
+      "geo": {
+        "city_name": "Paris",
+        "country_iso_code": "FR",
+        "location": {
+          "lat": 48.856578,
+          "lon": 2.351828
+        },
+        "region_name": "Paris"
+      },
+      "ip": "1.2.3.4"
+    },
+    "user": {
+      "email": "john.doe@example.org",
+      "full_name": "John DOE"
+    },
+    "user_agent": {
+      "device": {
+        "name": "iPhone"
+      },
+      "name": "Mobile Safari UI/WKWebView",
+      "original": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148",
+      "os": {
+        "name": "iOS",
+        "version": "16.6"
+      }
     }
   }
 }

--- a/Azure/azure-ad/tests/sign-in_activity4.json
+++ b/Azure/azure-ad/tests/sign-in_activity4.json
@@ -16,83 +16,50 @@
       ]
     },
     "@timestamp": "2023-10-04T13:09:02.679994Z",
-    "service": {
-      "type": "ldap",
-      "name": "Azure Active Directory"
-    },
     "action": {
       "name": "Sign-in activity"
     },
     "azuread": {
-      "resourceId": "/tenants/34314e6e-4023-4e4b-a15e-143f63244e2b/providers/Microsoft.aadiam",
-      "operationName": "Sign-in activity",
-      "operationVersion": "1.0",
-      "category": "SignInLogs",
-      "tenantId": "34314e6e-4023-4e4b-a15e-143f63244e2b",
-      "durationMs": 0,
-      "correlationId": "e68960e2-8996-448c-ba7a-e54eeb8ff2ed",
-      "identity": "DOE Jane",
       "Level": 4,
       "callerIpAddress": "11.11.11.11",
+      "category": "SignInLogs",
+      "correlationId": "e68960e2-8996-448c-ba7a-e54eeb8ff2ed",
+      "durationMs": 0,
+      "identity": "DOE Jane",
+      "operationName": "Sign-in activity",
+      "operationVersion": "1.0",
       "properties": {
-        "id": "e14254f4-4288-4c00-8689-80823c4f4cb5",
-        "correlationId": "11d70870-823f-4450-828a-aba3cf69af8d",
-        "riskState": "none",
-        "riskDetail": "none",
-        "riskLevelAggregated": "none",
-        "riskLevelDuringSignIn": "none",
-        "riskEventTypes": [],
-        "riskEventTypes_v2": [],
-        "status": {
-          "errorCode": "0"
-        },
-        "authenticationProtocol": "deviceCode",
         "appDisplayName": "Microsoft Authentication Broker",
+        "authenticationProtocol": "deviceCode",
+        "correlationId": "11d70870-823f-4450-828a-aba3cf69af8d",
         "deviceDetail": {
           "isCompliant": true,
           "isManaged": true,
           "trustType": "Azure AD joined"
-        }
-      }
-    },
-    "source": {
-      "ip": "11.11.11.11",
-      "geo": {
-        "city_name": "Bordeaux",
-        "region_name": "Gironde",
-        "country_iso_code": "FR",
-        "location": {
-          "lon": -0.5805000066757202,
-          "lat": 44.84040069580078
+        },
+        "id": "e14254f4-4288-4c00-8689-80823c4f4cb5",
+        "riskDetail": "none",
+        "riskEventTypes": [],
+        "riskEventTypes_v2": [],
+        "riskLevelAggregated": "none",
+        "riskLevelDuringSignIn": "none",
+        "riskState": "none",
+        "status": {
+          "errorCode": "0"
         }
       },
-      "address": "11.11.11.11"
+      "resourceId": "/tenants/34314e6e-4023-4e4b-a15e-143f63244e2b/providers/Microsoft.aadiam",
+      "tenantId": "34314e6e-4023-4e4b-a15e-143f63244e2b"
     },
     "error": {
       "code": "0"
     },
     "host": {
-      "id": "e14254f4-4288-4c00-8689-80823c4f4cb5",
       "hostname": "LPTC-PC1M4VZQ",
+      "id": "e14254f4-4288-4c00-8689-80823c4f4cb5",
+      "name": "LPTC-PC1M4VZQ",
       "os": {
         "type": "Ios"
-      },
-      "name": "LPTC-PC1M4VZQ"
-    },
-    "user": {
-      "full_name": "Jane DOE",
-      "email": "jane.doe@example.org"
-    },
-    "user_agent": {
-      "original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36 Edg/116.0.1938.98",
-      "device": {
-        "name": "Other"
-      },
-      "name": "Edge",
-      "version": "116.0.1938",
-      "os": {
-        "name": "Windows",
-        "version": "10"
       }
     },
     "related": {
@@ -102,6 +69,39 @@
       "ip": [
         "11.11.11.11"
       ]
+    },
+    "service": {
+      "name": "Azure Active Directory",
+      "type": "ldap"
+    },
+    "source": {
+      "address": "11.11.11.11",
+      "geo": {
+        "city_name": "Bordeaux",
+        "country_iso_code": "FR",
+        "location": {
+          "lat": 44.84040069580078,
+          "lon": -0.5805000066757202
+        },
+        "region_name": "Gironde"
+      },
+      "ip": "11.11.11.11"
+    },
+    "user": {
+      "email": "jane.doe@example.org",
+      "full_name": "Jane DOE"
+    },
+    "user_agent": {
+      "device": {
+        "name": "Other"
+      },
+      "name": "Edge",
+      "original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36 Edg/116.0.1938.98",
+      "os": {
+        "name": "Windows",
+        "version": "10"
+      },
+      "version": "116.0.1938"
     }
   }
 }

--- a/Azure/azure-ad/tests/sign-in_activity4.json
+++ b/Azure/azure-ad/tests/sign-in_activity4.json
@@ -30,6 +30,7 @@
       "operationVersion": "1.0",
       "properties": {
         "appDisplayName": "Microsoft Authentication Broker",
+        "appId": "89bee1f7-5e6e-4d8a-9f3d-ecd601259da7",
         "authenticationProtocol": "deviceCode",
         "correlationId": "11d70870-823f-4450-828a-aba3cf69af8d",
         "deviceDetail": {

--- a/Office 365/o365/ingest/parser.yml
+++ b/Office 365/o365/ingest/parser.yml
@@ -248,6 +248,7 @@ stages:
           event.type: ["info"]
           office365.logon_error: "{{json_event.message.LogonError}}"
           office365.error_number: "{{json_event.message.ErrorNumber}}"
+          office365.context.client.id: "{{json_event.message.ApplicationId}}"
 
       - set:
           host.os.full: '{% for deviceProperty in json_event.message.DeviceProperties %}{% if deviceProperty.Name == "OS" %}{% if deviceProperty.get("Value") != None and deviceProperty.Value != "<Null>"%}{{deviceProperty.Value}}{% endif %}{% endif %}{% endfor %}'

--- a/Office 365/o365/tests/ad.json
+++ b/Office 365/o365/tests/ad.json
@@ -40,6 +40,9 @@
         "user_authentication_method": 1
       },
       "context": {
+        "client": {
+          "id": "5e3ce6c0-2b1f-4285-8d4b-75ee78787346"
+        },
         "correlation": {
           "id": "d23dd5d2-ccc8-4928-b7a0-f446a2ca4a90"
         }

--- a/Office 365/o365/tests/ad_1.json
+++ b/Office 365/o365/tests/ad_1.json
@@ -44,6 +44,9 @@
       },
       "context": {
         "aad_session_id": "8e2cdebf",
+        "client": {
+          "id": "1b3c667f"
+        },
         "correlation": {
           "id": "d8254b84"
         }

--- a/Office 365/o365/tests/user_logged_in.json
+++ b/Office 365/o365/tests/user_logged_in.json
@@ -40,6 +40,9 @@
         "user_authentication_method": 1
       },
       "context": {
+        "client": {
+          "id": "89bee1f7-5e6e-4d8a-9f3d-ecd601259da7"
+        },
         "correlation": {
           "id": "794c9504-66fe-441c-831a-5fc2badfcdc8"
         }

--- a/Office 365/o365/tests/user_logged_in_2.json
+++ b/Office 365/o365/tests/user_logged_in_2.json
@@ -45,6 +45,9 @@
       },
       "context": {
         "aad_session_id": "77f6d9ce-da8f-46bf-a651-4bec3c189770",
+        "client": {
+          "id": "77f6d9ce-da8f-46bf-a651-4bec3c189770"
+        },
         "correlation": {
           "id": "77f6d9ce-da8f-46bf-a651-4bec3c189770"
         }

--- a/Office 365/o365/tests/user_login_failed.json
+++ b/Office 365/o365/tests/user_login_failed.json
@@ -45,6 +45,9 @@
       },
       "context": {
         "aad_session_id": "b3a9b2b4-57c9-406b-9a2d-106b7f612248",
+        "client": {
+          "id": "00000003-0000-0ff1-ce00-000000000000"
+        },
         "correlation": {
           "id": "d48e6ea0-40c1-5000-5eba-0ee33d13b1ca"
         }


### PR DESCRIPTION
Hi!
This is not a customer request, but I'd like to have these fields available to create detection rules.
On O365, I reused an existing field that has the same meaning in other events (it designates the client_id of an OAuth app).
On Azure AD, I created an new field with a name similar to the one that already exists for the app name.