### PR TITLE
Adding a possible value to destination.domain on Fortigate logs

### DIFF
--- a/Fortinet/fortigate/ingest/parser.yml
+++ b/Fortinet/fortigate/ingest/parser.yml
@@ -191,7 +191,7 @@ stages:
           event.action: "{{parsed_event.message.name or parsed_event.message.FTNTFGTaction or parsed_event.message.FortinetFortiGateaction or parsed_event.message.act or parsed_event.message.action or parsed_event.message.reason}}"
           destination.address: "{{parsed_event.message.dstip or parsed_event.message.dst}}"
           destination.bytes: "{{parsed_event.message.rcvdbyte or parsed_event.message.in}}"
-          destination.domain: "{{parsed_event.message.hostname or parsed_event.message.dhost}}"
+          destination.domain: "{{parsed_event.message.remotename or parsed_event.message.hostname or parsed_event.message.dhost}}"
           destination.mac: "{{parsed_event.message.dstmac}}"
           destination.nat.port: "{{parsed_event.message.destinationTranslatedPort}}"
           destination.packets: "{{parsed_event.message.rcvdpkt or parsed_event.message.FTNTFGTrcvpkt or parsed_event.message.FortinetFortiGatercvdpkt or parsed_event.message.get('Packets Received')}}"


### PR DESCRIPTION
Adding the value of remotename to the field destination.domain.

The current parsing doesn't work well as the field destination.domain takes the value of hostname, which is the name of the host that generate the log.

With my change, it search for the remotename field first, then search for hostname and dhost.

Example of log where the old parsing didn't work properly:

```
devname="FIREWALLDEVICENAME" devid="DEVICEID" vd="default" itime=1732887262 fctsn="AAA0000123456879" date="2024-11-29" time="14:34:22" logver=1 id=96900 type="traffic" subtype="system" eventtype="traffic" level="info" uid="18269958131647cc9d18e84c0bc205c1" hostname="fakehostname" pcdomain="N/A" deviceip=10.1.1.2 devicemac="ee-dd-cc-1a-bb-aa" site="default" fctver="10.4.4.0515" fgtserial="N/A" emsserial="DEVICEID" usingpolicy="policy" os="Microsoft Windows 11 Professional Edition, 64-bit (build 26100)" user="user@CONTOSO.ORG" msg="Traffic log" sessionid=1732887262 srcname="msedgewebview2.exe" srcproduct="Microsoft Edge WebView2" srcport=0 direction="outbound" remotename="login.microsoftonline.com" dstport=443 proto=6 rcvdbyte=0 sentbyte=0 utmaction="userbrowsed" utmevent="webfilter" service="https" userinitiated=1 browsetime=3 url="/common/oauth2/v2.0/authorize?client_id=test_value" tz="+0100"
```

The destination.domain value was "fakehostname" and not "**login.microsoftonline.com**"