### PR TITLE
Fortigate: Addition of logdev fields in the parser

### DIFF
--- a/Fortinet/fortigate/_meta/fields.yml
+++ b/Fortinet/fortigate/_meta/fields.yml
@@ -63,6 +63,21 @@ fortinet.fortigate.icmp.request.type:
   name: fortinet.fortigate.icmp.request.type
   type: keyword
 
+fortinet.fortigate.logdev.id:
+  description: ID of the device that generated the log.
+  name: fortinet.fortigate.logdev.id
+  type: keyword
+
+fortinet.fortigate.logdev.last_logging:
+  description: Last logging time of the device.
+  name: fortinet.fortigate.logdev.last_logging
+  type: date
+
+fortinet.fortigate.logdev.name:
+  description: Name of the device that generated the log.
+  name: fortinet.fortigate.logdev.name
+  type: keyword
+
 fortinet.fortigate.policyid:
   description: ID of the policy
   name: fortinet.fortigate.policyid

--- a/Fortinet/fortigate/ingest/parser.yml
+++ b/Fortinet/fortigate/ingest/parser.yml
@@ -166,8 +166,7 @@ stages:
   #      - set:
   #          event.kind: "event"
   #          event.category: ["network"]
-  #
-  #      - set:
+  #action
   #          event.type: [ "allowed", "connection" ]
   #        filter: '{{parsed_event.message.action == "accept"
   #         or parsed_event.message.act in ["pass", "permit", "passthrough", "log-only", "ssl-new-con", "accept", "dns"]
@@ -321,6 +320,11 @@ stages:
           user.domain: '{{final.user.name.split("\\") | first}}'
           user.name: '{{final.user.name.split("\\") | last}}'
         filter: "{{final.get('user', {}).get('name') != None and '\\\\' in final.user.name}}"
+      - set:
+          fortinet.fortigate.logdev.id: "{{parsed_event.message.logdev_id}}"
+          fortinet.fortigate.logdev.name: "{{parsed_event.message.logdev_name}}"
+          fortinet.fortigate.logdev.last_logging: "{{parsed_event.message.logdev_last_logging | to_rfc3339}}"
+        filter: "{{parsed_event.message.subtype == 'logdev'}}"
       - set:
           fortinet.fortigate.tunnel.name: "{{parsed_event.message.vpntunnel}}"
           fortinet.fortigate.tunnel.version: "{{parsed_event.message.version}}"

--- a/Fortinet/fortigate/tests/DNS.STANDARD.json
+++ b/Fortinet/fortigate/tests/DNS.STANDARD.json
@@ -36,9 +36,6 @@
         "virtual_domain": "root"
       }
     },
-    "host": {
-      "name": "my-device"
-    },
     "log": {
       "hostname": "my-device",
       "level": "information"

--- a/Fortinet/fortigate/tests/DNS2.STANDARD.json
+++ b/Fortinet/fortigate/tests/DNS2.STANDARD.json
@@ -39,9 +39,6 @@
         "virtual_domain": "root"
       }
     },
-    "host": {
-      "name": "dev-name"
-    },
     "log": {
       "hostname": "dev-name",
       "level": "information"

--- a/Fortinet/fortigate/tests/IP_SEC.STANDARD.json
+++ b/Fortinet/fortigate/tests/IP_SEC.STANDARD.json
@@ -37,9 +37,6 @@
         "virtual_domain": "root"
       }
     },
-    "host": {
-      "name": "abc"
-    },
     "log": {
       "description": "Progress IPsec phase 2",
       "hostname": "abc",

--- a/Fortinet/fortigate/tests/LOGOUT.STANDARD.json
+++ b/Fortinet/fortigate/tests/LOGOUT.STANDARD.json
@@ -33,9 +33,6 @@
         "virtual_domain": "root"
       }
     },
-    "host": {
-      "name": "abc"
-    },
     "http": {
       "request": {
         "method": "jsconsole"

--- a/Fortinet/fortigate/tests/ROLL-LOG.STANDARD.json
+++ b/Fortinet/fortigate/tests/ROLL-LOG.STANDARD.json
@@ -27,9 +27,6 @@
         "virtual_domain": "PRX1-AA"
       }
     },
-    "host": {
-      "name": "abc"
-    },
     "log": {
       "description": "Disk log rolled",
       "hostname": "abc",

--- a/Fortinet/fortigate/tests/WAD.STANDARD.json
+++ b/Fortinet/fortigate/tests/WAD.STANDARD.json
@@ -36,9 +36,6 @@
         "virtual_domain": "PRX1-AA"
       }
     },
