### PR TITLE
TrendMicro: rename TrendMicro Apex One

### DIFF
--- a/Trend Micro/trend-micro-apex-one/_meta/manifest.yml
+++ b/Trend Micro/trend-micro-apex-one/_meta/manifest.yml
@@ -1,7 +1,7 @@
 uuid: 064f7e8b-ce5f-474d-802e-e88fe2193365
-name: Trend Micro Apex One
+name: Trend Micro Apex One / Vision One endpoint
 slug: trend-micro-apex-one
-description: Trend Micro APEX ONE is Endpoint Detection and Response (EDR) solution that detects and protects your endpoints against threats.
+description: Trend Micro Apex One / Vision One endpoint is Endpoint Detection and Response (EDR) solution that detects and protects your endpoints against threats.
 data_sources:
   Authentication logs: Trend Micro Deep Security produce logs describing authentication events
   File monitoring: Trend Micro Deep Security monitor changes made on the host and on the appplications


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Rename the Trend Micro Apex One integration to Trend Micro Apex One / Vision One endpoint.