### PR TITLE
Fix: Fortigate sessionid utmaction (515)

### DIFF
--- a/Fortinet/fortigate/_meta/fields.yml
+++ b/Fortinet/fortigate/_meta/fields.yml
@@ -93,6 +93,11 @@ fortinet.fortigate.poluuid:
   name: fortinet.fortigate.poluuid
   type: keyword
 
+fortinet.fortigate.sessionid:
+  description: Session ID
+  name: fortinet.fortigate.sessionid
+  type: keyword
+
 fortinet.fortigate.sn:
   description: Serial number of the security fabric
   name: fortinet.fortigate.sn
@@ -126,6 +131,11 @@ fortinet.fortigate.tunnel.version:
 fortinet.fortigate.user.source:
   description: The source of the username
   name: fortinet.fortigate.user.source
+  type: keyword
+
+fortinet.fortigate.utmaction:
+  description: UTM action taken by Fortigate
+  name: fortinet.fortigate.utmaction
   type: keyword
 
 fortinet.fortigate.virtual_domain:

--- a/Fortinet/fortigate/ingest/parser.yml
+++ b/Fortinet/fortigate/ingest/parser.yml
@@ -242,6 +242,8 @@ stages:
           fortinet.fortigate.attack.id: "{{parsed_event.message.attackid}}"
           fortinet.fortigate.policyid: "{{parsed_event.message.policyid}}"
           fortinet.fortigate.poluuid: "{{parsed_event.message.poluuid}}"
+          fortinet.fortigate.sessionid: "{{parsed_event.message.sessionid}}"
+          fortinet.fortigate.utmaction: "{{parsed_event.message.utmaction}}"
           network.forwarded_ip: "{{parsed_event.message.forwardedfor}}"
           group.name: "{{parsed_event.message.group or parsed_event.message.FTNTFGTgroup}}"
 

--- a/Fortinet/fortigate/tests/DNS.STANDARD.json
+++ b/Fortinet/fortigate/tests/DNS.STANDARD.json
@@ -33,6 +33,7 @@
         },
         "policyid": "1685",
         "poluuid": "4470d4c5-7e12-4a8f-a369-08eff4a43b5b",
+        "sessionid": "933308058",
         "virtual_domain": "root"
       }
     },

--- a/Fortinet/fortigate/tests/DNS2.STANDARD.json
+++ b/Fortinet/fortigate/tests/DNS2.STANDARD.json
@@ -36,6 +36,7 @@
         },
         "policyid": "770",
         "poluuid": "f2aef0f2-a721-49cf-9dd3-b27f7f5b90bc",
+        "sessionid": "933538554",
         "virtual_domain": "root"
       }
     },

--- a/Fortinet/fortigate/tests/anomaly.CSV.json
+++ b/Fortinet/fortigate/tests/anomaly.CSV.json
@@ -44,6 +44,7 @@
             "type": "0x92"
           }
         },
+        "sessionid": "0",
         "virtual_domain": "vdom1"
       }
     },

--- a/Fortinet/fortigate/tests/anomaly.STANDARD.json
+++ b/Fortinet/fortigate/tests/anomaly.STANDARD.json
@@ -44,6 +44,7 @@
             "type": "0x92"
           }
         },
+        "sessionid": "0",
         "virtual_domain": "vdom1"
       }
     },

--- a/Fortinet/fortigate/tests/app_ctrl.json
+++ b/Fortinet/fortigate/tests/app_ctrl.json
@@ -42,6 +42,7 @@
           "type": "utm"
         },
         "policyid": "293",
+        "sessionid": "1947800834",
         "virtual_domain": "root"
       }
     },

--- a/Fortinet/fortigate/tests/dns.CSV.json
+++ b/Fortinet/fortigate/tests/dns.CSV.json
@@ -43,6 +43,7 @@
           "type": "dns"
         },
         "policyid": "1",
+        "sessionid": "13355",
         "virtual_domain": "vdom1"
       }
     },

