### PR TITLE
Office365: Add subject and message_id in Exchange events

### DIFF
--- a/Office 365/o365/ingest/parser.yml
+++ b/Office 365/o365/ingest/parser.yml
@@ -178,6 +178,10 @@ stages:
           office365.exchange.mailbox_guid: "{{json_event.message.MailboxGuid}}"
           office365.exchange.modified_properties: "{{json_event.message.ModifiedProperties}}"
           office365.context.aad_session_id: "{{json_event.message.SessionId}}"
+      - set:
+          email.subject: "{{json_event.message.Item.Subject}}"
+          email.message_id: "{{json_event.message.Item.InternetMessageId[1:-1]}}"
+        filter: '{{json_event.message.get("Item") != None}}'
 
   parse_exchange_item_group:
     actions:

--- a/Office 365/o365/tests/exchange_event1.json
+++ b/Office 365/o365/tests/exchange_event1.json
@@ -31,6 +31,10 @@
       "outcome": "success",
       "target": "user"
     },
+    "email": {
+      "message_id": "PR3PR03MB6601D07B33E82733537EF049DEE49@PR3PR03MB6601.eurprd03.prod.outlook.com",
+      "subject": "Email subject"
+    },
     "office365": {
       "context": {
         "aad_session_id": "8ad3822b-1cfd-40e7-aeaa-6d0708691ad8"

--- a/Office 365/o365/tests/exchange_item_update.json
+++ b/Office 365/o365/tests/exchange_item_update.json
@@ -31,6 +31,10 @@
       "outcome": "success",
       "target": "user"
     },
+    "email": {
+      "message_id": "44444444444444444444444444444444444444@MYSERVER.USA2345.PROD.OUTLOOK.COM",
+      "subject": "HI"
+    },
     "office365": {
       "exchange": {
         "mailbox_guid": "8208550a-4001-439d-a9f6-e95d76767507",


### PR DESCRIPTION
Hi!
This is not a customer request, but I'd like to have these fields available to create detection rules.
I used existing ECS fields (`email.subject` and `email.message_id`).