-    "host": {
-      "name": "abc"
-    },
     "log": {
       "description": "SSL fatal alert sent",
       "hostname": "abc",

--- a/Fortinet/fortigate/tests/editpolicy.json
+++ b/Fortinet/fortigate/tests/editpolicy.json
@@ -35,9 +35,6 @@
         "virtual_domain": "AAAA-AA"
       }
     },
-    "host": {
-      "name": "PC-01-OS1"
-    },
     "log": {
       "description": "Object attribute configured",
       "hostname": "PC-01-OS1",

--- a/Fortinet/fortigate/tests/event_logdev.json
+++ b/Fortinet/fortigate/tests/event_logdev.json
@@ -1,0 +1,63 @@
+{
+  "input": {
+    "message": "devname=\".self\" devid=\"1111111111111111\" vd=\"root\" itime=1725479662 date=\"2024-09-04\" time=\"19:54:22\" tz=\"+0000\" type=\"appevent\" user=\"system\" user_from=\"system\" logid=\"222222\" subtype=\"logdev\" eventtype=\"logging-status\" level=\"warning\" desc=\"Device offline\" logdev_id=\"ABCDEFGHIJKLMNOP\" logdev_name=\"LOGDEV-NAME\" logdev_offline_duration=69138 logdev_last_logging=1721331330 msg=\"Did not receive any log from device LOGDEV-NAME[ABCDEFGHIJKLMNOP] in past 48d18m52s (69138 minutes).\"",
+    "sekoiaio": {
+      "intake": {
+        "dialect": "Fortinet FortiGate",
+        "dialect_uuid": "5702ae4e-7d8a-455f-a47b-ef64dd87c981"
+      }
+    }
+  },
+  "expected": {
+    "message": "devname=\".self\" devid=\"1111111111111111\" vd=\"root\" itime=1725479662 date=\"2024-09-04\" time=\"19:54:22\" tz=\"+0000\" type=\"appevent\" user=\"system\" user_from=\"system\" logid=\"222222\" subtype=\"logdev\" eventtype=\"logging-status\" level=\"warning\" desc=\"Device offline\" logdev_id=\"ABCDEFGHIJKLMNOP\" logdev_name=\"LOGDEV-NAME\" logdev_offline_duration=69138 logdev_last_logging=1721331330 msg=\"Did not receive any log from device LOGDEV-NAME[ABCDEFGHIJKLMNOP] in past 48d18m52s (69138 minutes).\"",
+    "event": {
+      "category": "appevent",
+      "code": "222222",
+      "reason": "Did not receive any log from device LOGDEV-NAME[ABCDEFGHIJKLMNOP] in past 48d18m52s (69138 minutes).",
+      "timezone": "+0000",
+      "type": "Device offline"
+    },
+    "action": {
+      "outcome_reason": "Did not receive any log from device LOGDEV-NAME[ABCDEFGHIJKLMNOP] in past 48d18m52s (69138 minutes).",
+      "type": "logdev"
+    },
+    "fortinet": {
+      "fortigate": {
+        "event": {
+          "desc": "Device offline",
+          "type": "appevent"
+        },
+        "logdev": {
+          "id": "ABCDEFGHIJKLMNOP",
+          "last_logging": "2024-07-18T19:35:30.000000Z",
+          "name": "LOGDEV-NAME"
+        },
+        "virtual_domain": "root"
+      }
+    },
+    "log": {
+      "hostname": ".self",
+      "level": "warning"
+    },
+    "observer": {
+      "hostname": ".self",
+      "serial_number": "1111111111111111"
+    },
+    "related": {
+      "hosts": [
+        ".self"
+      ],
+      "user": [
+        "system"
+      ]
+    },
+    "source": {
+      "user": {
+        "name": "system"
+      }
+    },
+    "user": {
+      "name": "system"
+    }
+  }
+}

--- a/Fortinet/fortigate/tests/forwadedfor.json
+++ b/Fortinet/fortigate/tests/forwadedfor.json
@@ -44,9 +44,6 @@
         "virtual_domain": "root"
       }
     },
-    "host": {
-      "name": "FW-001"
-    },
     "http": {
       "request": {
         "method": "domain"

--- a/Fortinet/fortigate/tests/hostname.STANDARD.json
+++ b/Fortinet/fortigate/tests/hostname.STANDARD.json
@@ -36,9 +36,6 @@
         "virtual_domain": "root"
       }
     },
