### PR TITLE
Fix: Fortinet forwardedfor (618)

### DIFF
--- a/Fortinet/fortigate/ingest/parser.yml
+++ b/Fortinet/fortigate/ingest/parser.yml
@@ -1,5 +1,5 @@
 name: fortinet-fortigate
-ignored_values: ["N/A"]
+ignored_values: [ "N/A" ]
 pipeline:
   # If event is formatted as CEF
   - name: parsed_event
@@ -243,8 +243,20 @@ stages:
           fortinet.fortigate.poluuid: "{{parsed_event.message.poluuid}}"
           fortinet.fortigate.sessionid: "{{parsed_event.message.sessionid}}"
           fortinet.fortigate.utmaction: "{{parsed_event.message.utmaction}}"
-          network.forwarded_ip: "{{parsed_event.message.forwardedfor}}"
           group.name: "{{parsed_event.message.group or parsed_event.message.FTNTFGTgroup}}"
+
+      - set:
+          network.forwarded_ip: "{{parsed_event.message.forwardedfor}}"
+        filter: "{{ ',' not in parsed_event.message.get('forwardedfor', '' )}}"
+
+      - set:
+          network.forwarded_ip: > 
+            [
+              {% for ip in parsed_event.message.forwardedfor.split(',') %}
+                "{{ip}}",
+              {% endfor %}
+            ]
+        filter: "{{ ',' in parsed_event.message.get('forwardedfor', '' )}}"
 
       - set:
           event.duration: "{{(parsed_event.message.duration | int) * 1_000_000_000}}" # nanoseconds

--- a/Fortinet/fortigate/ingest/parser.yml
+++ b/Fortinet/fortigate/ingest/parser.yml
@@ -1,5 +1,5 @@
 name: fortinet-fortigate
-ignored_values: [ "N/A" ]
+ignored_values: ["N/A"]
 pipeline:
   # If event is formatted as CEF
   - name: parsed_event
@@ -250,7 +250,7 @@ stages:
         filter: "{{ ',' not in parsed_event.message.get('forwardedfor', '' )}}"
 
       - set:
