### PR TITLE
Office365: only set office365.user_type.is_external for external user

### DIFF
--- a/Office 365/o365/ingest/parser.yml
+++ b/Office 365/o365/ingest/parser.yml
@@ -93,7 +93,8 @@ stages:
         filter: '{{"@" in json_event.message.UserId}}'
 
       - set:
-          office365.user_type.is_external: "{{'urn:spo:guest#' in json_event.message.UserId}}"
+          office365.user_type.is_external: "true"
+        filter: "{{'urn:spo:guest#' in json_event.message.UserId}}"
 
       - set:
           source.ip: "{{parse_client_ip_address.result.ip}}"

--- a/Office 365/o365/tests/ad.json
+++ b/Office 365/o365/tests/ad.json
@@ -44,7 +44,6 @@
       "result_status": "Succeeded",
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/ad_1.json
+++ b/Office 365/o365/tests/ad_1.json
@@ -53,7 +53,6 @@
       "result_status": "Success",
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/add_member_to_role.json
+++ b/Office 365/o365/tests/add_member_to_role.json
@@ -57,7 +57,6 @@
       "result_status": "Success",
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/automated_investigation_and_response.json
+++ b/Office 365/o365/tests/automated_investigation_and_response.json
@@ -50,7 +50,6 @@
       "record_type": 64,
       "user_type": {
         "code": 4,
-        "is_external": false,
         "name": "System"
       }
     },

--- a/Office 365/o365/tests/automated_investigation_and_response_1.json
+++ b/Office 365/o365/tests/automated_investigation_and_response_1.json
@@ -145,7 +145,6 @@
       "record_type": 64,
       "user_type": {
         "code": 4,
-        "is_external": false,
         "name": "System"
       }
     },

--- a/Office 365/o365/tests/automated_investigation_and_response_with_additional_fields.json
+++ b/Office 365/o365/tests/automated_investigation_and_response_with_additional_fields.json
@@ -95,7 +95,6 @@
       "record_type": 64,
       "user_type": {
         "code": 4,
-        "is_external": false,
         "name": "System"
       }
     },

--- a/Office 365/o365/tests/automated_investigation_and_response_with_additional_fields_1.json
+++ b/Office 365/o365/tests/automated_investigation_and_response_with_additional_fields_1.json
@@ -121,7 +121,6 @@
       "record_type": 64,
       "user_type": {
         "code": 4,
-        "is_external": false,
         "name": "System"
       }
     },

--- a/Office 365/o365/tests/automated_investigation_and_response_with_attachment.json
+++ b/Office 365/o365/tests/automated_investigation_and_response_with_attachment.json
@@ -108,7 +108,6 @@
       "record_type": 64,
       "user_type": {
         "code": 4,
-        "is_external": false,
         "name": "System"
       }
     },

--- a/Office 365/o365/tests/browser_log.json
+++ b/Office 365/o365/tests/browser_log.json
@@ -29,7 +29,6 @@
       "record_type": 36,
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/clientipadress.json
+++ b/Office 365/o365/tests/clientipadress.json
@@ -38,7 +38,6 @@
       "result_status": "Succeeded",
       "user_type": {
         "code": 5,
-        "is_external": false,
         "name": "Application"
       }
     },

--- a/Office 365/o365/tests/compliancemanager-scorechange.json
+++ b/Office 365/o365/tests/compliancemanager-scorechange.json
@@ -22,7 +22,6 @@
       "result_status": "Successful",
       "user_type": {
         "code": 2,
-        "is_external": false,
         "name": "Admin"
       }
     },

--- a/Office 365/o365/tests/email_reported.json
+++ b/Office 365/o365/tests/email_reported.json
@@ -39,7 +39,6 @@
       "result_status": "Succeeded",
       "user_type": {
         "code": 4,
-        "is_external": false,
         "name": "System"
       }
     },

