### PR TITLE
Adding event.outcome to the Microsoft 365 Defender parser

### DIFF
--- a/Microsoft/microsoft-365-defender/ingest/parser.yml
+++ b/Microsoft/microsoft-365-defender/ingest/parser.yml
@@ -493,6 +493,14 @@ stages:
       - set:
           event.dataset: "device_logon_events"
           event.category: ["authentication"]
+          event.outcome: >
+            {%- if json_event.message.properties.ActionType == "LogonSuccess" -%}
+              success
+            {%- elif json_event.message.properties.ActionType == "LogonFailed" -%}
+              failure
+            {%- else -%}
+              unknown
+            {%- endif -%}
           action.properties.RemoteIPType: "{{json_event.message.properties.RemoteIPType}}"
           action.properties.IsLocalAdmin: "{{json_event.message.properties.IsLocalAdmin}}"
   set_device_network_events_fields:
@@ -613,6 +621,12 @@ stages:
       - set:
           event.dataset: "identity_logon_events"
           event.category: ["authentication"]
+          event.outcome: >
+            {%- if json_event.message.properties.ActionType == "LogonSuccess" -%}
+              success
+            {%- else -%}
+              failure
+            {%- endif -%}
   set_identity_query_events_fields:
     actions:
       - set:

--- a/Microsoft/microsoft-365-defender/tests/test_device_logon_events.json
+++ b/Microsoft/microsoft-365-defender/tests/test_device_logon_events.json
@@ -9,6 +9,7 @@
         "authentication"
       ],
       "dataset": "device_logon_events",
+      "outcome": "success",
       "type": [
         "info"
       ]

--- a/Microsoft/microsoft-365-defender/tests/test_device_logon_failed.json
+++ b/Microsoft/microsoft-365-defender/tests/test_device_logon_failed.json
@@ -15,6 +15,7 @@
         "authentication"
       ],
       "dataset": "device_logon_events",
+      "outcome": "failure",
       "type": [
         "info"
       ]

--- a/Microsoft/microsoft-365-defender/tests/test_identity_logon.json
+++ b/Microsoft/microsoft-365-defender/tests/test_identity_logon.json
@@ -9,6 +9,7 @@
         "authentication"
       ],
       "dataset": "identity_logon_events",
+      "outcome": "failure",
       "type": [
         "info"
       ]

--- a/Microsoft/microsoft-365-defender/tests/test_identity_logon_2.json
+++ b/Microsoft/microsoft-365-defender/tests/test_identity_logon_2.json
@@ -9,6 +9,7 @@
         "authentication"
       ],
       "dataset": "identity_logon_events",
+      "outcome": "success",
       "type": [
         "info"
       ]

--- a/Microsoft/microsoft-365-defender/tests/test_identity_logon_3.json
+++ b/Microsoft/microsoft-365-defender/tests/test_identity_logon_3.json
@@ -9,6 +9,7 @@
         "authentication"
       ],
       "dataset": "identity_logon_events",
+      "outcome": "success",
       "type": [
         "info"
       ]


### PR DESCRIPTION
Improvement related to [this issue](https://github.com/SekoiaLab/integration/issues/593)

## Summary by Sourcery

Add event outcome mapping for Microsoft 365 Defender logon events

New Features:
- Add logic to map LogonSuccess and LogonFailed to success and failure event outcomes

Enhancements:
- Implement event.outcome determination for device and identity logon events based on ActionType