### PR TITLE
Normalize formats to use the same field for the severity

### DIFF
--- a/Google Cloud/Google Cloud Audit/CHANGELOG.md
+++ b/Google Cloud/Google Cloud Audit/CHANGELOG.md
@@ -6,3 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## 2024-02-20 - 1.0.1
+
+### Changed
+
+- Replace `google_cloud_audit.severity` by `log.level`

--- a/Google Cloud/Google Cloud Audit/_meta/fields.yml
+++ b/Google Cloud/Google Cloud Audit/_meta/fields.yml
@@ -176,8 +176,3 @@ google_cloud_audit.resource.type:
   description: ""
   name: google_cloud_audit.resource.type
   type: keyword
-
-google_cloud_audit.severity:
-  description: The severity of the log entry.
-  name: google_cloud_audit.severity
-  type: keyword

--- a/Google Cloud/Google Cloud Audit/ingest/parser.yml
+++ b/Google Cloud/Google Cloud Audit/ingest/parser.yml
@@ -25,7 +25,7 @@ stages:
           google_cloud_audit.receiveTimestamp: "{{json_event.message.receiveTimestamp}}"
           google_cloud_audit.insertId: "{{json_event.message.insertId}}"
           google_cloud_audit.logName: "{{json_event.message.logName}}"
-          google_cloud_audit.severity: "{{json_event.message.severity}}"
+          log.level: "{{json_event.message.severity | lower}}"
 
       # log entry's protoPayload field contains an AuditLog object that stores the audit logging data.
       - set:

--- a/Google Cloud/Google Cloud Audit/tests/2sv_disable.json
+++ b/Google Cloud/Google Cloud Audit/tests/2sv_disable.json
@@ -50,8 +50,10 @@
           "service": "login.googleapis.com"
         },
         "type": "audited_resource"
-      },
-      "severity": "NOTICE"
+      }
+    },
+    "log": {
+      "level": "notice"
     },
     "related": {
       "ip": [

--- a/Google Cloud/Google Cloud Audit/tests/2sv_enroll.json
+++ b/Google Cloud/Google Cloud Audit/tests/2sv_enroll.json
@@ -50,8 +50,10 @@
           "service": "login.googleapis.com"
         },
         "type": "audited_resource"
-      },
-      "severity": "NOTICE"
+      }
+    },
+    "log": {
+      "level": "notice"
     },
     "related": {
       "ip": [

--- a/Google Cloud/Google Cloud Audit/tests/account_disabled_generic.json
+++ b/Google Cloud/Google Cloud Audit/tests/account_disabled_generic.json
@@ -50,8 +50,10 @@
           "service": "login.googleapis.com"
         },
         "type": "audited_resource"
-      },
-      "severity": "NOTICE"
+      }
+    },
+    "log": {
+      "level": "notice"
     },
     "related": {
       "ip": [

--- a/Google Cloud/Google Cloud Audit/tests/account_disabled_hijacked.json
+++ b/Google Cloud/Google Cloud Audit/tests/account_disabled_hijacked.json
@@ -50,8 +50,10 @@
           "service": "login.googleapis.com"
         },
         "type": "audited_resource"
-      },
-      "severity": "NOTICE"
+      }
+    },
+    "log": {
+      "level": "notice"
     },
     "related": {
       "ip": [

--- a/Google Cloud/Google Cloud Audit/tests/account_disabled_password_leak.json
+++ b/Google Cloud/Google Cloud Audit/tests/account_disabled_password_leak.json
@@ -50,8 +50,10 @@
           "service": "login.googleapis.com"
         },
         "type": "audited_resource"
-      },
-      "severity": "NOTICE"
+      }
+    },
+    "log": {
+      "level": "notice"
     },
     "related": {
       "ip": [

--- a/Google Cloud/Google Cloud Audit/tests/account_disabled_spamming.json
+++ b/Google Cloud/Google Cloud Audit/tests/account_disabled_spamming.json
@@ -50,8 +50,10 @@
           "service": "login.googleapis.com"
         },
         "type": "audited_resource"
-      },
-      "severity": "NOTICE"
+      }
+    },
+    "log": {
+      "level": "notice"
     },
     "related": {
       "ip": [

--- a/Google Cloud/Google Cloud Audit/tests/account_disabled_spamming_through_relay.json
+++ b/Google Cloud/Google Cloud Audit/tests/account_disabled_spamming_through_relay.json
@@ -50,8 +50,10 @@
           "service": "login.googleapis.com"
         },
         "type": "audited_resource"
-      },
-      "severity": "NOTICE"
+      }
+    },
+    "log": {
+      "level": "notice"
     },
     "related": {
       "ip": [

--- a/Google Cloud/Google Cloud Audit/tests/attack_warning.json
+++ b/Google Cloud/Google Cloud Audit/tests/attack_warning.json
@@ -50,8 +50,10 @@
           "service": "login.googleapis.com"
         },
         "type": "audited_resource"
-      },
-      "severity": "NOTICE"
+      }
+    },
+    "log": {
+      "level": "notice"
     },
     "related": {
       "ip": [

--- a/Google Cloud/Google Cloud Audit/tests/email_forwarding_out_of_domain.json
+++ b/Google Cloud/Google Cloud Audit/tests/email_forwarding_out_of_domain.json
@@ -56,8 +56,10 @@
           "service": "login.googleapis.com"
         },
         "type": "audited_resource"
-      },
-      "severity": "NOTICE"
+      }
+    },
+    "log": {
+      "level": "notice"
     },
     "related": {
       "ip": [

--- a/Google Cloud/Google Cloud Audit/tests/gov_attack_warning.json
+++ b/Google Cloud/Google Cloud Audit/tests/gov_attack_warning.json
@@ -42,8 +42,10 @@
           "service": "login.googleapis.com"
         },
         "type": "audited_resource"
-      },
-      "severity": "NOTICE"
+      }
+    },
+    "log": {
+      "level": "notice"
     },
     "related": {
       "ip": [

--- a/Google Cloud/Google Cloud Audit/tests/k8s_delete_cluster.json
+++ b/Google Cloud/Google Cloud Audit/tests/k8s_delete_cluster.json
@@ -40,8 +40,10 @@
           "project_id": "hazel-aria-348413"
         },
         "type": "gke_cluster"
-      },
-      "severity": "NOTICE"
+      }
+    },
+    "log": {
+      "level": "notice"
     },
     "service": {
       "name": "container.googleapis.com"

--- a/Google Cloud/Google Cloud Audit/tests/login_challenge.json
+++ b/Google Cloud/Google Cloud Audit/tests/login_challenge.json
@@ -67,8 +67,10 @@
           "service": "login.googleapis.com"
         },
         "type": "audited_resource"