--- a/Office 365/o365/tests/exchange_event1.json
+++ b/Office 365/o365/tests/exchange_event1.json
@@ -39,7 +39,6 @@
       "result_status": "Succeeded",
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/exchange_item_aggregated.json
+++ b/Office 365/o365/tests/exchange_item_aggregated.json
@@ -30,7 +30,6 @@
       "result_status": "Succeeded",
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/exchange_item_group.json
+++ b/Office 365/o365/tests/exchange_item_group.json
@@ -40,7 +40,6 @@
       "result_status": "Succeeded",
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/exchange_item_group_2.json
+++ b/Office 365/o365/tests/exchange_item_group_2.json
@@ -93,7 +93,6 @@
       "result_status": "Succeeded",
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/exchange_item_update.json
+++ b/Office 365/o365/tests/exchange_item_update.json
@@ -41,7 +41,6 @@
       "result_status": "Succeeded",
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/file_previewed.json
+++ b/Office 365/o365/tests/file_previewed.json
@@ -42,7 +42,6 @@
       "record_type": 6,
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/file_size.json
+++ b/Office 365/o365/tests/file_size.json
@@ -52,7 +52,6 @@
       "record_type": 6,
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/file_sync_download_full.json
+++ b/Office 365/o365/tests/file_sync_download_full.json
@@ -48,7 +48,6 @@
       "record_type": 6,
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/file_visited.json
+++ b/Office 365/o365/tests/file_visited.json
@@ -30,7 +30,6 @@
       "result_status": "TRUE",
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/form_log.json
+++ b/Office 365/o365/tests/form_log.json
@@ -28,7 +28,6 @@
       },
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/inbox_rule.json
+++ b/Office 365/o365/tests/inbox_rule.json
@@ -46,7 +46,6 @@
       "result_status": "True",
       "user_type": {
         "code": 2,
-        "is_external": false,
         "name": "Admin"
       }
     },

--- a/Office 365/o365/tests/managed_sync.json
+++ b/Office 365/o365/tests/managed_sync.json
@@ -38,7 +38,6 @@
       "record_type": 4,
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/mass_download.json
+++ b/Office 365/o365/tests/mass_download.json
@@ -39,7 +39,6 @@
       "result_status": "Succeeded",
       "user_type": {
         "code": 4,
-        "is_external": false,
         "name": "System"
       }
     },

--- a/Office 365/o365/tests/mcas_alert.json
+++ b/Office 365/o365/tests/mcas_alert.json
@@ -41,7 +41,6 @@
       "result_status": "New",
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/microsoft_defender_threatintelligence_atp.json
+++ b/Office 365/o365/tests/microsoft_defender_threatintelligence_atp.json
@@ -33,7 +33,6 @@
       "record_type": 47,
       "user_type": {
         "code": 4,
-        "is_external": false,
         "name": "System"
       }
     },

--- a/Office 365/o365/tests/microsoft_defender_threatintelligence_mail.json
+++ b/Office 365/o365/tests/microsoft_defender_threatintelligence_mail.json
@@ -114,7 +114,6 @@
       "record_type": 28,
       "user_type": {
         "code": 4,
-        "is_external": false,
         "name": "System"
       }
     },

--- a/Office 365/o365/tests/microsoft_defender_threatintelligence_url_click.json
+++ b/Office 365/o365/tests/microsoft_defender_threatintelligence_url_click.json
@@ -21,7 +21,6 @@
       "record_type": 41,
       "user_type": {
         "code": 4,
-        "is_external": false,
         "name": "System"
       }
     },

--- a/Office 365/o365/tests/operation_properties_01.json
+++ b/Office 365/o365/tests/operation_properties_01.json
@@ -61,7 +61,6 @@
       "result_status": "Succeeded",
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/operation_properties_02.json
+++ b/Office 365/o365/tests/operation_properties_02.json
@@ -58,7 +58,6 @@
       "result_status": "Succeeded",
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/power_bi.json
+++ b/Office 365/o365/tests/power_bi.json
@@ -23,7 +23,6 @@
       "record_type": 20,
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/remove_member_from_role.json
+++ b/Office 365/o365/tests/remove_member_from_role.json
@@ -57,7 +57,6 @@
       "result_status": "Success",
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/security_compliance_alert.json
+++ b/Office 365/o365/tests/security_compliance_alert.json
@@ -39,7 +39,6 @@
       "result_status": "Succeeded",
       "user_type": {
         "code": 4,
-        "is_external": false,
         "name": "System"
       }
     },

--- a/Office 365/o365/tests/security_compliance_alert_2.json
+++ b/Office 365/o365/tests/security_compliance_alert_2.json
@@ -65,7 +65,6 @@
       "result_status": "Succeeded",
       "user_type": {
         "code": 4,
-        "is_external": false,
         "name": "System"
       }
     },