--- a/Fortinet/fortigate/tests/forwadedfor.json
+++ b/Fortinet/fortigate/tests/forwadedfor.json
@@ -41,6 +41,7 @@
         },
         "policyid": "00000",
         "poluuid": "xxxxxx-xxxx-xxxx-xxxxxx",
+        "sessionid": "111111111",
         "virtual_domain": "root"
       }
     },

--- a/Fortinet/fortigate/tests/hostname.STANDARD.json
+++ b/Fortinet/fortigate/tests/hostname.STANDARD.json
@@ -33,6 +33,7 @@
           "type": "utm"
         },
         "policyid": "1",
+        "sessionid": "1508480438",
         "virtual_domain": "root"
       }
     },

--- a/Fortinet/fortigate/tests/icmp.json
+++ b/Fortinet/fortigate/tests/icmp.json
@@ -30,6 +30,7 @@
         },
         "policyid": "1",
         "poluuid": "1520e1aa-823a-51e9-984f-a55e1f39b3c7",
+        "sessionid": "706677975",
         "virtual_domain": "root"
       }
     },

--- a/Fortinet/fortigate/tests/icmp6.json
+++ b/Fortinet/fortigate/tests/icmp6.json
@@ -31,6 +31,7 @@
           "type": "traffic"
         },
         "policyid": "0",
+        "sessionid": "1395131",
         "virtual_domain": "root"
       }
     },

--- a/Fortinet/fortigate/tests/ping.json
+++ b/Fortinet/fortigate/tests/ping.json
@@ -32,6 +32,7 @@
         },
         "policyid": "637",
         "poluuid": "b23818a6-8f49-51ea-9db7-4e4965a3483c",
+        "sessionid": "3558919660",
         "virtual_domain": "ROUTER"
       }
     },

--- a/Fortinet/fortigate/tests/test_group_field.json
+++ b/Fortinet/fortigate/tests/test_group_field.json
@@ -42,6 +42,7 @@
         },
         "policyid": "1018",
         "poluuid": "38fa6456-a819-51ef-3c99-000000000000000000",
+        "sessionid": "400190000",
         "virtual_domain": "EFF"
       }
     },

--- a/Fortinet/fortigate/tests/test_group_field_1.json
+++ b/Fortinet/fortigate/tests/test_group_field_1.json
@@ -39,6 +39,7 @@
         },
         "policyid": "274",
         "poluuid": "ac8ed64c-54e7-51eb-3525-d610000000000",
+        "sessionid": "100100046",
         "virtual_domain": "root"
       }
     },

--- a/Fortinet/fortigate/tests/test_ips.STANDARD.json
+++ b/Fortinet/fortigate/tests/test_ips.STANDARD.json
@@ -38,6 +38,7 @@
         },
         "policyid": "494",
         "poluuid": "aecacfaf-8d3f-4809-a60f-bf873e0fcab3",
+        "sessionid": "1234567890",
         "virtual_domain": "root"
       }
     },

--- a/Fortinet/fortigate/tests/test_unauthuser.json
+++ b/Fortinet/fortigate/tests/test_unauthuser.json
@@ -33,6 +33,7 @@
         },
         "policyid": "37",
         "poluuid": "6a8f76d0-1459-4ddb-948a-62700ddbf241",
+        "sessionid": "111111111",
         "user": {
           "source": "kerberos"
         },

