### PR TITLE
Citrix: apply linter

### DIFF
--- a/Citrix/citrix-adc/tests/test_cmd_executed_2.json
+++ b/Citrix/citrix-adc/tests/test_cmd_executed_2.json
@@ -18,10 +18,6 @@
     "process": {
       "command_line": "logout"
     },
-    "source": {
-        "address": "1.2.3.4",
-        "ip": "1.2.3.4"
-    },
     "related": {
       "ip": [
         "1.2.3.4"
@@ -29,6 +25,10 @@
       "user": [
         "john.doe"
       ]
+    },
+    "source": {
+      "address": "1.2.3.4",
+      "ip": "1.2.3.4"
     },
     "user": {
       "name": "john.doe"


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Cleaned up and formatted the test_cmd_executed_2.json file to comply with linter standards