### PR TITLE
Fix OGO errata in tests

### DIFF
--- a/OGO/ogo-shield/tests/blocked.json
+++ b/OGO/ogo-shield/tests/blocked.json
@@ -42,7 +42,7 @@
     "ogo": {
       "appliedAction": "brain",
       "auditMode": "false",
-      "blocked": "false",
+      "blocked": "true",
       "credibility": "19000",
       "drive": {
         "label": "Linux files",


### PR DESCRIPTION
Blocked request has `"ogo.blocked": true`