### PR TITLE
SentinelOne: change the filter used to compute the process name

### DIFF
--- a/SentinelOne/sentinelone/ingest/parser.yml
+++ b/SentinelOne/sentinelone/ingest/parser.yml
@@ -615,7 +615,7 @@ stages:
           process.executable: "{{json_event.message.data.sourceprocessfilepath}}"
 
       - set:
-          process.name: "{{json_event.message.data.sourceprocessfilepath.replace('/', '\\\\').split('\\\\') | last}}"
+          process.name: "{{json_event.message.data.sourceprocessfilepath | basename}}"
         filter: "{{json_event.message.data.sourceprocessfilepath | length > 0}}"
 
       - set:


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Simplify the process name extraction by using a native basename filter instead of manual string manipulation