--- a/Fortinet/fortigate/tests/traffic.json
+++ b/Fortinet/fortigate/tests/traffic.json
@@ -1,0 +1,88 @@
+{
+  "input": {
+    "message": "timestamp=1742602531 devname=\"XXX\" devid=\"XXX\" vd=\"root\" date=2025-03-22 time=00:15:31 eventtime=1742613330828471629 tz=\"-0300\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" srcip=1.2.3.4 srcport=60568 srcintf=\"port1\" srcintfrole=\"undefined\" dstip=2.3.4.5 dstport=53 dstintf=\"XXX\" dstintfrole=\"undefined\" srccountry=\"Reserved\" dstcountry=\"Japan\" sessionid=496025498 proto=17 action=\"accept\" policyid=398 policytype=\"policy\" poluuid=\"215103c0-f60e-51eb-74b6-a3eaf61ab72e\" service=\"udp-53\" trandisp=\"noop\" appid=16195 app=\"DNS\" appcat=\"Network.Service\" apprisk=\"elevated\" applist=\"XXX\" duration=180 sentbyte=0 rcvdbyte=0 sentpkt=0 rcvdpkt=0 vpntype=\"ipsecvpn\" utmaction=\"block\" countips=1 crscore=30 craction=8192"
+  },
+  "expected": {
+    "message": "timestamp=1742602531 devname=\"XXX\" devid=\"XXX\" vd=\"root\" date=2025-03-22 time=00:15:31 eventtime=1742613330828471629 tz=\"-0300\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" srcip=1.2.3.4 srcport=60568 srcintf=\"port1\" srcintfrole=\"undefined\" dstip=2.3.4.5 dstport=53 dstintf=\"XXX\" dstintfrole=\"undefined\" srccountry=\"Reserved\" dstcountry=\"Japan\" sessionid=496025498 proto=17 action=\"accept\" policyid=398 policytype=\"policy\" poluuid=\"215103c0-f60e-51eb-74b6-a3eaf61ab72e\" service=\"udp-53\" trandisp=\"noop\" appid=16195 app=\"DNS\" appcat=\"Network.Service\" apprisk=\"elevated\" applist=\"XXX\" duration=180 sentbyte=0 rcvdbyte=0 sentpkt=0 rcvdpkt=0 vpntype=\"ipsecvpn\" utmaction=\"block\" countips=1 crscore=30 craction=8192",
+    "event": {
+      "action": "accept",
+      "category": "traffic",
+      "code": "0000000013",
+      "dataset": "traffic:forward",
+      "outcome": "success",
+      "timezone": "-0300"
+    },
+    "@timestamp": "2025-03-22T03:15:30.828472Z",
+    "action": {
+      "name": "accept",
+      "outcome": "success",
+      "target": "network-traffic",
+      "type": "forward"
+    },
+    "destination": {
+      "address": "2.3.4.5",
+      "bytes": 0,
+      "ip": "2.3.4.5",
+      "packets": 0,
+      "port": 53
+    },
+    "fortinet": {
+      "fortigate": {
+        "apprisk": "elevated",
+        "event": {
+          "type": "traffic"
+        },
+        "policyid": "398",
+        "poluuid": "215103c0-f60e-51eb-74b6-a3eaf61ab72e",
+        "sessionid": "496025498",
+        "utmaction": "block",
+        "virtual_domain": "root"
+      }
+    },
+    "log": {
+      "hostname": "XXX",
+      "level": "notice"
+    },
+    "network": {
+      "application": "DNS",
+      "bytes": 0,
+      "protocol": "udp-53",
+      "transport": "udp"
+    },
+    "observer": {
+      "egress": {
+        "interface": {
+          "name": "XXX"
+        }
+      },
+      "hostname": "XXX",
+      "ingress": {
+        "interface": {
+          "name": "port1"
+        }
+      },
+      "serial_number": "XXX"
+    },
+    "related": {
+      "hosts": [
+        "XXX"
+      ],
+      "ip": [
+        "1.2.3.4",
+        "2.3.4.5"
+      ]
+    },
+    "rule": {
+      "apprisk": "elevated",
+      "category": "Network.Service",
+      "ruleset": "XXX"
+    },
+    "source": {
+      "address": "1.2.3.4",
+      "bytes": 0,
+      "ip": "1.2.3.4",
+      "packets": 0,
+      "port": 60568
+    }
+  }
+}