--- a/Office 365/o365/tests/security_compliance_alert_3.json
+++ b/Office 365/o365/tests/security_compliance_alert_3.json
@@ -60,7 +60,6 @@
       "result_status": "Succeeded",
       "user_type": {
         "code": 4,
-        "is_external": false,
         "name": "System"
       }
     },

--- a/Office 365/o365/tests/security_compliance_alert_4.json
+++ b/Office 365/o365/tests/security_compliance_alert_4.json
@@ -59,7 +59,6 @@
       "result_status": "Succeeded",
       "user_type": {
         "code": 4,
-        "is_external": false,
         "name": "System"
       }
     },

--- a/Office 365/o365/tests/security_compliance_alert_5.json
+++ b/Office 365/o365/tests/security_compliance_alert_5.json
@@ -39,7 +39,6 @@
       "result_status": "Succeeded",
       "user_type": {
         "code": 4,
-        "is_external": false,
         "name": "System"
       }
     },

--- a/Office 365/o365/tests/security_compliance_alert_7.json
+++ b/Office 365/o365/tests/security_compliance_alert_7.json
@@ -60,7 +60,6 @@
       "result_status": "Succeeded",
       "user_type": {
         "code": 4,
-        "is_external": false,
         "name": "System"
       }
     },

--- a/Office 365/o365/tests/security_compliance_alert_malicious_url.json
+++ b/Office 365/o365/tests/security_compliance_alert_malicious_url.json
@@ -53,7 +53,6 @@
       "result_status": "Succeeded",
       "user_type": {
         "code": 4,
-        "is_external": false,
         "name": "System"
       }
     },

--- a/Office 365/o365/tests/source_log.json
+++ b/Office 365/o365/tests/source_log.json
@@ -48,7 +48,6 @@
       "record_type": 14,
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/targetusername.json
+++ b/Office 365/o365/tests/targetusername.json
@@ -58,7 +58,6 @@
       "record_type": 14,
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/teams_message_has_link.json
+++ b/Office 365/o365/tests/teams_message_has_link.json
@@ -50,7 +50,6 @@
       },
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/teams_with_foreign_tenant_users.json
+++ b/Office 365/o365/tests/teams_with_foreign_tenant_users.json
@@ -50,7 +50,6 @@
       },
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/teams_with_foreign_tenant_users_2.json
+++ b/Office 365/o365/tests/teams_with_foreign_tenant_users_2.json
@@ -44,7 +44,6 @@
       },
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/teams_with_foreign_tenant_users_3.json
+++ b/Office 365/o365/tests/teams_with_foreign_tenant_users_3.json
@@ -44,7 +44,6 @@
       },
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/teams_without_foreign_tenant_users.json
+++ b/Office 365/o365/tests/teams_without_foreign_tenant_users.json
@@ -50,7 +50,6 @@
       },
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/threat_intel.json
+++ b/Office 365/o365/tests/threat_intel.json
@@ -33,7 +33,6 @@
       "record_type": 47,
       "user_type": {
         "code": 4,
-        "is_external": false,
         "name": "System"
       }
     },

--- a/Office 365/o365/tests/update_group.json
+++ b/Office 365/o365/tests/update_group.json
@@ -30,7 +30,6 @@
       "result_status": "Success",
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/update_user.json
+++ b/Office 365/o365/tests/update_user.json
@@ -30,7 +30,6 @@
       "result_status": "Success",
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/update_user_empty_source_ip.json
+++ b/Office 365/o365/tests/update_user_empty_source_ip.json
@@ -57,7 +57,6 @@
       "result_status": "Success",
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/user_logged_in.json
+++ b/Office 365/o365/tests/user_logged_in.json
@@ -44,7 +44,6 @@
       "result_status": "Succeeded",
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/user_logged_in_2.json
+++ b/Office 365/o365/tests/user_logged_in_2.json
@@ -57,7 +57,6 @@
       "result_status": "Success",
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },

--- a/Office 365/o365/tests/user_login_failed.json
+++ b/Office 365/o365/tests/user_login_failed.json
@@ -55,7 +55,6 @@
       "result_status": "Success",
       "user_type": {
         "code": 0,
-        "is_external": false,
         "name": "Regular"
       }
     },


### PR DESCRIPTION
Little change to avoid having most events with a custom field that we can consider the absence as a valuation to False.