### PR TITLE
Vectra: handle json message

### DIFF
--- a/Vectra/vectra_cognito_detect/ingest/parser.yml
+++ b/Vectra/vectra_cognito_detect/ingest/parser.yml
@@ -4,7 +4,7 @@ pipeline:
     external:
       name: json.parse-json
       properties:
-        input_field: "{{original.message[3:]}}"
+        input_field: "{{original.message.lstrip(':-').lstrip('-:').lstrip('- :').lstrip(': -').lstrip()}}"
         output_field: message
 
   - name: message_parse_grok

--- a/Vectra/vectra_cognito_detect/tests/vectra_hidden_https_tunnel.json
+++ b/Vectra/vectra_cognito_detect/tests/vectra_hidden_https_tunnel.json
@@ -1,0 +1,27 @@
+{
+  "input": {
+    "message": "{\"id\":11111,\"category\":\"command_and_control\",\"threat\":0,\"certainty\":0,\"triaged\":false,\"detection_type\":\"Hidden HTTPS Tunnel\",\"d_type_vname\":\"Hidden HTTPS Tunnel\",\"detection_href\":\"https://111111111111.ew1.portal.vectra.ai/detections/5432?detail_id=555555\",\"entity_id\":12345,\"entity_type\":\"host\",\"type\":\"host\",\"url\":\"https://111111111111.ew1.portal.vectra.ai/hosts/12345\",\"severity\":0,\"event_timestamp\":\"2025-03-19T18:59:56Z\",\"detection_id\":5432,\"entity_uid\":\"IP-1.2.3.4\",\"detail\":{\"session\":{\"tunnel_type\":\"Multiple short TCP sessions - Abnormal Beacon\",\"protocol\":\"tcp\",\"app_protocol\":\"\",\"dst_port\":443,\"dst_ip\":\"5.6.7.8\",\"bytes_received\":524576,\"bytes_sent\":0,\"first_timestamp\":\"2025-03-19T18:46:15Z\",\"last_timestamp\":\"2025-03-19T18:56:40Z\",\"dst_geo\":null,\"dst_geo_lat\":null,\"dst_geo_lon\":null},\"ja3_hash\":\"adc83b19e793491b1c6ea0fd\",\"ja3s_hash\":\"adc83b19e793491b1c6ea0fd\",\"external_target\":{\"ip\":\"5.6.7.8\",\"name\":\"example.org\"},\"dst_ip\":\"5.6.7.8\",\"dst_dns\":\"example.org\",\"dst_port\":443,\"num_sessions\":20,\"bytes_received\":524576,\"bytes_sent\":0,\"first_timestamp\":\"2025-03-19T18:46:15Z\",\"last_timestamp\":\"2025-03-19T18:56:40Z\"},\"mitre\":[\"T1043\",\"T1094\",\"T1024\",\"T1132\",\"T1001\",\"T1008\",\"T1071\",\"T1032\",\"T1105\",\"T1108\"]}",
+    "sekoiaio": {
+      "intake": {
+        "dialect": "Vectra Cognito Detect",
+        "dialect_uuid": "bf8867ee-43b7-444c-9475-a7f43754ab6d"
+      }
+    }
+  },
+  "expected": {
+    "message": "{\"id\":11111,\"category\":\"command_and_control\",\"threat\":0,\"certainty\":0,\"triaged\":false,\"detection_type\":\"Hidden HTTPS Tunnel\",\"d_type_vname\":\"Hidden HTTPS Tunnel\",\"detection_href\":\"https://111111111111.ew1.portal.vectra.ai/detections/5432?detail_id=555555\",\"entity_id\":12345,\"entity_type\":\"host\",\"type\":\"host\",\"url\":\"https://111111111111.ew1.portal.vectra.ai/hosts/12345\",\"severity\":0,\"event_timestamp\":\"2025-03-19T18:59:56Z\",\"detection_id\":5432,\"entity_uid\":\"IP-1.2.3.4\",\"detail\":{\"session\":{\"tunnel_type\":\"Multiple short TCP sessions - Abnormal Beacon\",\"protocol\":\"tcp\",\"app_protocol\":\"\",\"dst_port\":443,\"dst_ip\":\"5.6.7.8\",\"bytes_received\":524576,\"bytes_sent\":0,\"first_timestamp\":\"2025-03-19T18:46:15Z\",\"last_timestamp\":\"2025-03-19T18:56:40Z\",\"dst_geo\":null,\"dst_geo_lat\":null,\"dst_geo_lon\":null},\"ja3_hash\":\"adc83b19e793491b1c6ea0fd\",\"ja3s_hash\":\"adc83b19e793491b1c6ea0fd\",\"external_target\":{\"ip\":\"5.6.7.8\",\"name\":\"example.org\"},\"dst_ip\":\"5.6.7.8\",\"dst_dns\":\"example.org\",\"dst_port\":443,\"num_sessions\":20,\"bytes_received\":524576,\"bytes_sent\":0,\"first_timestamp\":\"2025-03-19T18:46:15Z\",\"last_timestamp\":\"2025-03-19T18:56:40Z\"},\"mitre\":[\"T1043\",\"T1094\",\"T1024\",\"T1132\",\"T1001\",\"T1008\",\"T1071\",\"T1032\",\"T1105\",\"T1108\"]}",
+    "event": {
+      "action": "host"
+    },
+    "vectra": {
+      "certainty": 0,
+      "detection": {
+        "id": 5432,
+        "name": "Hidden HTTPS Tunnel"
+      },
+      "risk_score_norm": 0,
+      "severity": 0,
+      "triaged": false
+    }
+  }
+}


### PR DESCRIPTION
For historical reason, this parser removes the 3 first characters of the message (that can be `-: `, `:- ` or any another combination of `:`, `-` and ` `).
However, we can receive Vectra events without these 3 characters.
This fix tries to handle the severable cases that we can face on Vectra events.

## Summary by Sourcery

Update the Vectra parser to handle events without the initial three characters by implementing a flexible string stripping method and add a corresponding test case.

Bug Fixes:
- Fix the parser to correctly handle Vectra events that may not have the initial three characters ('-: ', ':- ', etc.) by using a more flexible string stripping method.

Tests:
- Add a new test file 'vectra_hidden_https_tunnel.json' to verify the parser's handling of Vectra events without the initial three characters.