### PR TITLE
SentinelOne: add support for dns events from Mac OS X

### DIFF
--- a/SentinelOne/cloud_funnel2.0/ingest/parser.yml
+++ b/SentinelOne/cloud_funnel2.0/ingest/parser.yml
@@ -506,7 +506,7 @@ stages:
   set_dns_fields:
     actions:
       - set:
-          dns.question.name: '{{json_event.message.get("event.dns.request")}}'
+          dns.question.name: '{{json_event.message.get("event.dns.request").split(" ")[-1]}}'
           dns.type: "query"
         filter: '{{json_event.message.get("event.dns.request") != None}}'
 

--- a/SentinelOne/cloud_funnel2.0/tests/dns_macos.json
+++ b/SentinelOne/cloud_funnel2.0/tests/dns_macos.json
@@ -1,0 +1,129 @@
+{
+  "input": {
+    "message": "{\n  \"src.process.image.path\": \"/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/123.0.6312.123/Helpers/Google Chrome Helper.app/Contents/MacOS/Google Chrome Helper\",\n  \"src.process.subsystem\": \"SUBSYSTEM_UNKNOWN\",\n  \"src.process.parent.isStorylineRoot\": true,\n  \"event.category\": \"dns\",\n  \"src.process.parent.integrityLevel\": \"INTEGRITY_LEVEL_UNKNOWN\",\n  \"src.process.parent.image.sha1\": \"adc83b19e793491b1c6ea0fd8b46cd9f32e592fc\",\n  \"src.process.parent.storyline.id\": \"0A62D926-DFE7-4968-AA28-F0024BAC804D\",\n  \"src.process.isRedirectCmdProcessor\": false,\n  \"src.process.parent.publisher\": \"<Type=DevID/ID=com.google.Chrome/Subject=OU:DESKTOP001>\",\n  \"src.process.parent.startTime\": 1713167784335,\n  \"endpoint.type\": \"laptop\",\n  \"endpoint.os\": \"osx\",\n  \"src.process.integrityLevel\": \"INTEGRITY_LEVEL_UNKNOWN\",\n  \"src.process.parent.displayName\": \"Google Chrome\",\n  \"src.process.name\": \"Google Chrome Helper\",\n  \"src.process.startTime\": 1713167795818,\n  \"agent.uuid\": \"75084C59-0F8A-479D-A9C4-2232C37D9D51\",\n  \"event.dns.response\": \"type:  5 edge-web-gew4.dual-gslb.spotify.com;2600:1901:1:4be::;\",\n  \"src.process.image.sha256\": \"01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b\",\n  \"src.process.user\": \"jdoe\",\n  \"timestamp\": \"2024-06-26T08:44:30.000Z\",\n  \"src.process.displayName\": \"Google Chrome Helper\",\n  \"endpoint.name\": \"MXY2XC6J7VJ\",\n  \"src.process.image.sha1\": \"adc83b19e793491b1c6ea0fd8b46cd9f32e592fc\",\n  \"event.dns.request\": \"type:  28 gew4-spclient.spotify.com\",\n  \"src.process.isStorylineRoot\": false,\n  \"src.process.parent.image.path\": \"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome\",\n  \"src.process.isNative64Bit\": false,\n  \"src.process.parent.sessionId\": 0,\n  \"src.process.uid\": \"CF37475F-BCA9-4F89-8A31-7B6C88CC6F1E\",\n  \"src.process.parent.image.md5\": \"68b329da9893e34099c7d8ad5cb9c940\",\n  \"src.process.parent.user\": \"psinha\",\n  \"src.process.pid\": 1063,\n  \"src.process.parent.name\": \"Google Chrome\",\n  \"src.process.cmdline\": \"/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/123.0.6312.123/Helpers/Google Chrome Helper.app/Contents/MacOS/Google Chrome Helper --type=utility --utility-sub-type=network.mojom.NetworkService --lang=en-GB --service-sandbox-type=network --shared-files --field-trial-handle=1718379636,r,10310964397040083203,6939088771020272477,262144 --variations-seed-version=20240412-130119.249000 --seatbelt-client=25\",\n  \"src.process.publisher\": \"<Type=DevID/ID=com.google.Chrome.helper/Subject=OU:DESKTOP001>\",\n  \"src.process.parent.isNative64Bit\": false,\n  \"src.process.parent.isRedirectCmdProcessor\": false,\n  \"src.process.image.md5\": \"68b329da9893e34099c7d8ad5cb9c940\",\n  \"src.process.storyline.id\": \"0A62D926-DFE7-4968-AA28-F0024BAC804D\",\n  \"event.type\": \"DNS Resolved\",\n  \"agent.version\": \"24.1.2.7444\",\n  \"src.process.signedStatus\": \"signed\",\n  \"src.process.parent.image.sha256\": \"01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b\",\n  \"src.process.parent.cmdline\": \"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome\",\n  \"src.process.sessionId\": 0,\n  \"src.process.parent.pid\": 790\n}\n",
+    "sekoiaio": {
+      "intake": {
+        "dialect": "SentinelOne Cloud Funnel 2.0",
+        "dialect_uuid": "40deb162-6bb1-4635-9c99-5c2de7e1d340"
+      }
+    }
+  },
+  "expected": {
+    "message": "{\n  \"src.process.image.path\": \"/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/123.0.6312.123/Helpers/Google Chrome Helper.app/Contents/MacOS/Google Chrome Helper\",\n  \"src.process.subsystem\": \"SUBSYSTEM_UNKNOWN\",\n  \"src.process.parent.isStorylineRoot\": true,\n  \"event.category\": \"dns\",\n  \"src.process.parent.integrityLevel\": \"INTEGRITY_LEVEL_UNKNOWN\",\n  \"src.process.parent.image.sha1\": \"adc83b19e793491b1c6ea0fd8b46cd9f32e592fc\",\n  \"src.process.parent.storyline.id\": \"0A62D926-DFE7-4968-AA28-F0024BAC804D\",\n  \"src.process.isRedirectCmdProcessor\": false,\n  \"src.process.parent.publisher\": \"<Type=DevID/ID=com.google.Chrome/Subject=OU:DESKTOP001>\",\n  \"src.process.parent.startTime\": 1713167784335,\n  \"endpoint.type\": \"laptop\",\n  \"endpoint.os\": \"osx\",\n  \"src.process.integrityLevel\": \"INTEGRITY_LEVEL_UNKNOWN\",\n  \"src.process.parent.displayName\": \"Google Chrome\",\n  \"src.process.name\": \"Google Chrome Helper\",\n  \"src.process.startTime\": 1713167795818,\n  \"agent.uuid\": \"75084C59-0F8A-479D-A9C4-2232C37D9D51\",\n  \"event.dns.response\": \"type:  5 edge-web-gew4.dual-gslb.spotify.com;2600:1901:1:4be::;\",\n  \"src.process.image.sha256\": \"01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b\",\n  \"src.process.user\": \"jdoe\",\n  \"timestamp\": \"2024-06-26T08:44:30.000Z\",\n  \"src.process.displayName\": \"Google Chrome Helper\",\n  \"endpoint.name\": \"MXY2XC6J7VJ\",\n  \"src.process.image.sha1\": \"adc83b19e793491b1c6ea0fd8b46cd9f32e592fc\",\n  \"event.dns.request\": \"type:  28 gew4-spclient.spotify.com\",\n  \"src.process.isStorylineRoot\": false,\n  \"src.process.parent.image.path\": \"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome\",\n  \"src.process.isNative64Bit\": false,\n  \"src.process.parent.sessionId\": 0,\n  \"src.process.uid\": \"CF37475F-BCA9-4F89-8A31-7B6C88CC6F1E\",\n  \"src.process.parent.image.md5\": \"68b329da9893e34099c7d8ad5cb9c940\",\n  \"src.process.parent.user\": \"psinha\",\n  \"src.process.pid\": 1063,\n  \"src.process.parent.name\": \"Google Chrome\",\n  \"src.process.cmdline\": \"/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/123.0.6312.123/Helpers/Google Chrome Helper.app/Contents/MacOS/Google Chrome Helper --type=utility --utility-sub-type=network.mojom.NetworkService --lang=en-GB --service-sandbox-type=network --shared-files --field-trial-handle=1718379636,r,10310964397040083203,6939088771020272477,262144 --variations-seed-version=20240412-130119.249000 --seatbelt-client=25\",\n  \"src.process.publisher\": \"<Type=DevID/ID=com.google.Chrome.helper/Subject=OU:DESKTOP001>\",\n  \"src.process.parent.isNative64Bit\": false,\n  \"src.process.parent.isRedirectCmdProcessor\": false,\n  \"src.process.image.md5\": \"68b329da9893e34099c7d8ad5cb9c940\",\n  \"src.process.storyline.id\": \"0A62D926-DFE7-4968-AA28-F0024BAC804D\",\n  \"event.type\": \"DNS Resolved\",\n  \"agent.version\": \"24.1.2.7444\",\n  \"src.process.signedStatus\": \"signed\",\n  \"src.process.parent.image.sha256\": \"01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b\",\n  \"src.process.parent.cmdline\": \"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome\",\n  \"src.process.sessionId\": 0,\n  \"src.process.parent.pid\": 790\n}\n",
+    "event": {
+      "action": "DNS Resolved",
+      "category": [
+        "network"
+      ],
+      "dataset": "cloud-funnel-2.0",
+      "type": [
+        "info"
+      ]
+    },
+    "@timestamp": "2024-06-26T08:44:30Z",
+    "agent": {
+      "version": "24.1.2.7444"
+    },
+    "deepvisibility": {
+      "agent": {
+        "uuid": "75084C59-0F8A-479D-A9C4-2232C37D9D51"
+      },
+      "event": {
+        "category": "dns",
+        "type": "DNS Resolved"
+      },
+      "process": {
+        "parent": {
+          "storyline_id": "0A62D926-DFE7-4968-AA28-F0024BAC804D"
+        },
+        "storyline_id": "0A62D926-DFE7-4968-AA28-F0024BAC804D"
+      }
+    },
+    "dns": {
+      "answers": [
+        {
+          "name": "edge-web-gew4.dual-gslb.spotify.com",
+          "type": "CNAME"
+        },
+        {
+          "name": "2600:1901:1:4be::",
+          "type": "AAAA"
+        }
+      ],
+      "question": {
+        "name": "gew4-spclient.spotify.com",
+        "registered_domain": "spotify.com",
+        "subdomain": "gew4-spclient",
+        "top_level_domain": "com"
+      },
+      "type": "answer"
+    },
+    "host": {
+      "name": "MXY2XC6J7VJ",
+      "os": {
+        "family": "osx"
+      },
+      "type": "laptop"
+    },
+    "observer": {
+      "vendor": "SentinelOne"
+    },
+    "process": {
+      "code_signature": {
+        "exists": true,
+        "subject_name": "<Type=DevID/ID=com.google.Chrome.helper/Subject=OU:DESKTOP001>"
+      },
+      "command_line": "/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/123.0.6312.123/Helpers/Google Chrome Helper.app/Contents/MacOS/Google Chrome Helper --type=utility --utility-sub-type=network.mojom.NetworkService --lang=en-GB --service-sandbox-type=network --shared-files --field-trial-handle=1718379636,r,10310964397040083203,6939088771020272477,262144 --variations-seed-version=20240412-130119.249000 --seatbelt-client=25",
+      "executable": "/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/123.0.6312.123/Helpers/Google Chrome Helper.app/Contents/MacOS/Google Chrome Helper",
+      "hash": {
+        "md5": "68b329da9893e34099c7d8ad5cb9c940",
+        "sha1": "adc83b19e793491b1c6ea0fd8b46cd9f32e592fc",
+        "sha256": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"
+      },
+      "name": "Google Chrome Helper",
+      "parent": {
+        "code_signature": {
+          "exists": false
+        },
+        "command_line": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        "executable": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        "hash": {
+          "md5": "68b329da9893e34099c7d8ad5cb9c940",
+          "sha1": "adc83b19e793491b1c6ea0fd8b46cd9f32e592fc",
+          "sha256": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"
+        },
+        "name": "Google Chrome",
+        "pid": 790,
+        "start": "2024-04-15T07:56:24.335000Z",
+        "title": "Google Chrome",
+        "user": {
+          "name": "psinha"
+        },
+        "working_directory": "/Applications/Google Chrome.app/Contents/MacOS"
+      },
+      "pid": 1063,
+      "start": "2024-04-15T07:56:35.818000Z",
+      "title": "Google Chrome Helper",
+      "user": {
+        "name": "jdoe"
+      },
+      "working_directory": "/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/123.0.6312.123/Helpers/Google Chrome Helper.app/Contents/MacOS"
+    },
+    "related": {
+      "hash": [
+        "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+        "68b329da9893e34099c7d8ad5cb9c940",
+        "adc83b19e793491b1c6ea0fd8b46cd9f32e592fc"
+      ],
+      "hosts": [
+        "gew4-spclient.spotify.com"
+      ],
+      "user": [
+        "jdoe"
+      ]
+    },
+    "user": {
+      "name": "jdoe"
+    }
+  }
+}


### PR DESCRIPTION
Add support for dns events from Mac OS X that prefixes the `event.dns.request` value with the type of the request