-      },
-      "severity": "NOTICE"
+      }
+    },
+    "log": {
+      "level": "notice"
     },
     "related": {
       "ip": [

--- a/Google Cloud/Google Cloud Audit/tests/login_failure.json
+++ b/Google Cloud/Google Cloud Audit/tests/login_failure.json
@@ -63,8 +63,10 @@
           "service": "login.googleapis.com"
         },
         "type": "audited_resource"
-      },
-      "severity": "NOTICE"
+      }
+    },
+    "log": {
+      "level": "notice"
     },
     "related": {
       "ip": [

--- a/Google Cloud/Google Cloud Audit/tests/login_success.json
+++ b/Google Cloud/Google Cloud Audit/tests/login_success.json
@@ -67,8 +67,10 @@
           "service": "login.googleapis.com"
         },
         "type": "audited_resource"
-      },
-      "severity": "NOTICE"
+      }
+    },
+    "log": {
+      "level": "notice"
     },
     "related": {
       "ip": [

--- a/Google Cloud/Google Cloud Audit/tests/login_verification.json
+++ b/Google Cloud/Google Cloud Audit/tests/login_verification.json
@@ -73,8 +73,10 @@
           "service": "login.googleapis.com"
         },
         "type": "audited_resource"
-      },
-      "severity": "NOTICE"
+      }
+    },
+    "log": {
+      "level": "notice"
     },
     "related": {
       "ip": [

--- a/Google Cloud/Google Cloud Audit/tests/logout.json
+++ b/Google Cloud/Google Cloud Audit/tests/logout.json
@@ -53,8 +53,10 @@
           "service": "login.googleapis.com"
         },
         "type": "audited_resource"
-      },
-      "severity": "NOTICE"
+      }
+    },
+    "log": {
+      "level": "notice"
     },
     "related": {
       "ip": [

--- a/Google Cloud/Google Cloud Audit/tests/password_edit.json
+++ b/Google Cloud/Google Cloud Audit/tests/password_edit.json
@@ -50,8 +50,10 @@
           "service": "login.googleapis.com"
         },
         "type": "audited_resource"
-      },
-      "severity": "NOTICE"
+      }
+    },
+    "log": {
+      "level": "notice"
     },
     "related": {
       "ip": [

--- a/Google Cloud/Google Cloud Audit/tests/recovery_email_edit.json
+++ b/Google Cloud/Google Cloud Audit/tests/recovery_email_edit.json
@@ -50,8 +50,10 @@
           "service": "login.googleapis.com"
         },
         "type": "audited_resource"
-      },
-      "severity": "NOTICE"
+      }
+    },
+    "log": {
+      "level": "notice"
     },
     "related": {
       "ip": [

--- a/Google Cloud/Google Cloud Audit/tests/recovery_phone_edit.json
+++ b/Google Cloud/Google Cloud Audit/tests/recovery_phone_edit.json
@@ -50,8 +50,10 @@
           "service": "login.googleapis.com"
         },
         "type": "audited_resource"
-      },
-      "severity": "NOTICE"
+      }
+    },
+    "log": {
+      "level": "notice"
     },
     "related": {
       "ip": [

--- a/Google Cloud/Google Cloud Audit/tests/recovery_secret_qa_edit.json
+++ b/Google Cloud/Google Cloud Audit/tests/recovery_secret_qa_edit.json
@@ -50,8 +50,10 @@
           "service": "login.googleapis.com"
         },
         "type": "audited_resource"
-      },
-      "severity": "NOTICE"
+      }
+    },
+    "log": {
+      "level": "notice"
     },
     "related": {
       "ip": [

--- a/Google Cloud/Google Cloud Audit/tests/suspicious_login.json
+++ b/Google Cloud/Google Cloud Audit/tests/suspicious_login.json
@@ -50,8 +50,10 @@
           "service": "login.googleapis.com"
         },
         "type": "audited_resource"
-      },
-      "severity": "NOTICE"
+      }
+    },
+    "log": {
+      "level": "notice"
     },
     "related": {
       "ip": [

--- a/Google Cloud/Google Cloud Audit/tests/suspicious_login_less_secure_app.json
+++ b/Google Cloud/Google Cloud Audit/tests/suspicious_login_less_secure_app.json
@@ -50,8 +50,10 @@
           "service": "login.googleapis.com"
         },
         "type": "audited_resource"
-      },
-      "severity": "NOTICE"
+      }
+    },
+    "log": {
+      "level": "notice"
     },
     "related": {
       "ip": [

--- a/Google Cloud/Google Cloud Audit/tests/suspicious_programmatic_login.json
+++ b/Google Cloud/Google Cloud Audit/tests/suspicious_programmatic_login.json
@@ -50,8 +50,10 @@
           "service": "login.googleapis.com"
         },
         "type": "audited_resource"
-      },
-      "severity": "NOTICE"
+      }
+    },
+    "log": {
+      "level": "notice"
     },
     "related": {
       "ip": [

--- a/Google Cloud/Google Cloud Audit/tests/titanium_enroll.json
+++ b/Google Cloud/Google Cloud Audit/tests/titanium_enroll.json
@@ -50,8 +50,10 @@
           "service": "login.googleapis.com"
         },
         "type": "audited_resource"
-      },
-      "severity": "NOTICE"
+      }
+    },
+    "log": {
+      "level": "notice"
     },
     "related": {
       "ip": [

--- a/Google Cloud/Google Cloud Audit/tests/titanium_unenroll.json
+++ b/Google Cloud/Google Cloud Audit/tests/titanium_unenroll.json
@@ -50,8 +50,10 @@
           "service": "login.googleapis.com"
         },
         "type": "audited_resource"
-      },
-      "severity": "NOTICE"
+      }
+    },
+    "log": {
+      "level": "notice"
     },
     "related": {
       "ip": [

--- a/Google Cloud/Google Kubernetes Engine/CHANGELOG.md
+++ b/Google Cloud/Google Kubernetes Engine/CHANGELOG.md
@@ -6,3 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## 2024-02-20 - 1.0.1
+
+### Changed
+
+- replace `google_kubernetes_engine.severity` by `log.level`

--- a/Google Cloud/Google Kubernetes Engine/_meta/fields.yml
+++ b/Google Cloud/Google Kubernetes Engine/_meta/fields.yml
@@ -162,8 +162,3 @@ google_kubernetes_engine.receiveTimestamp:
   description: ""
   name: google_kubernetes_engine.receiveTimestamp
   type: keyword
-
-google_kubernetes_engine.severity:
-  description: ""
-  name: google_kubernetes_engine.severity
-  type: keyword

--- a/Google Cloud/Google Kubernetes Engine/ingest/parser.yml
+++ b/Google Cloud/Google Kubernetes Engine/ingest/parser.yml
@@ -37,7 +37,7 @@ stages:
           google_kubernetes_engine.insertId: "{{json_event.message.insertId}}"
           google_kubernetes_engine.logName: "{{json_event.message.logName}}"
           google_kubernetes_engine.receiveTimestamp: "{{json_event.message.receiveTimestamp}}"
-          google_kubernetes_engine.severity: "{{json_event.message.severity}}"
+          log.level: "{{json_event.message.severity | lower}}"
 
   parse_kv_data:
     actions:

--- a/Google Cloud/Google Kubernetes Engine/tests/gke_log_id_event.json
+++ b/Google Cloud/Google Kubernetes Engine/tests/gke_log_id_event.json
@@ -72,11 +72,13 @@
         "type": "Normal"
       },
       "logName": "projects/hazel-aria-348413/logs/events",
-      "receiveTimestamp": "2022-06-01T14:05:39.683992581Z",
-      "severity": "INFO"
+      "receiveTimestamp": "2022-06-01T14:05:39.683992581Z"
     },
     "host": {
       "name": "gke-cluster-1-default-pool-476246ab-wnl7"
+    },
+    "log": {
+      "level": "info"
     },
     "orchestrator": {
       "api_version": "v1",

--- a/Google Cloud/Google Kubernetes Engine/tests/gke_log_id_event2.json
+++ b/Google Cloud/Google Kubernetes Engine/tests/gke_log_id_event2.json
@@ -70,11 +70,13 @@
         "type": "Warning"
       },
       "logName": "projects/hazel-aria-348413/logs/events",
