### PR TITLE
Citrix: Adding support for bash logs

### DIFF
--- a/Citrix/citrix-adc/CHANGELOG.md
+++ b/Citrix/citrix-adc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.4] - 2025-04-16
+
+### Added
+
+- Support for bash logs
+
 ## [1.0.3] - 2024-02-05
 
 ### Added

--- a/Citrix/citrix-adc/_meta/fields.yml
+++ b/Citrix/citrix-adc/_meta/fields.yml
@@ -23,6 +23,11 @@ citrix.adc.message:
   name: citrix.adc.message
   type: keyword
 
+citrix.adc.pseudo_tty:
+  description: ''
+  name: citrix.adc.pseudo_tty
+  type: keyword
+
 citrix.adc.virtual_server.ip:
   description: ''
   name: citrix.adc.virtual_server.ip

--- a/Citrix/citrix-adc/_meta/smart-descriptions.json
+++ b/Citrix/citrix-adc/_meta/smart-descriptions.json
@@ -112,10 +112,10 @@
     ]
   },
   {
-    "value": "{user.name} executed a shell command on {process.working_directory}: {process.command_line}",
+    "value": "{user.name} executed a shell command on {citrix.adc.pseudo_tty}: {process.command_line}",
     "conditions": [
       { "field": "user.name" },
-      { "field": "process.working_directory" },
+      { "field": "citrix.adc.pseudo_tty" },
       { "field": "process.command_line" },
       { "field": "event.action", "value": "execute_shell_command" }
     ]

--- a/Citrix/citrix-adc/_meta/smart-descriptions.json
+++ b/Citrix/citrix-adc/_meta/smart-descriptions.json
@@ -112,6 +112,23 @@
     ]
   },
   {
+    "value": "{user.name} executed a shell command on {process.working_directory}: {process.command_line}",
+    "conditions": [
+      { "field": "user.name" },
+      { "field": "process.working_directory" },
+      { "field": "process.command_line" },
+      { "field": "event.action", "value": "execute_shell_command" }
+    ]
+  },
+  {
+    "value": "{user.name} executed a shell command: {process.command_line}",
+    "conditions": [
+      { "field": "user.name" },
+      { "field": "process.command_line" },
+      { "field": "event.action", "value": "execute_shell_command" }
+    ]
+  },
+  {
     "value": "{event.code} event from {source.ip} ended with {event.outcome}",
     "conditions": [
       { "field": "event.code" },

--- a/Citrix/citrix-adc/ingest/parser.yml
+++ b/Citrix/citrix-adc/ingest/parser.yml
@@ -288,5 +288,6 @@ stages:
           user.name: "{{ parse_audit_bash.message.source }}"
 
       - set:
-          process.working_directory: "{{ parse_audit_bash.message.path }}"
+          citrix.adc.pseudo_tty: "{{ parse_audit_bash.message.path }}"
+          process.interactive: "true"
         filter: "{{ parse_audit_bash.message.path != '(null)' }}"

--- a/Citrix/citrix-adc/ingest/parser.yml
+++ b/Citrix/citrix-adc/ingest/parser.yml
@@ -20,7 +20,7 @@ pipeline:
           DATE_TIME_YMD: "%{YEAR:year}/%{MONTHNUM:month}/%{MONTHDAY:day}:%{HOUR:hour}:%{MINUTE:minute}:%{SECOND:second}"
           DATE_TIME_MDY: "%{MONTHNUM:month}/%{MONTHDAY:day}/%{YEAR:year}:%{HOUR:hour}:%{MINUTE:minute}:%{SECOND:second}"
           TIMEZONE: "GMT"
-    filter: "{{ not original.message.startswith('CEF') }}"
+    filter: "{{ not original.message.startswith('CEF') and not 'shell_command=' in original.message }}"
 
   - name: parse_audit_timestamp
     filter: "{{ parse_audit_header.message.DATE_TIME_YMD != None }}"
@@ -102,6 +102,14 @@ pipeline:
         output_field: message
         pattern: '.*User %{USERNAME:user_name} -.*ADM_User (NONE|%{USERNAME:adm_user}).*Remote_ip %{IP:src_ip}.*Command "%{GREEDYDATA:command}".*Status \"%{DATA:status}\".*'
 
+  - name: parse_audit_bash
+    external:
+      name: grok.match
+      properties:
+        output_field: message
+        pattern: '%{DATA:source} on %{DATA:path} shell_command="%{GREEDYDATA:command}"'
+    filter: "{{ not original.message.startswith('CEF') and 'shell_command=' in original.message}}"
+
   - name: set_audit_log_fields
     filter: '{{not original.message.startswith("CEF") and parse_audit_header.message.type not in ["AAATM"]}}'
 
@@ -122,6 +130,9 @@ pipeline:
 
   - name: set_other_log_fields
     filter: "{{ parse_audit_header.message.type not in ['SSLVPN', 'SSLLOG', 'TCP', 'AAATM'] and parse_audit_header.message.message_type != 'CMD_EXECUTED'}}"
+
+  - name: set_bash_log_fields
+    filter: "{{ parse_audit_bash.get('message') != None }}"
 
 stages:
   set_cef_header_fields:
@@ -264,3 +275,18 @@ stages:
       - set:
           event.reason: "{{ parse_audit_sslvpn_logs.message.reason }}"
         filter: "{{ parse_audit_sslvpn_logs.message.get('reason') != None }}"
+
+  set_bash_log_fields:
+    actions:
+      - set:
+          event.action: "execute_shell_command"
+          event.category: ["configuration"]
+          event.dataset: "audit_cmd"
+          event.type: ["change"]
+          process.command_line: "{{ parse_audit_bash.message.command }}"
+          process.name: "bash"
+          user.name: "{{ parse_audit_bash.message.source }}"
+
+      - set:
+          process.working_directory: "{{ parse_audit_bash.message.path }}"
+        filter: "{{ parse_audit_bash.message.path != '(null)' }}"

--- a/Citrix/citrix-adc/tests/test_bash_log_1.json
+++ b/Citrix/citrix-adc/tests/test_bash_log_1.json
@@ -1,0 +1,36 @@
+{
+  "input": {
+    "message": "root on (null) shell_command=\"for pid in $PROF_PIDS; do kill -0 $pid > /dev/null 2>&1; if [ $? -ne 0 ]; then kill -9 $PROF_PIDS > /dev/null 2>&1; return; fi; done\"",
+    "sekoiaio": {
+      "intake": {
+        "dialect": "Citrix NetScaler / ADC",
+        "dialect_uuid": "02a74ceb-a9b0-467c-97d1-588319e39d71"
+      }
+    }
+  },
+  "expected": {
+    "message": "root on (null) shell_command=\"for pid in $PROF_PIDS; do kill -0 $pid > /dev/null 2>&1; if [ $? -ne 0 ]; then kill -9 $PROF_PIDS > /dev/null 2>&1; return; fi; done\"",
+    "event": {
+      "action": "execute_shell_command",
+      "category": [
+        "configuration"
+      ],
+      "dataset": "audit_cmd",
+      "type": [
+        "change"
+      ]
+    },
+    "process": {
+      "command_line": "for pid in $PROF_PIDS; do kill -0 $pid > /dev/null 2>&1; if [ $? -ne 0 ]; then kill -9 $PROF_PIDS > /dev/null 2>&1; return; fi; done",
+      "name": "bash"
+    },
+    "related": {
+      "user": [
+        "root"
+      ]
+    },
+    "user": {
+      "name": "root"
+    }
+  }
+}

--- a/Citrix/citrix-adc/tests/test_bash_log_2.json
+++ b/Citrix/citrix-adc/tests/test_bash_log_2.json
@@ -20,10 +20,15 @@
         "change"
       ]
     },
