### PR TITLE
OpenBSD: rename the packet filter format

### DIFF
--- a/OpenBSD/openbsd-packet-filter/_meta/manifest.yml
+++ b/OpenBSD/openbsd-packet-filter/_meta/manifest.yml
@@ -1,7 +1,7 @@
 uuid: 8510051d-c7cf-4b0c-a398-031afe91faa0
-name: OpenBSD Packet Filter
+name: OpenBSD Packet Filter / OPNSense / PfSense
 slug: openbsd-packet-filter
-description: OpenBSD is packet filter is stateful firewall available in many BSD-derived Operating system. Providing Packet filter logs to Sekoia.io can be useful in discovering potential network security threats.
+description: OpenBSD is packet filter is stateful firewall available in many BSD-derived Operating system (like OPNSense, PfSense, ...). Providing Packet filter logs to Sekoia.io can be useful in discovering potential network security threats.
 data_sources:
   Network protocol analysis: Packet Filter analyzes passing network packet.
 automation_module_uuid: 77d450fd-f480-408e-a141-8ad534dbb25a


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Rename the packet filter format to include OPNSense and PfSense.