-      "receiveTimestamp": "2022-06-01T14:05:39.683992581Z",
-      "severity": "WARNING"
+      "receiveTimestamp": "2022-06-01T14:05:39.683992581Z"
     },
     "host": {
       "name": "kube-dns.16f484369d214dae"
+    },
+    "log": {
+      "level": "warning"
     },
     "orchestrator": {
       "api_version": "v1",

--- a/Google Cloud/Google Kubernetes Engine/tests/gke_log_id_event3.json
+++ b/Google Cloud/Google Kubernetes Engine/tests/gke_log_id_event3.json
@@ -72,11 +72,13 @@
         "type": "Normal"
       },
       "logName": "projects/hazel-aria-348413/logs/events",
-      "receiveTimestamp": "2022-06-01T14:05:39.683992581Z",
-      "severity": "INFO"
+      "receiveTimestamp": "2022-06-01T14:05:39.683992581Z"
     },
     "host": {
       "name": "gke-cluster-1-default-pool-476246ab-wnl7"
+    },
+    "log": {
+      "level": "info"
     },
     "orchestrator": {
       "api_version": "v1",

--- a/Google Cloud/Google Kubernetes Engine/tests/k8s_node.json
+++ b/Google Cloud/Google Kubernetes Engine/tests/k8s_node.json
@@ -70,11 +70,13 @@
         "type": "Warning"
       },
       "logName": "projects/hazel-aria-348413/logs/events",
