### PR TITLE
OCSF: fix the parsing of dns answers

### DIFF
--- a/OCSF/ocsf/ingest/parser.yml
+++ b/OCSF/ocsf/ingest/parser.yml
@@ -1000,7 +1000,7 @@ stages:
                 {%- if item.get('type') != None -%}"type": "{{item.type}}",{%- endif -%}
                 {%- if item.get('ttl') != None -%}"ttl": "{{item.ttl}}",{%- endif -%}
                 {%- if item.get('rdata') != None -%}"data": "{{item.rdata}}",{%- endif -%}
-            }
+            },
             {%- endfor -%}
             ]
         filter: "{{ parse_event.message.get('answers') != None }}"

--- a/OCSF/ocsf/tests/test_dns_activity_3.json
+++ b/OCSF/ocsf/tests/test_dns_activity_3.json
@@ -1,0 +1,90 @@
+{
+  "input": {
+    "message": "{\"metadata\":{\"product\":{\"version\":\"1.100000\",\"name\":\"Route 53\",\"feature\":{\"name\":\"Resolver Query Logs\"},\"vendor_name\":\"AWS\"},\"profiles\":[\"cloud\",\"security_control\",\"datetime\"],\"version\":\"1.1.0\"},\"cloud\":{\"account\":{\"uid\":\"111111111111\"},\"region\":\"eu-west-3\",\"provider\":\"AWS\"},\"src_endpoint\":{\"vpc_uid\":\"vpc-11111111\",\"ip\":\"1.2.3.4\",\"port\":62699,\"instance_uid\":\"i-11111111111111111\"},\"time\":1726395887000,\"time_dt\":1726395887000,\"query\":{\"hostname\":\"settings-win.data.microsoft.com.\",\"type\":\"A\",\"class\":\"IN\"},\"answers\":[{\"type\":\"CNAME\",\"rdata\":\"atm-settingsfe-prod-geo2.trafficmanager.net.\",\"class\":\"IN\"},{\"type\":\"CNAME\",\"rdata\":\"settings-prod-weu-2.westeurope.cloudapp.azure.com.\",\"class\":\"IN\"},{\"type\":\"A\",\"rdata\":\"5.6.7.8\",\"class\":\"IN\"}],\"connection_info\":{\"protocol_name\":\"UDP\",\"direction\":\"Unknown\",\"direction_id\":0},\"dst_endpoint\":null,\"firewall_rule\":null,\"severity_id\":1,\"severity\":\"Informational\",\"class_name\":\"DNS Activity\",\"class_uid\":4003,\"category_name\":\"Network Activity\",\"category_uid\":4,\"activity_id\":6,\"activity_name\":\"Traffic\",\"type_uid\":400306,\"type_name\":\"DNS Activity: Traffic\",\"rcode_id\":0,\"rcode\":\"NoError\",\"disposition\":\"Unknown\",\"action\":\"Unknown\",\"action_id\":0,\"unmapped\":null,\"accountid\":null,\"region\":null,\"asl_version\":null,\"observables\":[{\"name\":\"answers[].rdata\",\"value\":\"settings-prod-weu-2.westeurope.cloudapp.azure.com.\",\"type\":\"IP Address\",\"type_id\":2},{\"name\":\"src_endpoint.instance_uid\",\"value\":\"i-11111111111111111\",\"type\":\"Resource UID\",\"type_id\":10},{\"name\":\"answers[].rdata\",\"value\":\"5.6.7.8\",\"type\":\"IP Address\",\"type_id\":2},{\"name\":\"src_endpoint.ip\",\"value\":\"1.2.3.4\",\"type\":\"IP Address\",\"type_id\":2},{\"name\":\"answers[].rdata\",\"value\":\"atm-settingsfe-prod-geo2.trafficmanager.net.\",\"type\":\"IP Address\",\"type_id\":2},{\"name\":\"query.hostname\",\"value\":\"settings-win.data.microsoft.com.\",\"type\":\"Hostname\",\"type_id\":1}]}\n",
+    "sekoiaio": {
+      "intake": {
+        "dialect": "OCSF",
+        "dialect_uuid": "a9c959ac-78ec-47a4-924e-8156a77cebf5"
+      }
+    }
+  },
+  "expected": {
+    "message": "{\"metadata\":{\"product\":{\"version\":\"1.100000\",\"name\":\"Route 53\",\"feature\":{\"name\":\"Resolver Query Logs\"},\"vendor_name\":\"AWS\"},\"profiles\":[\"cloud\",\"security_control\",\"datetime\"],\"version\":\"1.1.0\"},\"cloud\":{\"account\":{\"uid\":\"111111111111\"},\"region\":\"eu-west-3\",\"provider\":\"AWS\"},\"src_endpoint\":{\"vpc_uid\":\"vpc-11111111\",\"ip\":\"1.2.3.4\",\"port\":62699,\"instance_uid\":\"i-11111111111111111\"},\"time\":1726395887000,\"time_dt\":1726395887000,\"query\":{\"hostname\":\"settings-win.data.microsoft.com.\",\"type\":\"A\",\"class\":\"IN\"},\"answers\":[{\"type\":\"CNAME\",\"rdata\":\"atm-settingsfe-prod-geo2.trafficmanager.net.\",\"class\":\"IN\"},{\"type\":\"CNAME\",\"rdata\":\"settings-prod-weu-2.westeurope.cloudapp.azure.com.\",\"class\":\"IN\"},{\"type\":\"A\",\"rdata\":\"5.6.7.8\",\"class\":\"IN\"}],\"connection_info\":{\"protocol_name\":\"UDP\",\"direction\":\"Unknown\",\"direction_id\":0},\"dst_endpoint\":null,\"firewall_rule\":null,\"severity_id\":1,\"severity\":\"Informational\",\"class_name\":\"DNS Activity\",\"class_uid\":4003,\"category_name\":\"Network Activity\",\"category_uid\":4,\"activity_id\":6,\"activity_name\":\"Traffic\",\"type_uid\":400306,\"type_name\":\"DNS Activity: Traffic\",\"rcode_id\":0,\"rcode\":\"NoError\",\"disposition\":\"Unknown\",\"action\":\"Unknown\",\"action_id\":0,\"unmapped\":null,\"accountid\":null,\"region\":null,\"asl_version\":null,\"observables\":[{\"name\":\"answers[].rdata\",\"value\":\"settings-prod-weu-2.westeurope.cloudapp.azure.com.\",\"type\":\"IP Address\",\"type_id\":2},{\"name\":\"src_endpoint.instance_uid\",\"value\":\"i-11111111111111111\",\"type\":\"Resource UID\",\"type_id\":10},{\"name\":\"answers[].rdata\",\"value\":\"5.6.7.8\",\"type\":\"IP Address\",\"type_id\":2},{\"name\":\"src_endpoint.ip\",\"value\":\"1.2.3.4\",\"type\":\"IP Address\",\"type_id\":2},{\"name\":\"answers[].rdata\",\"value\":\"atm-settingsfe-prod-geo2.trafficmanager.net.\",\"type\":\"IP Address\",\"type_id\":2},{\"name\":\"query.hostname\",\"value\":\"settings-win.data.microsoft.com.\",\"type\":\"Hostname\",\"type_id\":1}]}\n",
+    "event": {
+      "action": "traffic",
+      "category": [
+        "network"
+      ],
+      "kind": "event",
+      "severity": 1,
+      "type": [
+        "info",
+        "protocol"
+      ]
+    },
+    "@timestamp": "2024-09-15T10:24:47Z",
+    "cloud": {
+      "account": {
+        "id": "111111111111"
+      },
+      "provider": "AWS",
+      "region": "eu-west-3"
+    },
+    "dns": {
+      "answers": [
+        {
+          "class": "IN",
+          "data": "atm-settingsfe-prod-geo2.trafficmanager.net.",
+          "type": "CNAME"
+        },
+        {
+          "class": "IN",
+          "data": "settings-prod-weu-2.westeurope.cloudapp.azure.com.",
+          "type": "CNAME"
+        },
+        {
+          "class": "IN",
+          "data": "5.6.7.8",
+          "type": "A"
+        }
+      ],
+      "question": {
+        "class": [
+          "IN"
+        ],
+        "name": "settings-win.data.microsoft.com.",
+        "registered_domain": "microsoft.com",
+        "subdomain": "settings-win.data",
+        "top_level_domain": "com",
+        "type": [
+          "A"
+        ]
+      },
+      "response_code": "NoError"
+    },
+    "network": {
+      "direction": [
+        "unknown"
+      ]
+    },
+    "ocsf": {
+      "activity_id": 6,
+      "activity_name": "Traffic",
+      "class_name": "DNS Activity",
+      "class_uid": 4003
+    },
+    "related": {
+      "hosts": [
+        "settings-win.data.microsoft.com."
+      ],
+      "ip": [
+        "1.2.3.4"
+      ]
+    },
+    "source": {
+      "address": "1.2.3.4",
+      "ip": "1.2.3.4",
+      "port": 62699
+    }
+  }
+}


### PR DESCRIPTION
Fix the parsing of the dns answers, from the raw events, when containing several answers.