### PR TITLE
fix(microsoft-intune): adding DeviceHostName and priority

### DIFF
--- a/Microsoft/microsoft-intune/ingest/parser.yml
+++ b/Microsoft/microsoft-intune/ingest/parser.yml
@@ -22,23 +22,24 @@ stages:
           action.type: "{{json_event.message.category}}"
           event.type: ["info"]
           host.id: "{{json_event.message.properties.DeviceId}}"
-
       - set:
           host.mac: ["{{json_event.message.properties.WifiMacAddress}}"]
         filter: "{{json_event.message.properties.WifiMacAddress != null}}"
       - set:
-          host.name: "{{json_event.message.properties.ManagedDeviceName or json_event.message.properties.DeviceHostName }}"
+          host.name: "{{json_event.message.properties.DeviceHostName}}"
+      - set:
+          host.name: "{{json_event.message.properties.DeviceName or json_event.message.properties.ManagedDeviceName}}"
+        filter: "{{final.host.name == null}}"
+      - set:
           host.type: "{{json_event.message.properties.Model}}"
           microsoft.intune.compliant_state: "{{json_event.message.properties.CompliantState}}"
           network.application: "{{json_event.message.ApplicationName}}"
           host.os.full: "{{json_event.message.properties.OS}}"
           host.os.version: "{{json_event.message.properties.OSVersion}}"
           service.name: "{{json_event.message.properties.ManagedBy}}"
-
       - set:
           source.ip: "{{json_event.message.actor.ipAddress}}"
         filter: "{{json_event.message.actor.ipAddress | is_ipaddress}}"
-
       - set:
           source.mac: "{{json_event.message.properties.WifiMacAddress}}"
           user.email: "{{json_event.message.properties.UserEmail}}"

--- a/Microsoft/microsoft-intune/tests/DeviceComplianceOrg.json
+++ b/Microsoft/microsoft-intune/tests/DeviceComplianceOrg.json
@@ -17,6 +17,7 @@
     },
     "host": {
       "id": "06334044-1a53-47d6-b6f8-ec9dcba8fa93",
+      "name": "DESKTOP-086N6KI",
       "os": {
         "full": "Windows",
         "version": "10.0.19044.2130"


### PR DESCRIPTION
Review `host.name` field, actions to:
* add `DeviceHostName` info
* prioritize with the order `DeviceHostName` -> `DeviceName` -> `ManagedDeviceName`

That doe not solve issues with uuid, name + date concatenation.