### PR TITLE
fix(o365): Parse ClientAppId in Exchange events

### DIFF
--- a/Office 365/o365/ingest/parser.yml
+++ b/Office 365/o365/ingest/parser.yml
@@ -164,6 +164,10 @@ stages:
         filter: '{{json_event.message.get("Parameters") != None}}'
       - set:
           office365.context.aad_session_id: "{{json_event.message.SessionId}}"
+          office365.context.client.id: "{{json_event.message.ClientAppId}}"
+      - set:
+          office365.context.client.id: "{{json_event.message.AppId}}"
+        filter: '{{json_event.message.get("ClientAppId") == ""}}'
 
   parse_exchange_item:
     actions:
@@ -189,6 +193,7 @@ stages:
           user.id: "{{json_event.message.LogonUserSid}}"
           office365.exchange.mailbox_guid: "{{json_event.message.MailboxGuid}}"
           office365.context.aad_session_id: "{{json_event.message.SessionId}}"
+          office365.context.client.id: "{{json_event.message.ClientAppId}}"
       - set:
           email.subject: "{{json_event.message.Item.Subject}}"
           email.message_id: "{{json_event.message.Item.InternetMessageId[1:-1]}}"
@@ -237,6 +242,7 @@ stages:
             ]
       - set:
           office365.context.aad_session_id: "{{json_event.message.SessionId}}"
+          office365.context.client.id: "{{json_event.message.ClientAppId}}"
   parse_share_point:
     actions:
       - set:
@@ -254,6 +260,7 @@ stages:
     actions:
       - set:
           office365.context.aad_session_id: "{{json_event.message.SessionId}}"
+          office365.context.client.id: "{{json_event.message.ClientAppId}}"
 
   parse_network_traffic:
     actions:

--- a/Office 365/o365/tests/clientipadress.json
+++ b/Office 365/o365/tests/clientipadress.json
@@ -23,6 +23,11 @@
       "target": "user"
     },
     "office365": {
+      "context": {
+        "client": {
+          "id": "clientappidxxxx-xxx-xxx-xxxx"
+        }
+      },
       "record_type": 50,
       "result_status": "Succeeded",
       "user_type": {

--- a/Office 365/o365/tests/exchange_item_update.json
+++ b/Office 365/o365/tests/exchange_item_update.json
@@ -29,6 +29,11 @@
       "subject": "HI"
     },
     "office365": {
+      "context": {
+        "client": {
+          "id": "037fd006-a72b-49ae-4bb0-08dba30c8729"
+        }
+      },
       "exchange": {
         "mailbox_guid": "8208550a-4001-439d-a9f6-e95d76767507"
       },

--- a/Office 365/o365/tests/inbox_rule.json
+++ b/Office 365/o365/tests/inbox_rule.json
@@ -21,7 +21,10 @@
         "object_id": "EURPR07A010.PROD.OUTLOOK.COM/Microsoft Exchange Hosted Organizations/example.onmicrosoft.com/bc1b1df3-f861-4aec-bf7c-40ce5b5566c1\\RULE_NAME"
       },
       "context": {
-        "aad_session_id": "984c0958-0631-4b90-b116-15094fc36847"
+        "aad_session_id": "984c0958-0631-4b90-b116-15094fc36847",
+        "client": {
+          "id": "00000002-0000-0ff1-ce00-000000000000"
+        }
       },
       "exchange_admin": {
         "parameters": [


### PR DESCRIPTION
I'd like to use this field for a detection rule.