### PR TITLE
Azure AD: change azuread.Level type from float to keyword

### DIFF
--- a/Azure/azure-ad/_meta/fields.yml
+++ b/Azure/azure-ad/_meta/fields.yml
@@ -13,7 +13,7 @@ action.target:
 azuread.Level:
   description: ''
   name: azuread.Level
-  type: long
+  type: keyword
 
 azuread.activityDateTime:
   description: ''

--- a/Azure/azure-ad/_meta/fields.yml
+++ b/Azure/azure-ad/_meta/fields.yml
@@ -10,11 +10,6 @@ action.target:
   short: action.target
   type: keyword
 
-azuread.Level:
-  description: ''
-  name: azuread.Level
-  type: keyword
-
 azuread.activityDateTime:
   description: ''
   name: azuread.activityDateTime

--- a/Azure/azure-ad/ingest/parser.yml
+++ b/Azure/azure-ad/ingest/parser.yml
@@ -113,6 +113,7 @@ stages:
           user.id: "{{ parsed_event.message.userId}}"
           user.name: "{{ parsed_event.message.userPrincipalName}}"
           user_agent.original: "{{ parsed_event.message.userAgent }}"
+          log.level: "{{parsed_event.message.Level}}"
 
       - set:
           source.ip: "{{parsed_event.message.ipAddress}}"
@@ -128,7 +129,6 @@ stages:
           azuread.durationMs: "{{parsed_event.message.durationMs}}"
           azuread.correlationId: "{{parsed_event.message.correlationId}}"
           azuread.identity: "{{parsed_event.message.identity}}"
-          azuread.Level: "{{parsed_event.message.Level}}"
 
           azuread.activityDateTime: "{{parsed_event.message.activityDateTime}}"
           azuread.detectedDateTime: "{{parsed_event.message.detectedDateTime}}"