-      "receiveTimestamp": "2022-06-15T01:55:52.012275121Z",
-      "severity": "WARNING"
+      "receiveTimestamp": "2022-06-15T01:55:52.012275121Z"
     },
     "host": {
       "name": "gke-cluster-1-default-pool-eb66079e-k3zf"
+    },
+    "log": {
+      "level": "warning"
     },
     "orchestrator": {
       "cluster": {

--- a/Google Cloud/Google Kubernetes Engine/tests/k8s_textPayload.json
+++ b/Google Cloud/Google Kubernetes Engine/tests/k8s_textPayload.json
@@ -29,8 +29,10 @@
     "google_kubernetes_engine": {
       "insertId": "1wtrhknf2gg14w",
       "logName": "projects/hazel-aria-348413/logs/events",
-      "receiveTimestamp": "2022-06-16T09:42:59.259491841Z",
-      "severity": "WARNING"
+      "receiveTimestamp": "2022-06-16T09:42:59.259491841Z"
+    },
+    "log": {
+      "level": "warning"
     },
     "orchestrator": {
       "cluster": {

--- a/Netskope/netskope_events/CHANGELOG.md
+++ b/Netskope/netskope_events/CHANGELOG.md
@@ -6,3 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## 2024-02-20 - 1.0.1
+
+### Changed
+
+- replace `netskope.events.severity.level` by `event.severity`

--- a/Netskope/netskope_events/_meta/fields.yml
+++ b/Netskope/netskope_events/_meta/fields.yml
@@ -62,8 +62,3 @@ netskope.events.severity.id:
   description: The identifier of the severity
   name: netskope.events.severity.id
   type: keyword
-
-netskope.events.severity.level:
-  description: The level of the severity
-  name: netskope.events.severity.level
-  type: integer

--- a/Netskope/netskope_events/ingest/parser.yml
+++ b/Netskope/netskope_events/ingest/parser.yml
@@ -85,6 +85,7 @@ stages:
           file.hash.md5: "{{parsed_event.message.md5}}"
           file.hash.sha256: "{{parsed_event.message.sha256}}"
           file.name: "{{parsed_event.message.filename}}"
+          event.severity: "{{parsed_event.message.severity_level}}"
       - set:
           file.mime_type: "{{parsed_event.message.file_type or parsed_event.message.mime_type or parsed_event.message.data_type}}"
         filter: '{{parsed_event.message.file_type not in [None, "", "File Type Not Detected"] or parsed_event.message.data_type not in [None, ""]}}'
@@ -140,7 +141,6 @@ stages:
           netskope.events.access_method: "{{parsed_event.message.access_method}}"
           netskope.events.ccl: "{{parsed_event.message.ccl}}"
           netskope.events.severity.id: "{{parsed_event.message.severity_id}}"
-          netskope.events.severity.level: "{{parsed_event.message.severity_level}}"
       - set:
           netskope.dlp.incident.id: "{{parsed_event.message.dlp_incident_id}}"
         filter: "{{parsed_event.message.dlp_incident_id not in [None, 0]}}"

--- a/Netskope/netskope_events/tests/test_audit_log_deleted_inline_policy.json
+++ b/Netskope/netskope_events/tests/test_audit_log_deleted_inline_policy.json
@@ -17,6 +17,7 @@
       "dataset": "admin_audit_logs",
       "kind": "event",
       "reason": "Deleted inline policy",
+      "severity": 2,
       "type": [
         "change"
       ]
@@ -30,10 +31,7 @@
             false
           ]
         },
-        "ccl": "unknown",
-        "severity": {
-          "level": 2
-        }
+        "ccl": "unknown"
       }
     },
     "observer": {

--- a/Netskope/netskope_events/tests/test_audit_log_edit_admin_record.json
+++ b/Netskope/netskope_events/tests/test_audit_log_edit_admin_record.json
@@ -17,6 +17,7 @@
       "dataset": "admin_audit_logs",
       "kind": "event",
       "reason": "Edit admin record",
+      "severity": 1,
       "type": [
         "change"
       ]
@@ -30,10 +31,7 @@
             "admin@example.org"
           ]
         },