--- a/Fortinet/fortigate/tests/traffic.json
+++ b/Fortinet/fortigate/tests/traffic.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "timestamp=1742602531 devname=\"XXX\" devid=\"XXX\" vd=\"root\" date=2025-03-22 time=00:15:31 eventtime=1742613330828471629 tz=\"-0300\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" srcip=1.2.3.4 srcport=60568 srcintf=\"port1\" srcintfrole=\"undefined\" dstip=2.3.4.5 dstport=53 dstintf=\"XXX\" dstintfrole=\"undefined\" srccountry=\"Reserved\" dstcountry=\"Japan\" sessionid=496025498 proto=17 action=\"accept\" policyid=398 policytype=\"policy\" poluuid=\"215103c0-f60e-51eb-74b6-a3eaf61ab72e\" service=\"udp-53\" trandisp=\"noop\" appid=16195 app=\"DNS\" appcat=\"Network.Service\" apprisk=\"elevated\" applist=\"XXX\" duration=180 sentbyte=0 rcvdbyte=0 sentpkt=0 rcvdpkt=0 vpntype=\"ipsecvpn\" utmaction=\"block\" countips=1 crscore=30 craction=8192"
+    "message": "timestamp=1742602531 devname=\"XXX\" devid=\"XXX\" vd=\"root\" date=2025-03-22 time=00:15:31 eventtime=1742613330828471629 tz=\"-0300\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" srcip=1.2.3.4 srcport=60568 srcintf=\"port1\" srcintfrole=\"undefined\" dstip=2.3.4.5 dstport=53 dstintf=\"XXX\" dstintfrole=\"undefined\" srccountry=\"Reserved\" dstcountry=\"Japan\" sessionid=496025498 proto=17 action=\"accept\" policyid=398 policytype=\"policy\" poluuid=\"poluuidvalue\" service=\"udp-53\" trandisp=\"noop\" appid=16195 app=\"DNS\" appcat=\"Network.Service\" apprisk=\"elevated\" applist=\"XXX\" duration=180 sentbyte=0 rcvdbyte=0 sentpkt=0 rcvdpkt=0 vpntype=\"ipsecvpn\" utmaction=\"block\" countips=1 crscore=30 craction=8192"
   },
   "expected": {
-    "message": "timestamp=1742602531 devname=\"XXX\" devid=\"XXX\" vd=\"root\" date=2025-03-22 time=00:15:31 eventtime=1742613330828471629 tz=\"-0300\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" srcip=1.2.3.4 srcport=60568 srcintf=\"port1\" srcintfrole=\"undefined\" dstip=2.3.4.5 dstport=53 dstintf=\"XXX\" dstintfrole=\"undefined\" srccountry=\"Reserved\" dstcountry=\"Japan\" sessionid=496025498 proto=17 action=\"accept\" policyid=398 policytype=\"policy\" poluuid=\"215103c0-f60e-51eb-74b6-a3eaf61ab72e\" service=\"udp-53\" trandisp=\"noop\" appid=16195 app=\"DNS\" appcat=\"Network.Service\" apprisk=\"elevated\" applist=\"XXX\" duration=180 sentbyte=0 rcvdbyte=0 sentpkt=0 rcvdpkt=0 vpntype=\"ipsecvpn\" utmaction=\"block\" countips=1 crscore=30 craction=8192",
+    "message": "timestamp=1742602531 devname=\"XXX\" devid=\"XXX\" vd=\"root\" date=2025-03-22 time=00:15:31 eventtime=1742613330828471629 tz=\"-0300\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" srcip=1.2.3.4 srcport=60568 srcintf=\"port1\" srcintfrole=\"undefined\" dstip=2.3.4.5 dstport=53 dstintf=\"XXX\" dstintfrole=\"undefined\" srccountry=\"Reserved\" dstcountry=\"Japan\" sessionid=496025498 proto=17 action=\"accept\" policyid=398 policytype=\"policy\" poluuid=\"poluuidvalue\" service=\"udp-53\" trandisp=\"noop\" appid=16195 app=\"DNS\" appcat=\"Network.Service\" apprisk=\"elevated\" applist=\"XXX\" duration=180 sentbyte=0 rcvdbyte=0 sentpkt=0 rcvdpkt=0 vpntype=\"ipsecvpn\" utmaction=\"block\" countips=1 crscore=30 craction=8192",
     "event": {
       "action": "accept",
       "category": "traffic",
@@ -33,7 +33,7 @@
           "type": "traffic"
         },
         "policyid": "398",
-        "poluuid": "215103c0-f60e-51eb-74b6-a3eaf61ab72e",
+        "poluuid": "poluuidvalue",
         "sessionid": "496025498",
         "utmaction": "block",
         "virtual_domain": "root"

--- a/Fortinet/fortigate/tests/traffic_forward.CSV.json
+++ b/Fortinet/fortigate/tests/traffic_forward.CSV.json
@@ -33,6 +33,8 @@
           "type": "traffic"
         },
         "policyid": "1",
