### PR TITLE
fix(o365): parse url in TIUrlClickData events

### DIFF
--- a/Office 365/o365/ingest/parser.yml
+++ b/Office 365/o365/ingest/parser.yml
@@ -63,6 +63,8 @@ pipeline:
     filter: "{{json_event.message.RecordType == 36}}"
   - name: parse_power_bi
     filter: "{{json_event.message.RecordType == 20}}"
+  - name: parse_threat_intelligence_url
+    filter: "{{json_event.message.RecordType == 41}}"
 
 stages:
   set_common_fields:
@@ -652,3 +654,8 @@ stages:
     actions:
       - set:
           user_agent.original: "{{json_event.message.UserAgent}}"
+
+  parse_threat_intelligence_url:
+    actions:
+      - set:
+          url.original: "{{json_event.message.Url}}"

--- a/Office 365/o365/tests/microsoft_defender_threatintelligence_url_click.json
+++ b/Office 365/o365/tests/microsoft_defender_threatintelligence_url_click.json
@@ -35,6 +35,15 @@
     "service": {
       "name": "ThreatIntelligence"
     },
+    "url": {
+      "domain": "malicious.domain.com",
+      "original": "https://malicious.domain.com",
+      "port": 443,
+      "registered_domain": "domain.com",
+      "scheme": "https",
+      "subdomain": "malicious",
+      "top_level_domain": "com"
+    },
     "user": {
       "email": "human@example.org",
       "id": "ThreatIntel",


### PR DESCRIPTION
To improve IOC matching and help with investigations.