-        "ccl": "unknown",
-        "severity": {
-          "level": 1
-        }
+        "ccl": "unknown"
       }
     },
     "observer": {

--- a/Netskope/netskope_events/tests/test_audit_log_login_failed.json
+++ b/Netskope/netskope_events/tests/test_audit_log_login_failed.json
@@ -17,6 +17,7 @@
       "dataset": "admin_audit_logs",
       "kind": "event",
       "reason": "Login Failed",
+      "severity": 1,
       "type": [
         "info"
       ]
@@ -31,10 +32,7 @@
             "student13"
           ]
         },
-        "ccl": "unknown",
-        "severity": {
-          "level": 1
-        }
+        "ccl": "unknown"
       }
     },
     "observer": {

--- a/Netskope/netskope_events/tests/test_audit_log_login_successful.json
+++ b/Netskope/netskope_events/tests/test_audit_log_login_successful.json
@@ -17,6 +17,7 @@
       "dataset": "admin_audit_logs",
       "kind": "event",
       "reason": "Login Successful",
+      "severity": 2,
       "type": [
         "start"
       ]
@@ -31,10 +32,7 @@
             "john.doe@example.org"
           ]
         },
-        "ccl": "unknown",
-        "severity": {
-          "level": 2
-        }
+        "ccl": "unknown"
       }
     },
     "observer": {

--- a/Netskope/netskope_events/tests/test_audit_log_logout_successful.json
+++ b/Netskope/netskope_events/tests/test_audit_log_logout_successful.json
@@ -17,6 +17,7 @@
       "dataset": "admin_audit_logs",
       "kind": "event",
       "reason": "Logout Successful",
+      "severity": 2,
       "type": [
         "end"
       ]
@@ -30,10 +31,7 @@
             "Logged out due to inactivity"
           ]
         },
-        "ccl": "unknown",
-        "severity": {
-          "level": 2
-        }
+        "ccl": "unknown"
       }
     },
     "observer": {

--- a/Netskope/netskope_events/tests/test_audit_log_password_change_successful.json
+++ b/Netskope/netskope_events/tests/test_audit_log_password_change_successful.json
@@ -17,6 +17,7 @@
       "dataset": "admin_audit_logs",
       "kind": "event",
       "reason": "Password Change Successful",
+      "severity": 1,
       "type": [
         "change"
       ]
@@ -31,10 +32,7 @@
             "admin@example.org"
           ]
         },
