### PR TITLE
Apache: Fix the parser

### DIFF
--- a/Apache/apache/ingest/parser.yml
+++ b/Apache/apache/ingest/parser.yml
@@ -1,5 +1,5 @@
 name: apache
-ignored_values: ["","-"]
+ignored_values: ["", "-"]
 pipeline:
   - name: grok
     description: parse received message

--- a/Apache/apache/ingest/parser.yml
+++ b/Apache/apache/ingest/parser.yml
@@ -12,7 +12,7 @@ pipeline:
           # HTTPD standard logs
           HTTPD20_ERRORLOG: '\[%{HTTPDERROR_DATE}\] \[%{LOGLEVEL:action_name}\] (?:\[client (%{IP:source_ip}|%{HOSTNAME:source_domain})?\] ){0,1}%{GREEDYDATA:action_outcome_reason}'
           HTTPD24_ERRORLOG: '\[%{HTTPDERROR_DATE}\] \[%{WORD}?:%{LOGLEVEL:action_name}\] \[pid %{POSINT:process_id}(:tid %{NUMBER:process_thread_id})?\]( \(%{POSINT}\)%{DATA}:)?( \[client (%{IP:source_ip}|%{HOSTNAME:source_domain})?(:%{POSINT:source_port})?\])?( %{DATA}:)? %{GREEDYDATA:action_outcome_reason}'
-          HTTPD_COMBINEDLOG: '%{HTTPD_COMMONLOG} %{QS:http_request_referrer} %{QS:user_agent_original}'
+          HTTPD_COMBINEDLOG: '%{HTTPD_COMMONLOG} "%{DATA:http_request_referrer}" "%{DATA:user_agent_original}"'
           HTTPD_COMMONLOG: >-
             (%{IPORHOST:destination_address}(:%{NUMBER:destination_port})? )?%{IPORHOST:source_ip} (?:-|%{HTTPDUSER:apache_access_user_identity}) (?:-( -)*|%{HTTPDUSER:user_name}) \[%{HTTPDATE:timestamp}]\ "(?:%{WORD:http_request_method} %{NOTSPACE:url_original}(?: HTTP/%{NUMBER:http_version})?|%{DATA})" (?:-|%{INT:http_response_status_code:int}) (?:-|%{INT:http_response_body_bytes:int})%{GREEDYDATA}
           # Apache ModSecurity logs

--- a/Apache/apache/ingest/parser.yml
+++ b/Apache/apache/ingest/parser.yml
@@ -12,9 +12,9 @@ pipeline:
           # HTTPD standard logs
           HTTPD20_ERRORLOG: '\[%{HTTPDERROR_DATE}\] \[%{LOGLEVEL:action_name}\] (?:\[client (%{IP:source_ip}|%{HOSTNAME:source_domain})?\] ){0,1}%{GREEDYDATA:action_outcome_reason}'
           HTTPD24_ERRORLOG: '\[%{HTTPDERROR_DATE}\] \[%{WORD}?:%{LOGLEVEL:action_name}\] \[pid %{POSINT:process_id}(:tid %{NUMBER:process_thread_id})?\]( \(%{POSINT}\)%{DATA}:)?( \[client (%{IP:source_ip}|%{HOSTNAME:source_domain})?(:%{POSINT:source_port})?\])?( %{DATA}:)? %{GREEDYDATA:action_outcome_reason}'
-          HTTPD_COMBINEDLOG: "%{HTTPD_COMMONLOG} %{QS:http_request_referrer} %{QS:user_agent_original}"
+          HTTPD_COMBINEDLOG: '%{HTTPD_COMMONLOG} %{QS:http_request_referrer} %{QS:user_agent_original}'
           HTTPD_COMMONLOG: >-
-            %{IPORHOST:source_ip} (?:-|%{HTTPDUSER:apache_access_user_identity}) (?:-( -)*|%{HTTPDUSER:user_name}) \[%{HTTPDATE:timestamp}]\ "(?:%{WORD:http_request_method} %{NOTSPACE:url_original}(?: HTTP/%{NUMBER:http_version})?|%{DATA})" (?:-|%{INT:http_response_status_code:int}) (?:-|%{INT:http_response_body_bytes:int})%{GREEDYDATA}
+            (%{IPORHOST:destination_address}(:%{NUMBER:destination_port})? )?%{IPORHOST:source_ip} (?:-|%{HTTPDUSER:apache_access_user_identity}) (?:-( -)*|%{HTTPDUSER:user_name}) \[%{HTTPDATE:timestamp}]\ "(?:%{WORD:http_request_method} %{NOTSPACE:url_original}(?: HTTP/%{NUMBER:http_version})?|%{DATA})" (?:-|%{INT:http_response_status_code:int}) (?:-|%{INT:http_response_body_bytes:int})%{GREEDYDATA}
           # Apache ModSecurity logs
           APACHEERRORPREFIX: '(\[%{HTTPDERROR_DATE:timestamp}\] )?(\[%{WORD}?:%{LOGLEVEL:action_name}\] )?(\[pid %{POSINT:process_pid}(:tid %{NUMBER:process_thread_id})?\] )?(\[client (%{IP:source_ip}|%{HOSTNAME:source_domain})?(:%{NUMBER:source_port})?\])?.*'
           MODSECHOSTNAME: '\[hostname "?%{DATA:destination_domain}"?\]'
