### PR TITLE
Replace zscaler.zia.deviceowner by user.name

### DIFF
--- a/Zscaler/zscaler-zia/_meta/fields.yml
+++ b/Zscaler/zscaler-zia/_meta/fields.yml
@@ -23,11 +23,6 @@ zscaler.zia.department:
   name: zscaler.zia.department
   type: keyword
 
-zscaler.zia.device.owner:
-  description: ZScaler device owner
-  name: zscaler.zia.device.owner
-  type: keyword
-
 zscaler.zia.event.outcome:
   description: ZScaler event outcome
   name: zscaler.zia.event.outcome

--- a/Zscaler/zscaler-zia/ingest/parser.yml
+++ b/Zscaler/zscaler-zia/ingest/parser.yml
@@ -83,7 +83,6 @@ stages:
           zscaler.zia.threat.name: "{{json_event.message.event.threatname}}"
           zscaler.zia.threat.class: "{{json_event.message.event.threatclass}}"
           zscaler.zia.threat.category: "{{json_event.message.event.threatcategory or json_event.message.event.threatcat}}"
-          zscaler.zia.device.owner: "{{json_event.message.event.deviceowner}}"
           zscaler.zia.keyprotectiontype: "{{json_event.message.event.keyprotectiontype}}"
           zscaler.zia.tuntype: "{{json_event.message.event.tuntype}}"
           zscaler.zia.avgduration: "{{json_event.message.event.avgduration}}"
@@ -112,6 +111,7 @@ stages:
           url.original: "{{json_event.message.event.fullurl}}"
 
           user.email: "{{json_event.message.event.user or json_event.message.event.login}}"
+          user.name: "{{json_event.message.event.deviceowner}}"
           network.protocol: "{{json_event.message.event.protocol or json_event.message.event.proto}}"
 
           source.port: "{{json_event.message.event.csport or json_event.message.event.sourceport}}"

--- a/Zscaler/zscaler-zia/tests/test_event_dns.json
+++ b/Zscaler/zscaler-zia/tests/test_event_dns.json
@@ -39,6 +39,9 @@
       "ip": [
         "1.2.3.4",
         "5.6.7.8"
+      ],
+      "user": [
+        "johndoe"
       ]
     },
     "source": {
@@ -46,15 +49,13 @@
       "ip": "1.2.3.4"
     },
     "user": {
-      "email": "john.doe@example.orf"
+      "email": "john.doe@example.orf",
+      "name": "johndoe"
     },
     "zscaler": {
       "zia": {
         "category": "Corporate Marketing",
         "department": "Financial%20Dept",
-        "device": {
-          "owner": "johndoe"
-        },
         "source_type": "zscalernss-dns"
       }
     }

--- a/Zscaler/zscaler-zia/tests/test_event_firewall.json
+++ b/Zscaler/zscaler-zia/tests/test_event_firewall.json
@@ -32,6 +32,9 @@
       "ip": [
         "1.2.3.4",
         "5.6.7.8"
+      ],
+      "user": [
+        "johndoe"
       ]
     },
     "source": {
@@ -41,15 +44,13 @@
       "port": 52352
     },
     "user": {
-      "email": "john.doe@example.org"
+      "email": "john.doe@example.org",
+      "name": "johndoe"
     },
     "zscaler": {
       "zia": {
         "avgduration": "170000",
         "department": "Financial%20Dept",
-        "device": {
-          "owner": "johndoe"
-        },
         "source_type": "zscalernss-fw",
         "threat": {
           "category": "Threat category 2",

--- a/Zscaler/zscaler-zia/tests/test_event_web.json
+++ b/Zscaler/zscaler-zia/tests/test_event_web.json
@@ -46,6 +46,9 @@
       "ip": [
         "1.2.3.4",
         "5.6.7.8"
+      ],
+      "user": [
+        "johndoe"
       ]
     },
     "server": {
@@ -62,7 +65,8 @@
       "top_level_domain": "com"
     },
     "user": {
-      "email": "john.doe@example.org"
+      "email": "john.doe@example.org",
+      "name": "johndoe"
     },
     "user_agent": {
       "device": {
@@ -78,9 +82,6 @@
       "zia": {
         "appname": "General Browsing",
         "department": "Financial%20Dept",
-        "device": {
-          "owner": "johndoe"
-        },
         "event_id": "1111111111111111111",
         "keyprotectiontype": "N/A",
         "product": "NSS",

--- a/Zscaler/zscaler-zia/tests/test_event_web2.json
+++ b/Zscaler/zscaler-zia/tests/test_event_web2.json
@@ -47,6 +47,9 @@
       "ip": [
         "1.2.3.4",
         "5.6.7.8"
+      ],
+      "user": [
+        "johndoe"
       ]
     },
     "server": {
@@ -65,7 +68,8 @@
       "top_level_domain": "com"
     },
     "user": {
-      "email": "john.doe@example.org"
+      "email": "john.doe@example.org",
+      "name": "johndoe"
     },
     "user_agent": {
       "device": {
@@ -81,9 +85,6 @@
       "zia": {
         "appname": "General Browsing",
         "department": "Financial%20Dept",
-        "device": {
-          "owner": "johndoe"
-        },
         "event_id": "1111111111111111111",
         "keyprotectiontype": "N/A",
         "product": "NSS",


### PR DESCRIPTION
Based on Zscaler ZIA documentation, the `deviceowner` field in logs contains the locally logged in user. 
Setting the `user.name` field with this value would allow for a better discovery of Assets and the ability to easily pivot between different type of logs based on the `user.name`.

Source: https://help.zscaler.com/client-connector/viewing-device-fingerprint-enrolled-device
![image](https://github.com/SEKOIA-IO/intake-formats/assets/80452887/2e6f005b-3317-47dc-be4e-9657b51ef148)