### PR TITLE
Olfeo: fix the category identifier

### DIFF
--- a/Olfeo/olfeo-secure-web-gateway/_meta/fields.yml
+++ b/Olfeo/olfeo-secure-web-gateway/_meta/fields.yml
@@ -2,3 +2,8 @@ olfeo.request.type:
   description: Olfeo request url category
   name: olfeo.request.type
   type: keyword
+
+olfeo.request.type_id:
+  description: Olfeo request url category id
+  name: olfeo.request.type_id
+  type: long

--- a/Olfeo/olfeo-secure-web-gateway/ingest/parser.yml
+++ b/Olfeo/olfeo-secure-web-gateway/ingest/parser.yml
@@ -12,7 +12,7 @@ pipeline:
         pattern: >-
           \s*%{IP:source_ip} - %{DATA:user} \[%{DATA:date}\] "%{DATA:method}
           %{DATA:url} HTTP/%{NUMBER:http_version}" %{NUMBER:response_code} - -
-          %{DATA:bytes} %{GREEDYDATA:type}
+          %{DATA:type_id} %{GREEDYDATA:type}
         custom_patterns: {}
   - name: ecs_fields
     description: ""
@@ -32,9 +32,9 @@ stages:
           source.user.name: "{{parse_grok.message.user}}"
           source.ip: "{{parse_grok.message.source_ip}}"
           olfeo.request.type: "{{parse_grok.message.type}}"
+          olfeo.request.type_id: "{{parse_grok.message.type_id}}"
           http.version: "{{parse_grok.message.http_version}}"
           http.request.method: "{{parse_grok.message.method}}"
-          http.response.bytes: "{{parse_grok.message.bytes}}"
           http.response.status_code: "{{parse_grok.message.response_code}}"
           action.outcome: |
             {%- if parse_grok.message.response_code != None -%}

--- a/Olfeo/olfeo-secure-web-gateway/tests/network_log.json
+++ b/Olfeo/olfeo-secure-web-gateway/tests/network_log.json
@@ -24,7 +24,6 @@
         "method": "CONNECT"
       },
       "response": {
-        "bytes": 1000,
         "status_code": 200
       },
       "version": "1.1"
@@ -36,7 +35,8 @@
     },
     "olfeo": {
       "request": {
-        "type": "Business Services"
+        "type": "Business Services",
+        "type_id": 1000
       }
     },
     "related": {

--- a/Olfeo/olfeo-secure-web-gateway/tests/network_log_no_user.json
+++ b/Olfeo/olfeo-secure-web-gateway/tests/network_log_no_user.json
@@ -24,7 +24,6 @@
         "method": "POST"
       },
       "response": {
-        "bytes": 12,
         "status_code": 400
       },
       "version": "1.1"
@@ -36,7 +35,8 @@
     },
     "olfeo": {
       "request": {
-        "type": "Advertising"
+        "type": "Advertising",
+        "type_id": 12
       }
     },
     "related": {

--- a/Olfeo/olfeo-secure-web-gateway/tests/network_log_space.json
+++ b/Olfeo/olfeo-secure-web-gateway/tests/network_log_space.json
@@ -24,7 +24,6 @@
         "method": "PUT"
       },
       "response": {
-        "bytes": 512,
         "status_code": 300
       },
       "version": "1.1"
@@ -36,7 +35,8 @@
     },
     "olfeo": {
       "request": {
-        "type": "Shopping"
+        "type": "Shopping",
+        "type_id": 512
       }
     },
     "related": {


### PR DESCRIPTION
The integer before the category of the URL is the category identifier.

Fix the parser in accordance