### PR TITLE
Office365: remove empty arrays

### DIFF
--- a/Office 365/o365/ingest/parser.yml
+++ b/Office 365/o365/ingest/parser.yml
@@ -869,13 +869,13 @@ stages:
             ]
 
           office365.investigation.delivery.action: >
-            [
+            {%- set actions = [] -%}
             {%- for Property in parse_data.ParsedData.Entities -%}
               {%- if Property.DeliveryAction -%}
-                "{{ Property.DeliveryAction }}",
+                {%- set actions = actions.append(Property.DeliveryAction) -%}
               {%- endif -%}
             {%- endfor -%}
-            ]
+            {{ actions or None}}
 
           email.from.address: >
             {%- set senders = [] -%}

--- a/Office 365/o365/ingest/parser.yml
+++ b/Office 365/o365/ingest/parser.yml
@@ -898,17 +898,17 @@ stages:
             {%- endfor -%}
             {{receivers|unique|list}}
           email.attachments: >-
-            [
+            {%- set attachments = [] -%}
             {%- for Property in parse_data.ParsedData.Entities -%}
               {%- for file in Property.Files -%}
                 {%- for file_hash in file.FileHashes -%}
                   {%- if file_hash.Algorithm == 'SHA256' -%}
-                    {"file": {"name": "{{ file.Name }}", "hash": {"sha256": "{{ file_hash.Value }}"}}}
+                    {%- set attachments = attachments.append({"file": {"name": file.Name, "hash": {"sha256": file_hash.Value }}}) -%}
                   {%- endif -%}
                 {%- endfor -%}
               {%- endfor -%}
             {%- endfor -%}
-            ]
+            {{attachments or None}}
         filter: "{{parse_data.ParsedData.Entities != None and parse_data.ParsedData.Entities | length > 0}}"
 
   parse_mcas_alerts:

--- a/Office 365/o365/ingest/parser.yml
+++ b/Office 365/o365/ingest/parser.yml
@@ -896,7 +896,7 @@ stages:
                 {%- set receivers = receivers.append(Property.MailboxPrimaryAddress) -%}
               {%- endif -%}
             {%- endfor -%}
-            {{receivers|unique|list}}
+            {{receivers|unique|list or None}}
           email.attachments: >-
             {%- set attachments = [] -%}
             {%- for Property in parse_data.ParsedData.Entities -%}

--- a/Office 365/o365/ingest/parser.yml
+++ b/Office 365/o365/ingest/parser.yml
@@ -834,7 +834,15 @@ stages:
         filter: "{{final.office365.get('investigation', {}).get('emails', []) | length > 1}}"
 
       - set:
-          office365.investigation.email.urls: '[{% for Property in parse_data.ParsedData.Entities %}{% for Url in Property.Urls %} "{{Url}}", {% endfor %}{% endfor %}]'
+          office365.investigation.email.urls: >
+            {%- set urls = [] -%}
+              {%- for Property in parse_data.ParsedData.Entities -%}
+                {%- if Property.Urls -%}
+                  {%- set urls = urls.extend(Property.Urls) -%}
+                {%- endif -%}
+              {%- endfor -%}
+            {{urls|unique|list or None}}
+
           office365.investigation.email.sender.ip: >
             {%- set senders = [] -%}
               {%- for Property in parse_data.ParsedData.Entities -%}

--- a/Office 365/o365/ingest/parser.yml
+++ b/Office 365/o365/ingest/parser.yml
@@ -836,13 +836,14 @@ stages:
       - set:
           office365.investigation.email.urls: '[{% for Property in parse_data.ParsedData.Entities %}{% for Url in Property.Urls %} "{{Url}}", {% endfor %}{% endfor %}]'
           office365.investigation.email.sender.ip: >
-            [
+            {%- set senders = [] -%}
               {%- for Property in parse_data.ParsedData.Entities -%}
                 {%- if Property.SenderIP -%}
-                  "{{Property.SenderIP}}",
+                  {%- set senders = senders.append(Property.SenderIP) -%}
                 {%- endif -%}
               {%- endfor -%}
-            ]
+            {{senders|unique|list or None}}
+
           office365.investigation.email.subjects: >
             {%- set subjects = [] -%}
               {%- for Property in parse_data.ParsedData.Entities -%}

--- a/Office 365/o365/ingest/parser.yml
+++ b/Office 365/o365/ingest/parser.yml
@@ -878,13 +878,13 @@ stages:
             ]
 
           email.from.address: >
-            [
+            {%- set senders = [] -%}
             {%- for Property in parse_data.ParsedData.Entities -%}
               {%- if Property.Sender -%}
-                "{{Property.Sender}}",
+                {%- set senders = senders.append(Property.Sender) -%}
               {%- endif -%}
             {%- endfor -%}
-            ]
+            {{senders|unique|list or None}}
 
           email.to.address: >
             {%- set receivers = [] -%}

