### PR TITLE
Azure: remove 'event.kind'

### DIFF
--- a/Azure/azure-network-watcher/ingest/parser.yml
+++ b/Azure/azure-network-watcher/ingest/parser.yml
@@ -51,7 +51,6 @@ stages:
   set_common_fields:
     actions:
       - set:
-          event.kind: "event"
           event.category: ["network"]
           event.code: "{{json_event.message.operationName}}"
           "@timestamp": "{{json_event.message.time}}"

--- a/Azure/azure-network-watcher/tests/continue.json
+++ b/Azure/azure-network-watcher/tests/continue.json
@@ -10,7 +10,6 @@
         "network"
       ],
       "code": "NetworkSecurityGroupFlowEvents",
-      "kind": "event",
       "outcome": "success",
       "start": "2024-03-18T13:21:42.625922Z",
       "type": [

--- a/Azure/azure-network-watcher/tests/test_begin.json
+++ b/Azure/azure-network-watcher/tests/test_begin.json
@@ -16,7 +16,6 @@
         "network"
       ],
       "code": "NetworkSecurityGroupFlowEvents",
-      "kind": "event",
       "outcome": "success",
       "start": "2020-12-14T22:16:46.352816Z",
       "type": [

--- a/Azure/azure-network-watcher/tests/test_end.json
+++ b/Azure/azure-network-watcher/tests/test_end.json
@@ -16,7 +16,6 @@
         "network"
       ],
       "code": "NetworkSecurityGroupFlowEvents",
-      "kind": "event",
       "outcome": "success",
       "start": "2020-12-14T22:16:46.352816Z",
       "type": [

--- a/Azure/azure-network-watcher/tests/test_short.json
+++ b/Azure/azure-network-watcher/tests/test_short.json
@@ -16,7 +16,6 @@
         "network"
       ],
       "code": "NetworkSecurityGroupFlowEvents",
-      "kind": "event",
       "outcome": "success",
       "start": "2021-03-24T10:55:03.068074Z",
       "type": [


### PR DESCRIPTION
`event.kind: "event"` is now considered as useless. I remove this field from the format