### PR TITLE
Fortigate: reorder the fields for destination.domain

### DIFF
--- a/Fortinet/fortigate/ingest/parser.yml
+++ b/Fortinet/fortigate/ingest/parser.yml
@@ -191,7 +191,7 @@ stages:
           event.action: "{{parsed_event.message.name or parsed_event.message.FTNTFGTaction or parsed_event.message.FortinetFortiGateaction or parsed_event.message.act or parsed_event.message.action or parsed_event.message.reason}}"
           destination.address: "{{parsed_event.message.dstip or parsed_event.message.dst}}"
           destination.bytes: "{{parsed_event.message.rcvdbyte or parsed_event.message.in}}"
-          destination.domain: "{{parsed_event.message.remotename or parsed_event.message.hostname or parsed_event.message.dhost}}"
+          destination.domain: "{{parsed_event.message.remotename or parsed_event.message.dhost or parsed_event.message.hostname}}"
           destination.mac: "{{parsed_event.message.dstmac}}"
           destination.nat.port: "{{parsed_event.message.destinationTranslatedPort}}"
           destination.packets: "{{parsed_event.message.rcvdpkt or parsed_event.message.FTNTFGTrcvpkt or parsed_event.message.FortinetFortiGatercvdpkt or parsed_event.message.get('Packets Received')}}"


### PR DESCRIPTION
Reorder the fields used to fill `destination.domain` (according to their priority)