### PR TITLE
O365 - parse ItemType

### DIFF
--- a/Office 365/o365/ingest/parser.yml
+++ b/Office 365/o365/ingest/parser.yml
@@ -614,6 +614,7 @@ stages:
                 {% if json_event.message.get("UserAgent") != None %}"UserAgent": "{{json_event.message.UserAgent}}",{% endif %}
               }
             ]
+          office365.audit.item_type: "{{json_event.message.ItemType}}"
 
   parse_team:
     actions:

--- a/Office 365/o365/tests/external_user.json
+++ b/Office 365/o365/tests/external_user.json
@@ -38,6 +38,7 @@
     },
     "office365": {
       "audit": {
+        "item_type": "File",
         "object_id": "https://example.com/1.zip"
       },
       "context": {

--- a/Office 365/o365/tests/file_malware_detected.json
+++ b/Office 365/o365/tests/file_malware_detected.json
@@ -37,6 +37,7 @@
     },
     "office365": {
       "audit": {
+        "item_type": "File",
         "object_id": "https://example.com/files/AdobePhotoshop20-cs_CZ_x64.zip"
       },
       "context": {

--- a/Office 365/o365/tests/file_previewed.json
+++ b/Office 365/o365/tests/file_previewed.json
@@ -37,6 +37,7 @@
     },
     "office365": {
       "audit": {
+        "item_type": "File",
         "object_id": "https://company-my.sharepoint.com/personal/jane_doe_company_onmicrosoft_com/Documents/MyDocument.docx"
       },
       "record_type": 6,

--- a/Office 365/o365/tests/file_size.json
+++ b/Office 365/o365/tests/file_size.json
@@ -38,6 +38,7 @@
     },
     "office365": {
       "audit": {
+        "item_type": "File",
         "object_id": "https://site.file.name.xlsx"
       },
       "context": {

--- a/Office 365/o365/tests/file_sync_download_full.json
+++ b/Office 365/o365/tests/file_sync_download_full.json
@@ -37,6 +37,7 @@
     },
     "office365": {
       "audit": {
+        "item_type": "File",
         "object_id": "https://company.sharepoint.com/sites/shared/public/assets/website/logo.png"
       },
       "context": {

--- a/Office 365/o365/tests/source_log.json
+++ b/Office 365/o365/tests/source_log.json
@@ -37,6 +37,7 @@
     },
     "office365": {
       "audit": {
+        "item_type": "File",
         "object_id": "xxxxx.xlsx"
       },
       "context": {

--- a/Office 365/o365/tests/targetusername.json
+++ b/Office 365/o365/tests/targetusername.json
@@ -43,6 +43,7 @@
     },
     "office365": {
       "audit": {
+        "item_type": "File",
         "object_id": "https://compagny-my.sharepoint.com/personal/docname.pdf"
       },
       "context": {


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/624

## Summary by Sourcery

Add support for parsing the ItemType field in Office 365 audit events and update tests to cover this new mapping.

New Features:
- Extract the ItemType field from audit events and map it to office365.audit.item_type

Tests:
- Update parser test fixtures to include and validate the new ItemType field