### PR TITLE
GateWatcher: update the description for AIONIQ V103

### DIFF
--- a/GateWatcher/aioniq_ecs/_meta/manifest.yml
+++ b/GateWatcher/aioniq_ecs/_meta/manifest.yml
@@ -3,7 +3,7 @@ name: Gatewatcher AionIQ V103
 slug: aioniq-v103
 
 description: >-
-  A new detection and response platform (NDR) that enables to identify with certainty malicious actions and suspicious behaviors based on a mapping of all assets present on the information system.
+  A new detection and response platform (NDR) that enables to identify with certainty malicious actions and suspicious behaviors based on a mapping of all assets present on the information system. This format parses events up to the version 103.
 
 data_sources:
   Network intrusion detection system: AIONIQ identify suspicious behaviors


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Modify the manifest description to specify that the platform parses events up to version 103