### PR TITLE
feat(squid): adding simple HTTP connect smart desc

### DIFF
--- a/Squid/squid/_meta/smart-descriptions.json
+++ b/Squid/squid/_meta/smart-descriptions.json
@@ -1,5 +1,21 @@
 [
   {
+    "value": "{http.request.method} request from {source.ip} to {destination.domain} with status: {http.response.status_code}",
+    "conditions": [
+      {
+        "field": "http.request.method",
+        "value": "CONNECT"
+      }
+    ],
+    "relationships": [
+      {
+        "source": "source.ip",
+        "target": "destination.domain",
+        "type": "HTTP {http.request.method} request"
+      }
+    ]
+  },
+  {
     "value": "User {user.name} made {http.request.method} request from {source.ip}: {url.original} (status: {http.response.status_code})",
     "conditions": [
       {


### PR DESCRIPTION
A proposal to add a simple smart description for HTTP Connect method, commonly use for HTTPS through proxy.