-    "host": {
-      "name": "abc"
-    },
     "log": {
       "hostname": "abc",
       "level": "information"

--- a/Fortinet/fortigate/tests/icmp.json
+++ b/Fortinet/fortigate/tests/icmp.json
@@ -33,9 +33,6 @@
         "virtual_domain": "root"
       }
     },
-    "host": {
-      "name": "abc"
-    },
     "log": {
       "hostname": "abc",
       "level": "warning"

--- a/Fortinet/fortigate/tests/icmp6.json
+++ b/Fortinet/fortigate/tests/icmp6.json
@@ -34,9 +34,6 @@
         "virtual_domain": "root"
       }
     },
-    "host": {
-      "name": "abc"
-    },
     "log": {
       "hostname": "abc",
       "level": "notice"

--- a/Fortinet/fortigate/tests/ping.json
+++ b/Fortinet/fortigate/tests/ping.json
@@ -35,9 +35,6 @@
         "virtual_domain": "ROUTER"
       }
     },
-    "host": {
-      "name": "abc"
-    },
     "log": {
       "hostname": "abc",
       "level": "notice"

--- a/Fortinet/fortigate/tests/test_ips.STANDARD.json
+++ b/Fortinet/fortigate/tests/test_ips.STANDARD.json
@@ -41,9 +41,6 @@
         "virtual_domain": "root"
       }
     },
-    "host": {
-      "name": "abc"
-    },
     "log": {
       "hostname": "abc",
       "level": "alert"

--- a/Fortinet/fortigate/tests/traffic_forward.STANDARD_2.json
+++ b/Fortinet/fortigate/tests/traffic_forward.STANDARD_2.json
@@ -34,9 +34,6 @@
         "virtual_domain": "PRX1-AA"
       }
     },
-    "host": {
-      "name": "abc"
-    },
     "log": {
       "hostname": "abc",
       "level": "notice"

--- a/Fortinet/fortigate/tests/traffic_nat.STANDARD.json
+++ b/Fortinet/fortigate/tests/traffic_nat.STANDARD.json
@@ -39,9 +39,6 @@
         "virtual_domain": "root"
       }
     },
-    "host": {
-      "name": "abc"
-    },
     "log": {
       "hostname": "abc",
       "level": "notice"

--- a/Fortinet/fortigate/tests/tunnel.json
+++ b/Fortinet/fortigate/tests/tunnel.json
@@ -37,9 +37,6 @@
         "virtual_domain": "IPSEC"
       }
     },
-    "host": {
-      "name": "abc"
-    },
     "log": {
       "description": "SSL VPN statistics",
       "hostname": "abc",

--- a/Fortinet/fortigate/tests/tunnel_statistics.CSV.json
+++ b/Fortinet/fortigate/tests/tunnel_statistics.CSV.json
@@ -39,9 +39,6 @@
         "virtual_domain": "root"
       }
     },
-    "host": {
-      "name": "abc"
-    },
     "log": {
       "description": "IPsec tunnel statistics",
       "hostname": "abc",

--- a/Fortinet/fortigate/tests/vpn.STANDARD.json
+++ b/Fortinet/fortigate/tests/vpn.STANDARD.json
@@ -28,9 +28,6 @@
         "virtual_domain": "root"
       }
     },
-    "host": {
-      "name": "abc"
-    },
     "http": {
       "request": {
         "method": "HTTP"

--- a/Fortinet/fortigate/tests/vpn_login_failed.STANDARD.json
+++ b/Fortinet/fortigate/tests/vpn_login_failed.STANDARD.json
@@ -32,9 +32,6 @@
         "virtual_domain": "root"
       }
     },
-    "host": {
-      "name": "FW-FOOBAR"
-    },
     "log": {
       "description": "SSL VPN login fail",
       "hostname": "FW-FOOBAR",

--- a/Fortinet/fortigate/tests/vpn_na_ip.STANDARD.json
+++ b/Fortinet/fortigate/tests/vpn_na_ip.STANDARD.json
@@ -32,9 +32,6 @@
         "virtual_domain": "root"
       }
     },
-    "host": {
-      "name": "FW-FOOBAR"
-    },
     "log": {
       "description": "SSL VPN login fail",
       "hostname": "FW-FOOBAR",


### PR DESCRIPTION
Fix concerning [this issue](https://github.com/SekoiaLab/integration/issues/210).
Some tests have also been updated, probably from a previous fix (disappearance of host.name field, but the info is still present on log.hostname)