-        "ccl": "unknown",
-        "severity": {
-          "level": 1
-        }
+        "ccl": "unknown"
       }
     },
     "observer": {

--- a/Okta/okta-system-logs/CHANGELOG.md
+++ b/Okta/okta-system-logs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2024-02-20 - 1.0.2
+
+### Changed
+
+- Replace `okta.system.severity` with `log.level`
+
 ## 2023-08-03 - 1.0.1
 
 ### Changed

--- a/Okta/okta-system-logs/_meta/fields.yml
+++ b/Okta/okta-system-logs/_meta/fields.yml
@@ -83,11 +83,6 @@ okta.system.security_context.isp:
   name: okta.system.security_context.isp
   type: keyword
 
-okta.system.severity:
-  description: The label of the severity of the event
-  name: okta.system.severity
-  type: keyword
-
 okta.system.target.alternateId:
   description: The alternate Id of the target
   name: okta.system.target.alternateId

--- a/Okta/okta-system-logs/ingest/parser.yml
+++ b/Okta/okta-system-logs/ingest/parser.yml
@@ -17,6 +17,7 @@ stages:
           event.reason: "{{parsed_event.message.displayMessage}}"
           event.category: ["iam"]
           observer.vendor: "Okta"
+          log.level: "{{parsed_event.message.severity | lower}}"
       - set:
           source.ip: "{{parsed_event.message.client.ipAddress}}"
         filter: "{{parsed_event.message.client.ipAddress | is_ipaddress}}"
@@ -125,7 +126,6 @@ stages:
   set_okta_fields:
     actions:
       - set:
-          okta.system.severity: "{{parsed_event.message.severity}}"
           okta.system.actor.id: "{{parsed_event.message.actor.id}}"
           okta.system.actor.type: "{{parsed_event.message.actor.type}}"
           okta.system.actor.alternate_id: "{{parsed_event.message.actor.alternateId}}"

--- a/Okta/okta-system-logs/tests/test_auth_via_idp.json
+++ b/Okta/okta-system-logs/tests/test_auth_via_idp.json
@@ -23,6 +23,9 @@
       ]
     },
     "@timestamp": "2022-11-15T08:04:22.213000Z",
+    "log": {
+      "level": "info"
+    },
     "observer": {
       "vendor": "Okta"
     },
@@ -47,7 +50,6 @@
         "outcome": {
           "result": "SUCCESS"
         },
-        "severity": "INFO",
         "target": {
           "alternateId": "Org2org",
           "displayName": "SAML 2.0 IdP",

--- a/Okta/okta-system-logs/tests/test_auth_via_mfa.json
+++ b/Okta/okta-system-logs/tests/test_auth_via_mfa.json
@@ -23,6 +23,9 @@
       ]
     },
     "@timestamp": "2022-11-02T12:00:00Z",
+    "log": {
+      "level": "info"
+    },
     "observer": {
       "vendor": "Okta"
     },
@@ -46,7 +49,6 @@
         "outcome": {
           "result": "SUCCESS"
         },
-        "severity": "INFO",
         "transaction": {
           "id": "jI80snAs0ZMym5tvc8Jbp",
           "type": "WEB"

--- a/Okta/okta-system-logs/tests/test_authentication_sso.json
+++ b/Okta/okta-system-logs/tests/test_authentication_sso.json
@@ -23,6 +23,9 @@
       ]
     },
     "@timestamp": "2022-11-15T08:05:07.656000Z",
+    "log": {
+      "level": "info"
+    },
     "observer": {
       "vendor": "Okta"
     },
@@ -37,7 +40,6 @@
         "outcome": {
           "result": "SUCCESS"
         },
-        "severity": "INFO",
         "target": {
           "alternateId": "Architecture Website",
           "displayName": "OpenID Connect Client",

--- a/Okta/okta-system-logs/tests/test_authentication_sso_failure.json
+++ b/Okta/okta-system-logs/tests/test_authentication_sso_failure.json
@@ -23,6 +23,9 @@
       ]
     },
     "@timestamp": "2022-12-16T17:05:07.656000Z",
+    "log": {
+      "level": "info"
+    },
     "observer": {
       "vendor": "Okta"
     },
@@ -38,7 +41,6 @@
           "reason": "INVALID_CREDENTIALS",
           "result": "FAILURE"
         },
-        "severity": "INFO",
         "target": {
           "alternateId": "Architecture Website",
           "displayName": "OpenID Connect Client",

--- a/Okta/okta-system-logs/tests/test_login.json
+++ b/Okta/okta-system-logs/tests/test_login.json
@@ -23,6 +23,9 @@
       ]
     },
     "@timestamp": "2017-09-30T22:23:07.777000Z",
+    "log": {
+      "level": "info"
+    },
     "observer": {
       "vendor": "Okta"
     },
@@ -40,7 +43,6 @@
         "outcome": {
           "result": "SUCCESS"
         },
-        "severity": "INFO",
         "transaction": {
           "id": "V04Oy4ubUOc5UuG6s9DyNQAABtc",
           "type": "WEB"

--- a/Okta/okta-system-logs/tests/test_send_factor.json
+++ b/Okta/okta-system-logs/tests/test_send_factor.json
@@ -23,6 +23,9 @@
       ]
     },
     "@timestamp": "2022-11-01T11:04:00.364000Z",
