### PR TITLE
Revert harfanglab.agent_ids

### DIFF
--- a/HarfangLab/harfanglab/_meta/fields.yml
+++ b/HarfangLab/harfanglab/_meta/fields.yml
@@ -961,11 +961,6 @@ action.properties.param9:
   name: action.properties.param9
   type: keyword
 
-harfanglab.agent_ids:
-  description: ''
-  name: harfanglab.agent_ids
-  type: keyword
-
 harfanglab.agents:
   description: ''
   name: harfanglab.agents

--- a/HarfangLab/harfanglab/ingest/parser.yml
+++ b/HarfangLab/harfanglab/ingest/parser.yml
@@ -179,7 +179,6 @@ stages:
           url.original: "{{json_event.message.details_url_request.url}}"
 
       - set:
-          harfanglab.agent_ids: "{{json_event.message.agents | map(attribute='agent_id') | list}}"
           harfanglab.agents: >
             [
               {%- for elt in json_event.message.agents -%}

--- a/HarfangLab/harfanglab/tests/test_threat_log_1.json
+++ b/HarfangLab/harfanglab/tests/test_threat_log_1.json
@@ -19,9 +19,6 @@
       "name": "harfanglab"
     },
     "harfanglab": {
-      "agent_ids": [
-        "94777777-8888-aaaa-ffff-0000000000000"
-      ],
       "agents": [
         {
           "hostname": "B810000",

--- a/HarfangLab/harfanglab/tests/test_threat_log_2.json
+++ b/HarfangLab/harfanglab/tests/test_threat_log_2.json
@@ -19,10 +19,6 @@
       "name": "harfanglab"
     },
     "harfanglab": {
-      "agent_ids": [
-        "57153fc2-62d2-462c-9676-6d42d32b6e9b",
-        "cce6c191-cdba-4389-afe7-9c4682fda503"
-      ],
       "agents": [
         {
           "hostname": "AGENT-DEV-WIND",

--- a/HarfangLab/harfanglab/tests/threat_critical.json
+++ b/HarfangLab/harfanglab/tests/threat_critical.json
@@ -13,9 +13,6 @@
       "name": "harfanglab"
     },
     "harfanglab": {
-      "agent_ids": [
-        "af5e2f63-becd-4660-ade8-30d04c0dd044"
-      ],
       "agents": [
         {
           "hostname": "Nuke",

--- a/HarfangLab/harfanglab/tests/threat_log.json
+++ b/HarfangLab/harfanglab/tests/threat_log.json
@@ -13,10 +13,6 @@
       "name": "harfanglab"
     },
     "harfanglab": {
-      "agent_ids": [
-        "215fe295-905f-4a8d-8347-e9d438d4e415",
-        "999ba0c7-96b8-4c57-bf0e-63b24813c873"
-      ],
       "agents": [
         {
           "hostname": "DESKTOP_0001",


### PR DESCRIPTION
This reverts commit 70dca72c0b42c7eb8d3738c87d9ddadf0b16001b.

## Summary by Sourcery

Reverts the addition of the harfanglab.agent_ids field.

Chores:
- Removes the harfanglab.agent_ids field from the fields.yml file.
- Removes the setting of the harfanglab.agent_ids field in the ingest/parser.yml file.
- Removes changes in test files related to the harfanglab.agent_ids field.