### PR TITLE
Winlogbeat: remove action.properties.Task

### DIFF
--- a/Beats/winlogbeat/_meta/fields.yml
+++ b/Beats/winlogbeat/_meta/fields.yml
@@ -531,11 +531,6 @@ action.properties.TargetUserSid:
     type: user-account
   type: keyword
 
-action.properties.Task:
-  description: ''
-  name: action.properties.Task
-  type: keyword
-
 action.properties.TerminalSessionId:
   description: ''
   name: action.properties.TerminalSessionId

--- a/Beats/winlogbeat/ingest/parser.yml
+++ b/Beats/winlogbeat/ingest/parser.yml
@@ -133,7 +133,6 @@ stages:
           user.target.domain: "{{json.event.winlog.event_data.TargetUserDomain}}"
 
       - set:
-          action.properties.Task: "{{json.event.winlog.task}}"
           action.properties.OpcodeValue: "{{json.event.winlog.opcode}}"
           action.properties.Keywords: "{{json.event.winlog.keywords}}"
           action.properties.ProviderGUID: "{{json.event.winlog.provider_guid}}"


### PR DESCRIPTION
Remove this field as it conflict with [Windows's action.property.Task field](https://github.com/SEKOIA-IO/intake-formats/blob/main/Windows/windows/_meta/fields.yml#L1161-L1164)