--- a/Office 365/o365/ingest/parser.yml
+++ b/Office 365/o365/ingest/parser.yml
@@ -860,13 +860,17 @@ stages:
               {%- endfor -%}
             ]
           office365.investigation.threats: >
-            [
+            {%- set threats = [] -%}
             {%- for Property in parse_data.ParsedData.Entities -%}
               {%- if Property.Threats -%}
-                "{{Property.Threats}}",
+                {%- if Property.Threats is iterable -%}
+                  {%- set threats = threats.extend(Property.Threats) -%}
+                {%- else -%}
+                  {%- set threats = threats.append(Property.Threats | string) -%}
+                {%- endif -%}
               {%- endif -%}
             {%- endfor -%}
-            ]
+            {{ threats or None}}
 
           office365.investigation.delivery.action: >
             {%- set actions = [] -%}

--- a/Office 365/o365/ingest/parser.yml
+++ b/Office 365/o365/ingest/parser.yml
@@ -781,7 +781,7 @@ stages:
                 {%- set urls = urls.append(link.Href) -%}
               {%- endif -%}
             {%- endfor -%}
-            {{urls|unique|list}}
+            {{urls|unique|list or None}}
         filter: '{{parse_data.ParsedData.ExtendedLinks|selectattr("Type", "equalto", "webLink") | list | length > 0}}'
 
       - set:

--- a/Office 365/o365/ingest/parser.yml
+++ b/Office 365/o365/ingest/parser.yml
@@ -852,13 +852,14 @@ stages:
               {%- endfor -%}
             ]
           office365.investigation.email.sender.domains: >
-            [
+            {%- set senders = [] -%}
               {%- for Property in parse_data.ParsedData.Entities -%}
                 {%- if Property.P1SenderDomain -%}
-                  "{{Property.P1SenderDomain}}",
+                  {%- set senders = senders.append(Property.P1SenderDomain) -%}
                 {%- endif -%}
               {%- endfor -%}
-            ]
+            {{senders|unique|list or None}}
+
           office365.investigation.threats: >
             {%- set threats = [] -%}
             {%- for Property in parse_data.ParsedData.Entities -%}

--- a/Office 365/o365/ingest/parser.yml
+++ b/Office 365/o365/ingest/parser.yml
@@ -844,13 +844,14 @@ stages:
               {%- endfor -%}
             ]
           office365.investigation.email.subjects: >
-            [
+            {%- set subjects = [] -%}
               {%- for Property in parse_data.ParsedData.Entities -%}
                 {%- if Property.Subject -%}
-                  "{{Property.Subject}}",
+                  {%- set subjects = subjects.append(Property.Subject) -%}
                 {%- endif -%}
               {%- endfor -%}
-            ]
+            {{ subjects or None}}
+
           office365.investigation.email.sender.domains: >
             {%- set senders = [] -%}
               {%- for Property in parse_data.ParsedData.Entities -%}

--- a/Office 365/o365/tests/automated_investigation_and_response_1.json
+++ b/Office 365/o365/tests/automated_investigation_and_response_1.json
@@ -141,7 +141,8 @@
         "name": "Mail with malicious urls is zapped - urn:ZappedUrlInvestigation:611e72a0f8dc10fecbf6fc017c51d101",
         "status": "Pending Action",
         "threats": [
-          "['ZapPhish', 'HighConfPhish']"
+          "HighConfPhish",
+          "ZapPhish"
         ],
         "type": "ZappedUrlInvestigation"
       },

--- a/Office 365/o365/tests/automated_investigation_and_response_2.json
+++ b/Office 365/o365/tests/automated_investigation_and_response_2.json
@@ -60,7 +60,6 @@
         },
         "email": {
           "sender": {
-            "domains": [],
             "ip": []
           },
           "subjects": [],

--- a/Office 365/o365/tests/automated_investigation_and_response_2.json
+++ b/Office 365/o365/tests/automated_investigation_and_response_2.json
@@ -26,9 +26,6 @@
       "target": "user"
     },
     "email": {
-      "from": {
-        "address": []
-      },
       "to": {
         "address": [
           "john.doe@company.eu"

--- a/Office 365/o365/tests/automated_investigation_and_response_2.json
+++ b/Office 365/o365/tests/automated_investigation_and_response_2.json
@@ -26,7 +26,6 @@
       "target": "user"
     },
     "email": {
-      "attachments": [],
       "from": {
         "address": []
       },

--- a/Office 365/o365/tests/automated_investigation_and_response_2.json
+++ b/Office 365/o365/tests/automated_investigation_and_response_2.json
@@ -62,7 +62,6 @@
           "sender": {
             "ip": []
           },
-          "subjects": [],
           "urls": []
         },
         "emails": [

--- a/Office 365/o365/tests/automated_investigation_and_response_2.json
+++ b/Office 365/o365/tests/automated_investigation_and_response_2.json
@@ -58,9 +58,6 @@
             "https://security.microsoft.com/alerts/fa44444444-4444-4444-4444-444444444444"
           ]
         },
-        "delivery": {
-          "action": []
-        },
         "email": {
           "sender": {
             "domains": [],

--- a/Office 365/o365/tests/automated_investigation_and_response_2.json
+++ b/Office 365/o365/tests/automated_investigation_and_response_2.json
@@ -76,7 +76,6 @@
         "id": "urn:UrlVerdictChangeInvestig:ef7ff0b054c22025f22f6f4416f75cc0",
         "name": "Clicked url Verdict changed to malicious - https://www.test.com.tr/2025%20inquiry.js",
         "status": "Pending Action",
-        "threats": [],
         "type": "UrlVerdictChangeInvestigation"
       },
       "record_type": 64,

--- a/Office 365/o365/tests/automated_investigation_and_response_2.json
+++ b/Office 365/o365/tests/automated_investigation_and_response_2.json
@@ -59,9 +59,6 @@
           ]
         },
         "email": {
-          "sender": {
-            "ip": []
-          },
           "urls": []
         },
         "emails": [

--- a/Office 365/o365/tests/automated_investigation_and_response_2.json
+++ b/Office 365/o365/tests/automated_investigation_and_response_2.json
@@ -58,9 +58,6 @@
             "https://security.microsoft.com/alerts/fa44444444-4444-4444-4444-444444444444"
           ]
         },