--- a/Azure/azure-ad/tests/empty_geolocalisation.json
+++ b/Azure/azure-ad/tests/empty_geolocalisation.json
@@ -19,7 +19,6 @@
       "outcome": "success"
     },
     "azuread": {
-      "Level": "4",
       "authenticationDetails": [
         {
           "RequestSequence": 1,
@@ -64,6 +63,9 @@
       "os": {
         "type": "Windows 10"
       }
+    },
+    "log": {
+      "level": "4"
     },
     "related": {
       "ip": [

--- a/Azure/azure-ad/tests/empty_geolocalisation.json
+++ b/Azure/azure-ad/tests/empty_geolocalisation.json
@@ -19,7 +19,7 @@
       "outcome": "success"
     },
     "azuread": {
-      "Level": 4,
+      "Level": "4",
       "authenticationDetails": [
         {
           "RequestSequence": 1,

--- a/Azure/azure-ad/tests/sign-in_activity.json
+++ b/Azure/azure-ad/tests/sign-in_activity.json
@@ -20,7 +20,7 @@
       "outcome": "failure"
     },
     "azuread": {
-      "Level": 4,
+      "Level": "4",
       "authenticationDetails": [
         {
           "RequestSequence": 0,

--- a/Azure/azure-ad/tests/sign-in_activity.json
+++ b/Azure/azure-ad/tests/sign-in_activity.json
@@ -20,7 +20,6 @@
       "outcome": "failure"
     },
     "azuread": {
-      "Level": "4",
       "authenticationDetails": [
         {
           "RequestSequence": 0,
@@ -67,6 +66,9 @@
       "os": {
         "type": "Windows 10"
       }
+    },
+    "log": {
+      "level": "4"
     },
     "related": {
       "ip": [

--- a/Azure/azure-ad/tests/sign-in_activity2.json
+++ b/Azure/azure-ad/tests/sign-in_activity2.json
@@ -19,7 +19,7 @@
       "outcome": "success"
     },
     "azuread": {
-      "Level": 4,
+      "Level": "4",
       "authenticationDetails": [
         {
           "RequestSequence": 0,

--- a/Azure/azure-ad/tests/sign-in_activity2.json
+++ b/Azure/azure-ad/tests/sign-in_activity2.json
@@ -19,7 +19,6 @@
       "outcome": "success"
     },
     "azuread": {
-      "Level": "4",
       "authenticationDetails": [
         {
           "RequestSequence": 0,
@@ -66,6 +65,9 @@
       "os": {
         "type": "Windows 10"
       }
+    },
+    "log": {
+      "level": "4"
     },
     "related": {
       "ip": [

--- a/Azure/azure-ad/tests/sign-in_activity3.json
+++ b/Azure/azure-ad/tests/sign-in_activity3.json
@@ -19,7 +19,6 @@
       "outcome": "success"
     },
     "azuread": {
-      "Level": "4",
       "authenticationDetails": [
         {
           "RequestSequence": 1,
@@ -75,6 +74,9 @@
       "os": {
         "type": "Ios"
       }
+    },
+    "log": {
+      "level": "4"
     },
     "related": {
       "ip": [

--- a/Azure/azure-ad/tests/sign-in_activity3.json
+++ b/Azure/azure-ad/tests/sign-in_activity3.json
@@ -19,7 +19,7 @@
       "outcome": "success"
     },
     "azuread": {
-      "Level": 4,
+      "Level": "4",
       "authenticationDetails": [
         {
           "RequestSequence": 1,

--- a/Azure/azure-ad/tests/sign-in_activity4.json
+++ b/Azure/azure-ad/tests/sign-in_activity4.json
@@ -19,7 +19,7 @@
       "outcome": "success"
     },
     "azuread": {
-      "Level": 4,
+      "Level": "4",
       "authenticationDetails": [],
       "callerIpAddress": "11.11.11.11",
       "category": "SignInLogs",

--- a/Azure/azure-ad/tests/sign-in_activity4.json
+++ b/Azure/azure-ad/tests/sign-in_activity4.json
@@ -19,7 +19,6 @@
       "outcome": "success"
     },
     "azuread": {
-      "Level": "4",
       "authenticationDetails": [],
       "callerIpAddress": "11.11.11.11",
       "category": "SignInLogs",
@@ -62,6 +61,9 @@
       "os": {
         "type": "Ios"
       }
+    },
+    "log": {
+      "level": "4"
     },
     "related": {
       "hosts": [

--- a/Azure/azure-ad/tests/user_risk_detection.json
+++ b/Azure/azure-ad/tests/user_risk_detection.json
@@ -18,7 +18,6 @@
       "name": "User Risk Detection"
     },
     "azuread": {
-      "Level": "4",
       "callerIpAddress": "11.22.33.44",
       "category": "UserRiskEvents",
       "correlationId": "ef7868bd7e94b06ecd6cc965fc826c85d367bb5b9b083da9a26686786a791080",
@@ -40,6 +39,9 @@
       },
       "resourceId": "/tenants/2d0c1986-ef7b-4bbf-8428-3c837471e7ad/providers/microsoft.aadiam",
       "tenantId": "2d0c1986-ef7b-4bbf-8428-3c837471e7ad"
+    },
+    "log": {
+      "level": "4"
     },
     "related": {
       "ip": [

--- a/Azure/azure-ad/tests/user_risk_detection.json
+++ b/Azure/azure-ad/tests/user_risk_detection.json
@@ -18,7 +18,7 @@
       "name": "User Risk Detection"
     },
     "azuread": {
-      "Level": 4,
+      "Level": "4",
       "callerIpAddress": "11.22.33.44",
       "category": "UserRiskEvents",
       "correlationId": "ef7868bd7e94b06ecd6cc965fc826c85d367bb5b9b083da9a26686786a791080",

--- a/Azure/azure-ad/tests/user_risk_detection_2.json
+++ b/Azure/azure-ad/tests/user_risk_detection_2.json
@@ -24,7 +24,7 @@
       "name": "User Risk Detection"
     },
     "azuread": {
-      "Level": 4,
+      "Level": "4",
       "callerIpAddress": "11.22.33.44",
       "category": "UserRiskEvents",
       "correlationId": "ef7868bd7e94b06ecd6cc965fc826c85d367bb5b9b083da9a26686786a791080",

--- a/Azure/azure-ad/tests/user_risk_detection_2.json
+++ b/Azure/azure-ad/tests/user_risk_detection_2.json
@@ -24,7 +24,6 @@
       "name": "User Risk Detection"
     },
     "azuread": {
-      "Level": "4",
       "callerIpAddress": "11.22.33.44",
       "category": "UserRiskEvents",
       "correlationId": "ef7868bd7e94b06ecd6cc965fc826c85d367bb5b9b083da9a26686786a791080",
@@ -55,6 +54,9 @@
       },
       "resourceId": "/tenants/2d0c1986-ef7b-4bbf-8428-3c837471e7ad/providers/microsoft.aadiam",
       "tenantId": "2d0c1986-ef7b-4bbf-8428-3c837471e7ad"
+    },
+    "log": {
+      "level": "4"
     },
     "related": {
       "ip": [

--- a/Azure/azure-ad/tests/user_risk_detection_3.json
+++ b/Azure/azure-ad/tests/user_risk_detection_3.json
@@ -1,0 +1,97 @@
+{
+  "input": {
+    "message": "{\"time\":\"12/13/2024 4:34:03 PM\",\"resourceId\":\"/tenants/1ed21da3-c6d6-41a5-8764-ebec8ba8a020/providers/microsoft.aadiam\",\"operationName\":\"User Risk Detection\",\"operationVersion\":\"1.0\",\"category\":\"UserRiskEvents\",\"tenantId\":\"1ed21da3-c6d6-41a5-8764-ebec8ba8a020\",\"resultSignature\":\"None\",\"durationMs\":0,\"callerIpAddress\":\"1.2.3.4\",\"correlationId\":\"111111111111111111111111111111111111\",\"identity\":\"doe john\",\"Level\":\"Information\",\"location\":\"fr\",\"properties\":{\"id\":\"111111111111111111111111111111111111\",\"requestId\":\"a91dd168-5e09-48e1-9120-185626543431\",\"correlationId\":\"d6e4b382-39a3-4988-9db3-85156bcdadfd\",\"riskType\":\"unfamiliarFeatures\",\"riskEventType\":\"unfamiliarFeatures\",\"riskState\":\"dismissed\",\"riskLevel\":\"low\",\"riskDetail\":\"aiConfirmedSigninSafe\",\"source\":\"IdentityProtection\",\"detectionTimingType\":\"realtime\",\"activity\":\"signin\",\"ipAddress\":\"1.2.3.4\",\"location\":{\"city\":\"Rennes\",\"state\":\"Bretagne\",\"countryOrRegion\":\"FR\",\"geoCoordinates\":{\"altitude\":0.0,\"latitude\":0.0,\"longitude\":0.0}},\"activityDateTime\":\"2024-12-13T16:31:49.945Z\",\"detectedDateTime\":\"2024-12-13T16:31:49.945Z\",\"lastUpdatedDateTime\":\"2024-12-13T16:34:03.966Z\",\"userId\":\"d6e4b382-39a3-4988-9db3-85156bcdadfd\",\"userDisplayName\":\"DOE John\",\"userPrincipalName\":\"DOE@company.com\",\"additionalInfo\":\"[{\\\"Key\\\":\\\"riskReasons\\\",\\\"Value\\\":[\\\"UnfamiliarBrowser\\\",\\\"UnfamiliarDevice\\\",\\\"UnfamiliarIP\\\",\\\"UnfamiliarLocation\\\",\\\"UnfamiliarEASId\\\",\\\"UnfamiliarTenantIPsubnet\\\"]},{\\\"Key\\\":\\\"userAgent\\\",\\\"Value\\\":\\\"Mozilla/5.0 (Linux; Android 14; SM-S911B Build/UP1A.231005.007; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/131.0.6778.105 Mobile Safari/537.36 PKeyAuth/1.0\\\"},{\\\"Key\\\":\\\"alertUrl\\\",\\\"Value\\\":null},{\\\"Key\\\":\\\"mitreTechniques\\\",\\\"Value\\\":\\\"T1078.004\\\"}]\",\"tokenIssuerType\":\"AzureAD\",\"resourceTenantId\":null,\"homeTenantId\":\"1ed21da3-c6d6-41a5-8764-ebec8ba8a020\",\"userType\":\"member\",\"crossTenantAccessType\":\"none\",\"mitreTechniqueId\":\"T1078.004\"}}",
+    "sekoiaio": {
+      "intake": {
+        "dialect": "Microsoft Entra ID / Azure AD",
+        "dialect_uuid": "19cd2ed6-f90c-47f7-a46b-974354a107bb"
+      }
+    }
+  },
+  "expected": {
+    "message": "{\"time\":\"12/13/2024 4:34:03 PM\",\"resourceId\":\"/tenants/1ed21da3-c6d6-41a5-8764-ebec8ba8a020/providers/microsoft.aadiam\",\"operationName\":\"User Risk Detection\",\"operationVersion\":\"1.0\",\"category\":\"UserRiskEvents\",\"tenantId\":\"1ed21da3-c6d6-41a5-8764-ebec8ba8a020\",\"resultSignature\":\"None\",\"durationMs\":0,\"callerIpAddress\":\"1.2.3.4\",\"correlationId\":\"111111111111111111111111111111111111\",\"identity\":\"doe john\",\"Level\":\"Information\",\"location\":\"fr\",\"properties\":{\"id\":\"111111111111111111111111111111111111\",\"requestId\":\"a91dd168-5e09-48e1-9120-185626543431\",\"correlationId\":\"d6e4b382-39a3-4988-9db3-85156bcdadfd\",\"riskType\":\"unfamiliarFeatures\",\"riskEventType\":\"unfamiliarFeatures\",\"riskState\":\"dismissed\",\"riskLevel\":\"low\",\"riskDetail\":\"aiConfirmedSigninSafe\",\"source\":\"IdentityProtection\",\"detectionTimingType\":\"realtime\",\"activity\":\"signin\",\"ipAddress\":\"1.2.3.4\",\"location\":{\"city\":\"Rennes\",\"state\":\"Bretagne\",\"countryOrRegion\":\"FR\",\"geoCoordinates\":{\"altitude\":0.0,\"latitude\":0.0,\"longitude\":0.0}},\"activityDateTime\":\"2024-12-13T16:31:49.945Z\",\"detectedDateTime\":\"2024-12-13T16:31:49.945Z\",\"lastUpdatedDateTime\":\"2024-12-13T16:34:03.966Z\",\"userId\":\"d6e4b382-39a3-4988-9db3-85156bcdadfd\",\"userDisplayName\":\"DOE John\",\"userPrincipalName\":\"DOE@company.com\",\"additionalInfo\":\"[{\\\"Key\\\":\\\"riskReasons\\\",\\\"Value\\\":[\\\"UnfamiliarBrowser\\\",\\\"UnfamiliarDevice\\\",\\\"UnfamiliarIP\\\",\\\"UnfamiliarLocation\\\",\\\"UnfamiliarEASId\\\",\\\"UnfamiliarTenantIPsubnet\\\"]},{\\\"Key\\\":\\\"userAgent\\\",\\\"Value\\\":\\\"Mozilla/5.0 (Linux; Android 14; SM-S911B Build/UP1A.231005.007; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/131.0.6778.105 Mobile Safari/537.36 PKeyAuth/1.0\\\"},{\\\"Key\\\":\\\"alertUrl\\\",\\\"Value\\\":null},{\\\"Key\\\":\\\"mitreTechniques\\\",\\\"Value\\\":\\\"T1078.004\\\"}]\",\"tokenIssuerType\":\"AzureAD\",\"resourceTenantId\":null,\"homeTenantId\":\"1ed21da3-c6d6-41a5-8764-ebec8ba8a020\",\"userType\":\"member\",\"crossTenantAccessType\":\"none\",\"mitreTechniqueId\":\"T1078.004\"}}",
+    "event": {
+      "category": [
+        "iam"
+      ],
+      "reason": "unfamiliarFeatures",
+      "type": [
+        "connection"
+      ]
+    },
+    "@timestamp": "2024-12-13T16:34:03Z",
+    "action": {
+      "name": "User Risk Detection"
+    },
+    "azuread": {
+      "Level": "Information",
+      "callerIpAddress": "1.2.3.4",
+      "category": "UserRiskEvents",
+      "correlationId": "111111111111111111111111111111111111",
+      "durationMs": 0,
+      "identity": "doe john",
+      "operationName": "User Risk Detection",
+      "operationVersion": "1.0",
+      "properties": {
+        "activity": "signin",
+        "correlationId": "d6e4b382-39a3-4988-9db3-85156bcdadfd",
+        "detectionTimingType": "realtime",
+        "id": "111111111111111111111111111111111111",
+        "requestId": "a91dd168-5e09-48e1-9120-185626543431",
+        "riskDetail": "aiConfirmedSigninSafe",
+        "riskEventType": "unfamiliarFeatures",
+        "riskLevel": "low",
+        "riskReasons": [
+          "UnfamiliarBrowser",
+          "UnfamiliarDevice",
+          "UnfamiliarEASId",
+          "UnfamiliarIP",
+          "UnfamiliarLocation",
+          "UnfamiliarTenantIPsubnet"
+        ],
+        "riskState": "dismissed",
+        "source": "IdentityProtection"
+      },
+      "resourceId": "/tenants/1ed21da3-c6d6-41a5-8764-ebec8ba8a020/providers/microsoft.aadiam",
+      "tenantId": "1ed21da3-c6d6-41a5-8764-ebec8ba8a020"
+    },
+    "related": {
+      "ip": [
+        "1.2.3.4"
+      ]
+    },
+    "service": {
+      "name": "Azure Active Directory",
+      "type": "ldap"
+    },
+    "source": {
+      "address": "1.2.3.4",
+      "geo": {
+        "city_name": "Rennes",
+        "country_iso_code": "fr",
+        "location": {
+          "lat": 0.0,
+          "lon": 0.0
+        },
+        "region_name": "Bretagne"
+      },
+      "ip": "1.2.3.4"
+    },
+    "user": {
+      "email": "DOE@company.com",
+      "full_name": "DOE John"
+    },
+    "user_agent": {
+      "device": {
+        "name": "Samsung SM-S911B"
+      },
+      "name": "Chrome Mobile WebView",
+      "original": "Mozilla/5.0 (Linux; Android 14; SM-S911B Build/UP1A.231005.007; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/131.0.6778.105 Mobile Safari/537.36 PKeyAuth/1.0",
+      "os": {
+        "name": "Android",
+        "version": "14"
+      },
+      "version": "131.0.6778"
+    }
+  }
+}

--- a/Azure/azure-ad/tests/user_risk_detection_3.json
+++ b/Azure/azure-ad/tests/user_risk_detection_3.json
@@ -24,7 +24,6 @@
       "name": "User Risk Detection"
     },
     "azuread": {
-      "Level": "Information",
       "callerIpAddress": "1.2.3.4",
       "category": "UserRiskEvents",
       "correlationId": "111111111111111111111111111111111111",
@@ -54,6 +53,9 @@
       },
       "resourceId": "/tenants/1ed21da3-c6d6-41a5-8764-ebec8ba8a020/providers/microsoft.aadiam",
       "tenantId": "1ed21da3-c6d6-41a5-8764-ebec8ba8a020"
+    },
+    "log": {
+      "level": "Information"
     },
     "related": {
       "ip": [


### PR DESCRIPTION
Fix related to [this issue](https://github.com/SekoiaLab/integration/issues/338)

As there is no standardization for the Level field for this format, I only stringified the field when it contains a number (using the Syslog standard might generate issues in some cases), so it might be quite poor in informations depending on the events, i.e. no idea of the meaning of the aforementioned level. Feel free to provide feedback if you have a better idea concerning the depiction of those fields.