+    "citrix": {
+      "adc": {
+        "pseudo_tty": "/dev/pts/0"
+      }
+    },
     "process": {
       "command_line": "PATH=/netscaler:/bin:/sbin:/usr/bin:/usr/sbin:/usr/libexec:/usr/local/bin:/usr/local/sbin:.",
-      "name": "bash",
-      "working_directory": "/dev/pts/0"
+      "interactive": true,
+      "name": "bash"
     },
     "related": {
       "user": [

--- a/Citrix/citrix-adc/tests/test_bash_log_2.json
+++ b/Citrix/citrix-adc/tests/test_bash_log_2.json
@@ -1,0 +1,37 @@
+{
+  "input": {
+    "message": "root on /dev/pts/0 shell_command=\"PATH=/netscaler:/bin:/sbin:/usr/bin:/usr/sbin:/usr/libexec:/usr/local/bin:/usr/local/sbin:.\"",
+    "sekoiaio": {
+      "intake": {
+        "dialect": "Citrix NetScaler / ADC",
+        "dialect_uuid": "02a74ceb-a9b0-467c-97d1-588319e39d71"
+      }
+    }
+  },
+  "expected": {
+    "message": "root on /dev/pts/0 shell_command=\"PATH=/netscaler:/bin:/sbin:/usr/bin:/usr/sbin:/usr/libexec:/usr/local/bin:/usr/local/sbin:.\"",
+    "event": {
+      "action": "execute_shell_command",
+      "category": [
+        "configuration"
+      ],
+      "dataset": "audit_cmd",
+      "type": [
+        "change"
+      ]
+    },
+    "process": {
+      "command_line": "PATH=/netscaler:/bin:/sbin:/usr/bin:/usr/sbin:/usr/libexec:/usr/local/bin:/usr/local/sbin:.",
+      "name": "bash",
+      "working_directory": "/dev/pts/0"
+    },
+    "related": {
+      "user": [
+        "root"
+      ]
+    },
+    "user": {
+      "name": "root"
+    }
+  }
+}


### PR DESCRIPTION
Fix related to [this issue](https://github.com/SekoiaLab/integration/issues/560)

## Summary by Sourcery

Add support for parsing Citrix ADC bash log entries in the ingest parser

New Features:
- Implement parsing for bash shell command logs in Citrix ADC log ingestion

Enhancements:
- Extend log parsing pipeline to handle bash command logs with additional filtering and extraction

Tests:
- Add test JSON files for bash log parsing scenarios

Chores:
- Update CHANGELOG.md to reflect new bash log support