-          network.forwarded_ip: > 
+          network.forwarded_ip: >
             [
               {% for ip in parsed_event.message.forwardedfor.split(',') %}
                 "{{ip}}",

--- a/Fortinet/fortigate/tests/hostname.STANDARD.1.json
+++ b/Fortinet/fortigate/tests/hostname.STANDARD.1.json
@@ -1,0 +1,98 @@
+{
+  "input": {
+    "message": "timestamp=1746183115 devname=\"devName1\" devid=\"devId\" vd=\"root\" date=2025-05-02 time=10:51:55 eventtime=1746175915421843994 tz=\"+0200\" logid=\"1000000000\" type=\"utm\" subtype=\"app-ctrl\" eventtype=\"signature\" level=\"information\" appid=15893 srcip=1.2.3.4 srccountry=\"Spain\" dstip=3.4.5.6 dstcountry=\"Reserved\" srcport=39972 dstport=80 srcintf=\"port2\" srcintfrole=\"wan\" dstintf=\"port3\" dstintfrole=\"dmz\" proto=6 service=\"HTTP\" direction=\"outgoing\" policyid=120 poluuid=\"5187b416-87fa-51ec-c830-268b6371a3ac\" policytype=\"policy\" sessionid=11111111 applist=\"block-high-risk\" action=\"pass\" appcat=\"Web.Client\" app=\"HTTP.BROWSER\" hostname=\"test.test\" incidentserialno=10101 url=\"/test/version_test_v2.php\" httpmethod=\"GET\" msg=\"Web.Client: HTTP.BROWSER\" apprisk=\"medium\" forwardedfor=\"5.6.7.8,6.7.8.9\""
+  },
+  "expected": {
+    "message": "timestamp=1746183115 devname=\"devName1\" devid=\"devId\" vd=\"root\" date=2025-05-02 time=10:51:55 eventtime=1746175915421843994 tz=\"+0200\" logid=\"1000000000\" type=\"utm\" subtype=\"app-ctrl\" eventtype=\"signature\" level=\"information\" appid=15893 srcip=1.2.3.4 srccountry=\"Spain\" dstip=3.4.5.6 dstcountry=\"Reserved\" srcport=39972 dstport=80 srcintf=\"port2\" srcintfrole=\"wan\" dstintf=\"port3\" dstintfrole=\"dmz\" proto=6 service=\"HTTP\" direction=\"outgoing\" policyid=120 poluuid=\"5187b416-87fa-51ec-c830-268b6371a3ac\" policytype=\"policy\" sessionid=11111111 applist=\"block-high-risk\" action=\"pass\" appcat=\"Web.Client\" app=\"HTTP.BROWSER\" hostname=\"test.test\" incidentserialno=10101 url=\"/test/version_test_v2.php\" httpmethod=\"GET\" msg=\"Web.Client: HTTP.BROWSER\" apprisk=\"medium\" forwardedfor=\"5.6.7.8,6.7.8.9\"",
+    "event": {
+      "action": "pass",
+      "category": "utm",
+      "code": "1000000000",
+      "dataset": "utm:app-ctrl",
+      "outcome": "success",
+      "reason": "Web.Client: HTTP.BROWSER",
+      "timezone": "+0200"
+    },
+    "@timestamp": "2025-05-02T08:51:55.421844Z",
+    "action": {
+      "name": "pass",
+      "outcome": "success",
+      "outcome_reason": "Web.Client: HTTP.BROWSER",
+      "target": "network-traffic",
+      "type": "app-ctrl"
+    },
+    "destination": {
+      "address": "3.4.5.6",
+      "domain": "test.test",
+      "ip": "3.4.5.6",
+      "port": 80
+    },
+    "file": {
+      "name": "version_test_v2.php"
+    },
+    "fortinet": {
+      "fortigate": {
+        "apprisk": "medium",
+        "event": {
+          "type": "utm"
+        },
+        "policyid": "120",
+        "poluuid": "5187b416-87fa-51ec-c830-268b6371a3ac",
+        "sessionid": "11111111",
+        "virtual_domain": "root"
+      }
+    },
+    "log": {
+      "hostname": "devName1",
+      "level": "information"
+    },
+    "network": {
+      "application": "HTTP.BROWSER",
+      "direction": "outbound",
+      "forwarded_ip": [
+        "5.6.7.8",
+        "6.7.8.9"
+      ],
+      "protocol": "http",
+      "transport": "tcp"
+    },
+    "observer": {
+      "egress": {
+        "interface": {
+          "name": "port3"
+        }
+      },
+      "hostname": "devName1",
+      "ingress": {
+        "interface": {
+          "name": "port2"
+        }
+      },
+      "serial_number": "devId"
+    },
+    "related": {
+      "hosts": [
+        "devName1",
+        "test.test"
+      ],
+      "ip": [
+        "1.2.3.4",
+        "3.4.5.6"
+      ]
+    },
+    "rule": {
+      "apprisk": "medium",
+      "category": "Web.Client",
+      "ruleset": "block-high-risk"
+    },
+    "source": {
+      "address": "1.2.3.4",
+      "ip": "1.2.3.4",
+      "port": 39972
+    },
+    "url": {
+      "original": "/test/version_test_v2.php",
+      "path": "/test/version_test_v2.php"
+    }
+  }
+}


### PR DESCRIPTION
Closes [618](https://github.com/SekoiaLab/integration/issues/618)

## Summary by Sourcery

Improve handling of forwarded IP addresses in Fortinet Fortigate parser

Bug Fixes:
- Fix parsing of forwarded IP addresses to support both single and multiple IP scenarios

Enhancements:
- Add conditional parsing for forwarded IP addresses with single and comma-separated formats