+    "log": {
+      "level": "info"
+    },
     "observer": {
       "vendor": "Okta"
     },
@@ -40,7 +43,6 @@
         "outcome": {
           "result": "SUCCESS"
         },
-        "severity": "INFO",
         "transaction": {
           "id": "Y3NH1qHvAmGouHz6XfAtaQAABNU",
           "type": "WEB"

--- a/Okta/okta-system-logs/tests/test_target.json
+++ b/Okta/okta-system-logs/tests/test_target.json
@@ -23,6 +23,9 @@
       ]
     },
     "@timestamp": "2023-02-13T09:47:12.106000Z",
+    "log": {
+      "level": "info"
+    },
     "observer": {
       "vendor": "Okta"
     },
@@ -40,7 +43,6 @@
         "outcome": {
           "result": "SUCCESS"
         },
-        "severity": "INFO",
         "target": {
           "alternateId": "Okta Dashboard",
           "displayName": "Okta Dashboard",

--- a/Okta/okta-system-logs/tests/test_update_account.json
+++ b/Okta/okta-system-logs/tests/test_update_account.json
@@ -23,6 +23,9 @@
       ]
     },
     "@timestamp": "2022-11-15T08:00:41.468000Z",
+    "log": {
+      "level": "info"
+    },
     "observer": {
       "vendor": "Okta"
     },
@@ -40,7 +43,6 @@
         "outcome": {
           "result": "SUCCESS"
         },
-        "severity": "INFO",
         "transaction": {
           "id": "jI80snAs0ZMym5tvc8Jbp",
           "type": "WEB"

--- a/Vectra/vectra_cognito_detect/CHANGELOG.md
+++ b/Vectra/vectra_cognito_detect/CHANGELOG.md
@@ -6,3 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## 2024-02-20 - 1.0.0
+
+### Changed
+
+- replace `vectra.severity` by `event.severity`

--- a/Vectra/vectra_cognito_detect/_meta/fields.yml
+++ b/Vectra/vectra_cognito_detect/_meta/fields.yml
@@ -396,11 +396,6 @@ vectra.risk_score_norm:
   name: vectra.risk_score_norm
   type: long
 
-vectra.severity:
-  description: A score proportional to threat
-  name: vectra.severity
-  type: long
-
 vectra.source.hid:
   description: The original host ID of the member host in this campaign
   name: vectra.source.hid

--- a/Vectra/vectra_cognito_detect/ingest/parser.yml
+++ b/Vectra/vectra_cognito_detect/ingest/parser.yml
@@ -95,7 +95,7 @@ stages:
 
           host.name: "{{json_event.message.host_name}}"
           vectra.detection.id: "{{json_event.message.detection_id}}"
-          vectra.severity: "{{json_event.message.severity}}"
+          event.severity: "{{json_event.message.severity | int}}"
           vectra.risk_score_norm: "{{json_event.message.threat}}"
           vectra.triaged: "{{json_event.message.triaged}}"
         # If Host Detection or Account Detection log event

--- a/Vectra/vectra_cognito_detect/tests/vectra_command_control.json
+++ b/Vectra/vectra_cognito_detect/tests/vectra_command_control.json
@@ -12,6 +12,7 @@
     "message": "-: {\"version\": \"6.12\", \"detection_id\": 13281, \"category\": \"COMMAND & CONTROL\", \"severity\": 6.0, \"threat\": 60, \"certainty\": 72, \"d_type\": \"hidden_http_tunnel_cnc\", \"d_type_vname\": \"Hidden HTTP Tunnel\", \"triaged\": false, \"headend_addr\": \"198.51.100.94\", \"dvchost\": \"198.51.100.94\", \"href\": \"https://198.51.100.94/detections/13281?detail_id=94738\", \"dd_dst_ip\": \"198.51.100.1\", \"dd_dst_port\": 8002, \"dd_dst_dns\": \"mirror.centos.org\", \"dd_bytes_sent\": 1476677, \"dd_bytes_rcvd\": 8269214038, \"host_name\": \"IP-198.51.100.14\", \"host_ip\": \"198.51.100.14\", \"dd_proto\": \"tcp\", \"vectra_timestamp\": \"1633516306\"}",
     "event": {
       "action": "COMMAND & CONTROL",
+      "severity": 6,
       "url": "https://198.51.100.94/detections/13281?detail_id=94738"
     },
     "destination": {
@@ -57,7 +58,6 @@
         "type": "hidden_http_tunnel_cnc"
       },
       "risk_score_norm": 60,
-      "severity": 6.0,
       "timestamp": 1633516306,
       "triaged": false
     }