+        "sessionid": "10006",
+        "utmaction": "allow",
         "virtual_domain": "root"
       }
     },

--- a/Fortinet/fortigate/tests/traffic_forward.STANDARD.json
+++ b/Fortinet/fortigate/tests/traffic_forward.STANDARD.json
@@ -33,6 +33,8 @@
           "type": "traffic"
         },
         "policyid": "1",
+        "sessionid": "10006",
+        "utmaction": "allow",
         "virtual_domain": "root"
       }
     },

--- a/Fortinet/fortigate/tests/traffic_forward.STANDARD_2.json
+++ b/Fortinet/fortigate/tests/traffic_forward.STANDARD_2.json
@@ -31,6 +31,8 @@
         },
         "policyid": "1",
         "poluuid": "1eb429d4-ff52-51ea-d119-d1db60e409a6",
+        "sessionid": "1224900441",
+        "utmaction": "allow",
         "virtual_domain": "PRX1-AA"
       }
     },

--- a/Fortinet/fortigate/tests/traffic_nat.STANDARD.json
+++ b/Fortinet/fortigate/tests/traffic_nat.STANDARD.json
@@ -36,6 +36,7 @@
         },
         "policyid": "207",
         "poluuid": "d77c53b2-a3c6-51e9-49b2-61c9e68c1f7e",
+        "sessionid": "578033623",
         "virtual_domain": "root"
       }
     },

--- a/Fortinet/fortigate/tests/traffic_nat_1.STANDARD.json
+++ b/Fortinet/fortigate/tests/traffic_nat_1.STANDARD.json
@@ -34,6 +34,7 @@
         },
         "policyid": "41",
         "poluuid": "703570eee-edfc-4565-8599-c6a75fd3e1e8",
+        "sessionid": "538959618",
         "virtual_domain": "root"
       }
     },

--- a/Fortinet/fortigate/tests/traffic_nat_2.STANDARD.json
+++ b/Fortinet/fortigate/tests/traffic_nat_2.STANDARD.json
@@ -34,6 +34,8 @@
         },
         "policyid": "12",
         "poluuid": "c1353c04-b6ee-51ea-9664-c8541f024774",
+        "sessionid": "157131884",
+        "utmaction": "allow",
         "virtual_domain": "root"
       }
     },

--- a/Fortinet/fortigate/tests/web_filter.json
+++ b/Fortinet/fortigate/tests/web_filter.json
@@ -42,6 +42,7 @@
         "method": "ip",
         "policyid": "32",
         "poluuid": "test-pol-uuid",
+        "sessionid": "1139869359",
         "virtual_domain": "root"
       }
     },

--- a/Fortinet/fortigate/tests/web_filter_1.json
+++ b/Fortinet/fortigate/tests/web_filter_1.json
@@ -42,6 +42,7 @@
         "method": "domain",
         "policyid": "106",
         "poluuid": "test-pol-uuid",
+        "sessionid": "958259665",
         "virtual_domain": "root"
       }
     },


### PR DESCRIPTION
Closes [515](https://github.com/SekoiaLab/integration/issues/515)

## Summary by Sourcery

Add support for sessionid and utmaction fields in Fortigate log parsing

New Features:
- Introduce new fields 'sessionid' and 'utmaction' for Fortigate log parsing

Enhancements:
- Update Fortigate log parsing configuration to extract and map sessionid and utmaction fields