-        "email": {
-          "urls": []
-        },
         "emails": [
           {
             "message_ids": [

--- a/Office 365/o365/tests/automated_investigation_and_response_with_additional_fields.json
+++ b/Office 365/o365/tests/automated_investigation_and_response_with_additional_fields.json
@@ -56,9 +56,6 @@
           "source_type": "source_alert_type_value",
           "type": "alert_type_value"
         },
-        "delivery": {
-          "action": []
-        },
         "email": {
           "sender": {
             "domains": [

--- a/Office 365/o365/tests/automated_investigation_and_response_with_additional_fields.json
+++ b/Office 365/o365/tests/automated_investigation_and_response_with_additional_fields.json
@@ -20,7 +20,6 @@
       "target": "user"
     },
     "email": {
-      "attachments": [],
       "from": {
         "address": [
           "test3@test.test",

--- a/Office 365/o365/tests/automated_investigation_and_response_with_additional_fields_1.json
+++ b/Office 365/o365/tests/automated_investigation_and_response_with_additional_fields_1.json
@@ -20,7 +20,6 @@
       "target": "user"
     },
     "email": {
-      "attachments": [],
       "from": {
         "address": [
           "sender@test.integration.com"

--- a/Office 365/o365/tests/automated_investigation_and_response_with_additional_fields_1.json
+++ b/Office 365/o365/tests/automated_investigation_and_response_with_additional_fields_1.json
@@ -116,7 +116,8 @@
         "name": "Mail with malicious urls is zapped - urn:ZappedUrlInvestigation:a01b23c4de5f678901a234bc5678d9",
         "status": "Pending Action",
         "threats": [
-          "['ZapPhish', 'NormalPhish']"
+          "NormalPhish",
+          "ZapPhish"
         ],
         "type": "ZappedUrlInvestigation"
       },

--- a/Office 365/o365/tests/automated_investigation_and_response_with_attachment.json
+++ b/Office 365/o365/tests/automated_investigation_and_response_with_attachment.json
@@ -105,7 +105,6 @@
         "id": "urn:ZappedFileInvestigation:adffaf6ed0f17079cf14e9dc2adf9c1d",
         "name": "Mail with malicious file is zapped - urn:ZappedFileInvestigation:adffaf6ed0f17079cf14e9dc2adf9c1d",
         "status": "Investigation Started",
-        "threats": [],
         "type": "ZappedFileInvestigation"
       },
       "record_type": 64,

--- a/Palo Alto Networks/paloalto-prisma-access/_meta/manifest.yml
+++ b/Palo Alto Networks/paloalto-prisma-access/_meta/manifest.yml
@@ -1,6 +1,6 @@
-uuid: ea265b9d-fb48-4e92-9c26-dcfbf937b630
-name: Palo Alto Prisma access
-slug: paloalto-prisma-access
+uuid: 5b885ad1-72fc-4620-8472-f8537d5efcf6
+name: Palo Alto Prisma access Test
+slug: paloalto-prisma-access-test
 description: >-
   Palo Alto Prisma Access is a cloud-delivered security platform that provides secure access to applications and data, using a scalable network to protect users and devices across all locations. It integrates advanced threat prevention and access controls to ensure consistent security policies.
 
@@ -10,4 +10,3 @@ data_sources:
   Authentication logs: Prisma Access monitor authentications to resources
   Web logs: Prisma Access monitor and logs HTTP requests
   Web application firewall logs: Prisma Access monitor and logs network traffic
-automation_module_uuid: 64a3b634-605d-4d69-a203-3a53c0474cae


### PR DESCRIPTION
Refactor `office365.investigation.email.*` fields and `email.*` fields to remove empty arrays.