--- a/Vectra/vectra_cognito_detect/tests/vectra_info.json
+++ b/Vectra/vectra_cognito_detect/tests/vectra_info.json
@@ -12,6 +12,7 @@
     "message": "-: {\"category\": \"INFO\", \"certainty\": 0, \"d_type\": \"si_new_host\", \"d_type_vname\": \"New Host\", \"dd_bytes_rcvd\": null, \"dd_bytes_sent\": null, \"dd_dst_dns\": \"\", \"dd_dst_ip\": \"0.0.0.0\", \"dd_dst_port\": 80, \"dd_proto\": \"\", \"detection_id\": 9999, \"dvchost\": \"255.255.255.1\", \"headend_addr\": \"255.255.255.1\", \"host_ip\": \"10.0.0.1\", \"host_name\": \"plop-99\", \"href\": \"https://255.255.255.1/detections/9999?detail_id=11111\", \"severity\": 0, \"threat\": 0, \"triaged\": false, \"vectra_timestamp\": \"1099999999\", \"version\": \"6.7\"}",
     "event": {
       "action": "INFO",
+      "severity": 0,
       "url": "https://255.255.255.1/detections/9999?detail_id=11111"
     },
     "destination": {
@@ -43,7 +44,6 @@
         "type": "si_new_host"
       },
       "risk_score_norm": 0,
-      "severity": 0,
       "timestamp": 1099999999,
       "triaged": false
     }

--- a/Vectra/vectra_cognito_detect/tests/vectra_lateral_movement.json
+++ b/Vectra/vectra_cognito_detect/tests/vectra_lateral_movement.json
@@ -12,6 +12,7 @@
     "message": "-: {\"accounts\": \"user@company.net\", \"shares\": \"\", \"reason\": \"MORE_PROCESSING_REQUIRED\", \"count\": 295, \"version\": \"6.12\", \"detection_id\": 13295, \"category\": \"LATERAL MOVEMENT\", \"severity\": 2.0, \"threat\": 20, \"certainty\": 74, \"d_type\": \"smb_brute_force\", \"d_type_vname\": \"SMB Brute-Force\", \"triaged\": false, \"headend_addr\": \"198.51.100.94\", \"dvchost\": \"198.51.100.94\", \"href\": \"https://198.51.100.94/detections/13295?detail_id=94908\", \"dd_dst_ip\": \"198.51.100.38\", \"dd_dst_port\": 445, \"dd_dst_dns\": \"\", \"dd_bytes_sent\": null, \"dd_bytes_rcvd\": null, \"host_name\": \"hostname\", \"host_ip\": \"198.51.100.155\", \"dd_proto\": \"\", \"vectra_timestamp\": \"1633681756\"}",
     "event": {
       "action": "LATERAL MOVEMENT",
+      "severity": 2,
       "url": "https://198.51.100.94/detections/13295?detail_id=94908"
     },
     "destination": {
@@ -46,7 +47,6 @@
         "type": "smb_brute_force"
       },
       "risk_score_norm": 20,
-      "severity": 2.0,
       "timestamp": 1633681756,
       "triaged": false
     }

--- a/Vectra/vectra_cognito_detect/tests/vectra_threat1.json
+++ b/Vectra/vectra_cognito_detect/tests/vectra_threat1.json
@@ -12,6 +12,7 @@
     "message": "-: {\"version\": \"6.8\", \"detection_id\": 1900, \"category\": \"RECONNAISSANCE\", \"severity\": 7.0, \"threat\": 70, \"certainty\": 86, \"d_type\": \"rpc_recon_1to1\", \"d_type_vname\": \"RPC Targeted Recon\", \"triaged\": false, \"headend_addr\": \"255.255.255.1\", \"dvchost\": \"255.255.255.1\", \"href\": \"https://255.255.255.1/detections/1900?detail_id=66777\", \"dd_dst_ip\": \"10.43.0.81\", \"dd_dst_port\": 49668, \"dd_dst_dns\": \"\", \"dd_bytes_sent\": null, \"dd_bytes_rcvd\": null, \"host_name\": \"IP-192.168.71.1\", \"host_ip\": \"192.168.71.1\", \"dd_proto\": \"\", \"vectra_timestamp\": \"1623742534\"}",
     "event": {
       "action": "RECONNAISSANCE",
+      "severity": 7,
       "url": "https://255.255.255.1/detections/1900?detail_id=66777"
     },
     "destination": {
@@ -43,7 +44,6 @@
         "type": "rpc_recon_1to1"
       },
       "risk_score_norm": 70,
-      "severity": 7.0,
       "timestamp": 1623742534,
       "triaged": false
     }


### PR DESCRIPTION
The ECS specification proposes `event.severity` (for number) and `log.level` (for string) to represent the severity of an event.
This PR fixes some formats to replace custom fields with ECS ones.