@@ -111,6 +111,8 @@ stages:
           url.original: "{{grok.event.url_original}}"
           user.name: "{{grok.event.user_name}}"
           user_agent.original: "{{grok.event.user_agent_original}}"
+          destination.address: "{{grok.event.destination_address}}"
+          destination.port: "{{grok.event.destination_port}}"
       - translate:
         dictionary:
           "info": ["info"]

--- a/Apache/apache/ingest/parser.yml
+++ b/Apache/apache/ingest/parser.yml
@@ -1,4 +1,5 @@
 name: apache
+ignored_values: ["","-"]
 pipeline:
   - name: grok
     description: parse received message

--- a/Apache/apache/tests/access_combined.json
+++ b/Apache/apache/tests/access_combined.json
@@ -23,7 +23,7 @@
     "http": {
       "request": {
         "method": "GET",
-        "referrer": "\"http://www.example.com/start.html\""
+        "referrer": "http://www.example.com/start.html"
       },
       "response": {
         "bytes": 2326,
@@ -55,7 +55,7 @@
         "name": "Other"
       },
       "name": "Other",
-      "original": "\"Mozilla/4.08 [en] (Win98; I ;Nav)\"",
+      "original": "Mozilla/4.08 [en] (Win98; I ;Nav)",
       "os": {
         "name": "Windows",
         "version": "98"

--- a/Apache/apache/tests/access_extended.json
+++ b/Apache/apache/tests/access_extended.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "message": "24.202.202.247 - - - [31/Jul/2024:16:41:52 +0200] \"GET /test/integration/abcdefgh123456.js HTTP/1.1\" 200 5771 \"https://www.website.fr/\" \"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/10101010 Firefox/128.0\" GoAway=- (107 47us) TLSv1.3 TLS_AES_256_GCM_SHA384",
+    "message": "mydomain:443 1.2.3.4 - - [31/Jul/2024:16:41:52 +0200] \"GET /test/integration/abcdefgh123456.js HTTP/1.1\" 200 5771 \"https://www.website.fr/\" \"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/10101010 Firefox/128.0\" GoAway=- (107 47us) TLSv1.3 TLS_AES_256_GCM_SHA384",
     "sekoiaio": {
       "intake": {
         "dialect": "Apache HTTP Server",
@@ -9,7 +9,7 @@
     }
   },
   "expected": {
-    "message": "24.202.202.247 - - - [31/Jul/2024:16:41:52 +0200] \"GET /test/integration/abcdefgh123456.js HTTP/1.1\" 200 5771 \"https://www.website.fr/\" \"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/10101010 Firefox/128.0\" GoAway=- (107 47us) TLSv1.3 TLS_AES_256_GCM_SHA384",
+    "message": "mydomain:443 1.2.3.4 - - [31/Jul/2024:16:41:52 +0200] \"GET /test/integration/abcdefgh123456.js HTTP/1.1\" 200 5771 \"https://www.website.fr/\" \"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/10101010 Firefox/128.0\" GoAway=- (107 47us) TLSv1.3 TLS_AES_256_GCM_SHA384",
     "event": {
       "category": [
         "web"
@@ -26,6 +26,11 @@
         "timestamp": "31/Jul/2024:16:41:52 +0200"
       }
     },
+    "destination": {
+      "address": "mydomain",
+      "port": 443,
+      "size_in_char": 0
+    },
     "http": {
       "request": {
         "method": "GET"
@@ -38,12 +43,12 @@
     },
     "related": {
       "ip": [
-        "24.202.202.247"
+        "1.2.3.4"
       ]
     },
     "source": {
-      "address": "24.202.202.247",
-      "ip": "24.202.202.247"
+      "address": "1.2.3.4",
+      "ip": "1.2.3.4"
     },
     "url": {
       "original": "/test/integration/abcdefgh123456.js",


### PR DESCRIPTION
- Add ignored values
- remove quotes from the user-agent and the HTTP referer
- extract the destination address that can prefix the log