### PR TITLE
Clavister : fix on event.outcome + improvement of event.reason

### DIFF
--- a/Clavister/clavister-ngfw/ingest/parser.yml
+++ b/Clavister/clavister-ngfw/ingest/parser.yml
@@ -7,6 +7,12 @@ pipeline:
         reversed: false
         groups: true
 
+  - name: parsed_reason
+    external:
+      name: grok.match
+      properties:
+        pattern: "%{GREEDYDATA} (\\[)?message=%{DATA:event_reason}( \\[| \\]| %{WORD}=)%{GREEDYDATA}"
+
   - name: set_common_fields
   - name: set_category_and_type
   - name: set_source_fields # like source.ip etc
@@ -19,7 +25,7 @@ stages:
           observer.vendor: "Clavister"
           observer.product: "NGFW"
           event.code: "{{parsed_event.message.id}}"
-          event.reason: "{{parsed_event.message.message}}"
+          event.reason: "{{parsed_reason.message.event_reason}}"
           rule.name: "{{parsed_event.message.rules.rule}}"
           user.name: "{{parsed_event.message.username or parsed_event.message.user or parsed_event.message.userauth.username}}"
           server.ip: "{{parsed_event.message.server}}"
@@ -293,21 +299,25 @@ stages:
       - set:
           event.category: ["authentication"]
           event.type: ["start"]
+          event.outcome: "success"
         filter: '{{parsed_event.message.get("event") == "user_login"}}'
 
       - set:
           event.category: ["authentication"]
           event.type: ["end"]
+          event.outcome: "success"
         filter: '{{parsed_event.message.get("event") == "user_logout"}}'
 
       - set:
           event.category: ["authentication"]
           event.type: ["end"]
+          event.outcome: "success"
         filter: '{{parsed_event.message.get("event") == "user_timeout"}}'
 
       - set:
           event.category: ["authentication"]
           event.type: ["end"]
+          event.outcome: "success"
         filter: '{{parsed_event.message.get("event") == "radius_auth_timeout"}}'
 
       - set:
@@ -333,6 +343,7 @@ stages:
       - set:
           event.category: ["authentication"]
           event.type: ["end"]
+          event.outcome: "success"
         filter: '{{parsed_event.message.get("event") == "user_disconnected"}}'
 
       - set:

--- a/Clavister/clavister-ngfw/tests/alg_session_closed.json
+++ b/Clavister/clavister-ngfw/tests/alg_session_closed.json
@@ -9,7 +9,7 @@
         "session"
       ],
       "code": "200002",
-      "reason": "ALG",
+      "reason": "ALG session closed",
       "type": [
         "end"
       ]

--- a/Clavister/clavister-ngfw/tests/radius_auth_timeout.json
+++ b/Clavister/clavister-ngfw/tests/radius_auth_timeout.json
@@ -9,7 +9,8 @@
         "authentication"
       ],
       "code": "3700105",
-      "reason": "Timeout",
+      "outcome": "success",
+      "reason": "Timeout during RADIUS user authentication, contact with RADIUS server not established",
       "type": [
         "end"
       ]

--- a/Clavister/clavister-ngfw/tests/user_disconnected.json
+++ b/Clavister/clavister-ngfw/tests/user_disconnected.json
@@ -9,6 +9,7 @@
         "authentication"
       ],
       "code": "9000011",
+      "outcome": "success",
       "reason": "User JDOE is forcibly disconnected. Client: 1.2.3.4",
       "type": [
         "end"

--- a/Clavister/clavister-ngfw/tests/user_login.json
+++ b/Clavister/clavister-ngfw/tests/user_login.json
@@ -9,6 +9,7 @@
         "authentication"
       ],
       "code": "3700102",
+      "outcome": "success",
       "reason": "User logged in. Idle timeout: 1800, Session timeout: 0",
       "type": [
         "start"

--- a/Clavister/clavister-ngfw/tests/user_logout.json
+++ b/Clavister/clavister-ngfw/tests/user_logout.json
@@ -9,7 +9,8 @@
         "authentication"
       ],
       "code": "3700110",
-      "reason": "User",
+      "outcome": "success",
+      "reason": "User logged out",
       "type": [
         "end"
       ]

--- a/Clavister/clavister-ngfw/tests/user_timeout.json
+++ b/Clavister/clavister-ngfw/tests/user_timeout.json
@@ -9,7 +9,8 @@
         "authentication"
       ],
       "code": "3700020",
-      "reason": "User",
+      "outcome": "success",
+      "reason": "User timeout expired, user is automatically logged out",
       "type": [
         "end"
       ]


### PR DESCRIPTION
Fix related to [this issue](https://github.com/SekoiaLab/integration/issues/582)

I also created a Grok to improve the display of `event.reason`, as the kv groups didn't seems to take all the reason into account (mostly displayed only the first term)