### PR TITLE
Entra ID - Fix missing action.outcome for SigninLogs

### DIFF
--- a/Azure/azure-ad/ingest/parser.yml
+++ b/Azure/azure-ad/ingest/parser.yml
@@ -43,7 +43,6 @@ stages:
   read_message_properties:
     actions:
       - set:
-          action.outcome: "{{parsed_event.message.properties.result}}"
           action.type: "{{parsed_event.message.properties.operationType |lower}}"
           event.reason: "{{ parsed_event.message.properties.riskType }}"
           error.code: "{{parsed_event.message.properties.status.errorCode}}"
@@ -177,6 +176,8 @@ stages:
 
   log_type_auditlogs_has_message_properties:
     actions:
+      - set:
+          action.outcome : "{{parsed_event.message.properties.result}}"
       - set:
           action.outcome_reason: "{{parsed_event.message.properties.resultReason}}"
           event.reason: "{{parsed_event.message.properties.resultReason}}"

--- a/Azure/azure-ad/ingest/parser.yml
+++ b/Azure/azure-ad/ingest/parser.yml
@@ -177,7 +177,7 @@ stages:
   log_type_auditlogs_has_message_properties:
     actions:
       - set:
-          action.outcome : "{{parsed_event.message.properties.result}}"
+          action.outcome: "{{parsed_event.message.properties.result}}"
       - set:
           action.outcome_reason: "{{parsed_event.message.properties.resultReason}}"
           event.reason: "{{parsed_event.message.properties.resultReason}}"


### PR DESCRIPTION
Fix missing `action.outcome` for SigninLogs by setting `action.outcome` from `properties.result` field only for AuditLogs events