### PR TITLE
PaloAlto: fix for event auth-fail

### DIFF
--- a/Palo Alto Networks/paloalto-ngfw/_meta/fields.yml
+++ b/Palo Alto Networks/paloalto-ngfw/_meta/fields.yml
@@ -258,9 +258,9 @@ paloalto.authentication.method:
   name: paloalto.authentication.method
   type: keyword
 
-paloalto.authetification.profile:
+paloalto.authentication.profile:
   description: The authentication profile
-  name: paloalto.authetification.profile
+  name: paloalto.authentication.profile
   type: keyword
 
 paloalto.connection.method:

--- a/Palo Alto Networks/paloalto-ngfw/ingest/parser.yml
+++ b/Palo Alto Networks/paloalto-ngfw/ingest/parser.yml
@@ -599,7 +599,7 @@ pipeline:
       properties:
         raise_errors: false
         input_field: "{{parsed_event.message.EventDescription}}"
-        pattern: "%{SYSTEM_AUTH_AUTHENTICATION_FOR}|%{CONNECTION}|%{CONTENT}|%{WILDFIRE}|%{NETWORK}|%{PANDB_GENERIC}|%{CLOUD_ELECTION}|%{AUTHENTICATION}|%{REASON1}|%{REASON2}|%{REASON3}|%{REASON4}|%{REASON5}"
+        pattern: "%{SYSTEM_AUTH_AUTHENTICATION_FOR}|%{CONNECTION}|%{CONTENT}|%{WILDFIRE}|%{NETWORK}|%{PANDB_GENERIC}|%{CLOUD_ELECTION}|%{AUTHENTICATION}|%{REASON}"
         custom_patterns:
           SYSTEM_AUTH_AUTHENTICATION_FOR: "authenticated for user '%{USERNAME:user}'.   auth profile '%{DATA:auth_profile}', vsys '%{DATA:vsys}', server profile '%{DATA:server_profile}', server address '%{HOSTNAME:server_address}', From: %{IP:src}."
           CONNECTION: "%{CONNECTION_SUCCESS}|%{CONNECTION_TO_SERVER}|%{CONNECTION_REGISTERED}"
@@ -624,10 +624,11 @@ pipeline:
           AUTHENTICATION: "%{AUTHENTICATION_CONSOLE}|%{AUTHENTICATION_WEB}"
           AUTHENTICATION_CONSOLE: "authenticated for user '%{USERNAME:user}'.   From: %{IP:src}."
           AUTHENTICATION_WEB: "User %{USERNAME:user} logged in via %{DATA} from %{IP:src} using %{DATA:proto}"
+          REASON: "%{REASON1}|%{REASON2}|%{REASON3}|%{REASON4}|%{REASON5}"
           REASON1: 'User-ID server monitor %{HOSTNAME:hostname}\(%{WORD:vsys}\) %{GREEDYDATA:message}'
           REASON2: "ldap cfg %{WORD:config_name} connected to server %{IP:destination_ip}:%{INT:port}, initiated by: %{IP:source_ip}"
           REASON3: "When authenticating user '?%{WORD:user}'? from '?%{IP:source_ip}'?, a less secure authentication method %{WORD:auth_method} is used. Please migrate to %{WORD:recommended_methods1} or %{DATA:recommended_methods2}. Authentication Profile '?%{WORD:auth_profile}'?, vsys '?%{WORD:vsys}'?, Server Profile '?%{WORD:server_profile}'?, Server Address '?%{IP:destination_ip}'?"
-          REASON4: "failed authentication for user %{WORD:user}. Reason: %{GREEDYDATA:reason} auth profile %{WORD:auth_profile}, vsys %{WORD:vsys}, server profile %{WORD:server_profile}, server address %{IP:destination_ip}, auth protocol %{WORD:auth_protocol}, From: %{IP:source_ip}"
+          REASON4: "failed authentication for user %{USERNAME:user}. Reason: %{GREEDYDATA:reason} auth profile %{DATA:auth_profile}, vsys %{WORD:vsys}, server profile %{WORD:server_profile}, server address %{IP:destination_ip}, auth protocol %{WORD:auth_protocol}, From: %{IP:source_ip}."
           REASON5: 'authenticated for user %{WORD:user}\.   auth profile %{WORD:auth_profile}, vsys %{WORD:vsys}, server profile %{DATA:server_profile}, server address %{IP:destination_ip}, auth protocol %{WORD:auth_protocol}, admin role %{WORD:admin_role}, From: %{IP:source_ip}\.'
     filter: '{{parsed_event.message.get("EventDescription") != None}}'
 
@@ -918,7 +919,7 @@ stages:
           paloalto.threat.id: "{{parsed_event.message.ThreatID or parsed_event.message.PanOSThreatID or parsed_threat.message.threat_code}}"
           paloalto.threat.name: "{{parsed_threat.message.threat_description}}"
           paloalto.vsys: "{{parsed_description.message.vsys}}"
