### PR TITLE
Gatewatcher: add event.kind:alert when processing an alert

### DIFF
--- a/GateWatcher/aioniq/ingest/parser.yml
+++ b/GateWatcher/aioniq/ingest/parser.yml
@@ -63,6 +63,9 @@ stages:
           gatewatcher.timestamp_analyzed: "{{json_load.message.timestamp_analyzed}}"
           gatewatcher.timestamp_detected: "{{json_load.message.timestamp_detected}}"
       - set:
+          event.kind: "alert"
+        filter: "{{json_load.message.event_type == 'alert'}}"
+      - set:
           observer.mac: >-
             ["{{json_load.message.ether.src_mac}}",
             "{{json_load.message.ether.dest_mac}}"]

--- a/GateWatcher/aioniq/tests/sigflow-alert.json
+++ b/GateWatcher/aioniq/tests/sigflow-alert.json
@@ -15,6 +15,7 @@
       "category": [
         "network"
       ],
+      "kind": "alert",
       "module": "alert",
       "severity": 1
     },


### PR DESCRIPTION
The previous changes withdrawn the `event.kind` for alerts