### PR TITLE
fix(suricata): default to hostname field

### DIFF
--- a/Suricata/suricata/ingest/parser.yml
+++ b/Suricata/suricata/ingest/parser.yml
@@ -109,7 +109,7 @@ stages:
         filter: '{{json_event.message.dns.get("grouped") != None}}'
       - set:
           action.type: '{{json_event.message.get("tags")[0]}}'
-          host.name: '{{json_event.message.get("host")}}'
+          host.hostname: '{{json_event.message.get("host")}}'
           event.type: ["info"]
         filter: '{{json_event.message.get("tags")[0] == "metric" or json_event.message.get("tags")[0] == "beats_input_raw_event"}}'
       - set:

--- a/Suricata/suricata/tests/beats.json
+++ b/Suricata/suricata/tests/beats.json
@@ -23,7 +23,13 @@
       "type": "beats_input_raw_event"
     },
     "host": {
+      "hostname": "probe",
       "name": "probe"
+    },
+    "related": {
+      "hosts": [
+        "probe"
+      ]
     }
   }
 }


### PR DESCRIPTION
Switching to `host.hostname` in the parser, as the `host.name` will be handled by the finalizer.