-          paloalto.authetification.profile: "{{parsed_description.message.auth_profile}}"
+          paloalto.authentication.profile: "{{parsed_description.message.auth_profile}}"
           paloalto.server.profile: "{{parsed_description.message.server_profile}}"
           paloalto.tls.chain_status: "{{parsed_event.message.ChainStatus}}"
           paloalto.tls.root_status: "{{parsed_event.message.RootStatus}}"

--- a/Palo Alto Networks/paloalto-ngfw/tests/system_csv.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/system_csv.json
@@ -36,7 +36,7 @@
       "DGHierarchyLevel4": "0",
       "EventID": "auth-success",
       "Threat_ContentType": "auth",
-      "authetification": {
+      "authentication": {
         "profile": "GP"
       },
       "server": {

--- a/Palo Alto Networks/paloalto-ngfw/tests/test_event_reason2.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/test_event_reason2.json
@@ -46,7 +46,7 @@
       "DGHierarchyLevel4": "0",
       "EventID": "auth-success",
       "Threat_ContentType": "auth",
-      "authetification": {
+      "authentication": {
         "profile": "FFFF"
       },
       "server": {

--- a/Palo Alto Networks/paloalto-ngfw/tests/test_event_reason3.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/test_event_reason3.json
@@ -46,7 +46,7 @@
       "DGHierarchyLevel4": "0",
       "EventID": "auth-success",
       "Threat_ContentType": "auth",
-      "authetification": {
+      "authentication": {
         "profile": "FFFF"
       },
       "server": {

--- a/Palo Alto Networks/paloalto-ngfw/tests/test_system_event_13.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/test_system_event_13.json
@@ -46,7 +46,7 @@
       "DGHierarchyLevel4": "0",
       "EventID": "auth-success",
       "Threat_ContentType": "auth",
-      "authetification": {
+      "authentication": {
         "profile": "FWPA"
       },
       "server": {

--- a/Palo Alto Networks/paloalto-ngfw/tests/test_system_event_14.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/test_system_event_14.json
@@ -1,0 +1,74 @@
+{
+  "input": {
+    "message": "1,2024/12/16 20:19:04,016301013072,SYSTEM,auth,2561,2024/12/16 20:19:04,,auth-fail,ESA-AUTH,0,0,general,medium,\"failed authentication for user john.doe. Reason: Authentication request is timed out. auth profile ESA-AUTH, vsys vsys1, server profile ESA, server address 1.2.3.4, auth protocol PAP, From: 5.6.7.8.\",7439393285273531690,0x0,0,0,0,0,,FWPADC1,0,0,2024-12-16T20:19:04.851+01:00",
+    "sekoiaio": {
+      "intake": {
+        "dialect": "Palo Alto NGFW",
+        "dialect_uuid": "903ec1b8-f206-4ba5-8563-db21da09cafd"
+      }
+    }
+  },
+  "expected": {
+    "message": "1,2024/12/16 20:19:04,016301013072,SYSTEM,auth,2561,2024/12/16 20:19:04,,auth-fail,ESA-AUTH,0,0,general,medium,\"failed authentication for user john.doe. Reason: Authentication request is timed out. auth profile ESA-AUTH, vsys vsys1, server profile ESA, server address 1.2.3.4, auth protocol PAP, From: 5.6.7.8.\",7439393285273531690,0x0,0,0,0,0,,FWPADC1,0,0,2024-12-16T20:19:04.851+01:00",
+    "event": {
+      "category": [
+        "authentication"
+      ],
+      "dataset": "system",
+      "reason": "Authentication request is timed out.",
+      "type": [
+        "info"
+      ]
+    },
+    "@timestamp": "2024-12-16T19:19:04.851000Z",
+    "action": {
+      "name": "auth-fail",
+      "type": "auth"
+    },
+    "destination": {
+      "address": "1.2.3.4",
+      "ip": "1.2.3.4"
+    },
+    "log": {
+      "hostname": "FWPADC1",
+      "level": "medium",
+      "logger": "system"
+    },
+    "observer": {
+      "name": "FWPADC1",
+      "product": "PAN-OS",
+      "serial_number": "016301013072"
+    },
+    "paloalto": {
+      "DGHierarchyLevel1": "0",
+      "DGHierarchyLevel2": "0",
+      "DGHierarchyLevel3": "0",
+      "DGHierarchyLevel4": "0",
+      "EventID": "auth-fail",
+      "Threat_ContentType": "auth",
+      "authentication": {
+        "profile": "ESA-AUTH"
+      },
+      "server": {
+        "profile": "ESA"
+      },
+      "vsys": "vsys1"
+    },
+    "related": {
+      "ip": [
+        "1.2.3.4",
+        "5.6.7.8"
+      ],
+      "user": [
+        "john.doe"
+      ]
+    },
+    "source": {
+      "address": "5.6.7.8",
+      "ip": "5.6.7.8"
+    },
+    "user": {
+      "name": "john.doe"
+    }
+  }
+}


### PR DESCRIPTION
Fix concerning [this issue](https://github.com/SekoiaLab/integration/issues/334)

I also renamed a custom field containing a typo in its name