### PR TITLE
BeyondTrust PRA - parse more fields

### DIFF
--- a/BeyondTrust/beyondtrust-pra/_meta/fields.yml
+++ b/BeyondTrust/beyondtrust-pra/_meta/fields.yml
@@ -1,3 +1,18 @@
+beyondtrust.pra.approval_applies_to:
+  description: ''
+  name: beyondtrust.pra.approval_applies_to
+  type: keyword
+
+beyondtrust.pra.approver_comments:
+  description: ''
+  name: beyondtrust.pra.approver_comments
+  type: keyword
+
+beyondtrust.pra.approver_name:
+  description: ''
+  name: beyondtrust.pra.approver_name
+  type: keyword
+
 beyondtrust.pra.destination_name:
   description: ''
   name: beyondtrust.pra.destination_name
@@ -13,6 +28,21 @@ beyondtrust.pra.jump_group.type:
   name: beyondtrust.pra.jump_group.type
   type: keyword
 
+beyondtrust.pra.jump_item_name:
+  description: ''
+  name: beyondtrust.pra.jump_item_name
+  type: keyword
+
+beyondtrust.pra.jump_item_type:
+  description: ''
+  name: beyondtrust.pra.jump_item_type
+  type: keyword
+
+beyondtrust.pra.jump_policy_name:
+  description: ''
+  name: beyondtrust.pra.jump_policy_name
+  type: keyword
+
 beyondtrust.pra.owner:
   description: ''
   name: beyondtrust.pra.owner
@@ -21,6 +51,36 @@ beyondtrust.pra.owner:
 beyondtrust.pra.performed_by.type:
   description: ''
   name: beyondtrust.pra.performed_by.type
+  type: keyword
+
+beyondtrust.pra.push_agent_name:
+  description: ''
+  name: beyondtrust.pra.push_agent_name
+  type: keyword
+
+beyondtrust.pra.request.duration:
+  description: ''
+  name: beyondtrust.pra.request.duration
+  type: keyword
+
+beyondtrust.pra.request.id:
+  description: ''
+  name: beyondtrust.pra.request.id
+  type: keyword
+
+beyondtrust.pra.request.start_time:
+  description: ''
+  name: beyondtrust.pra.request.start_time
+  type: keyword
+
+beyondtrust.pra.request_approver:
+  description: ''
+  name: beyondtrust.pra.request_approver
+  type: keyword
+
+beyondtrust.pra.request_reason:
+  description: ''
+  name: beyondtrust.pra.request_reason
   type: keyword
 
 beyondtrust.pra.session_id:

--- a/BeyondTrust/beyondtrust-pra/_meta/fields.yml
+++ b/BeyondTrust/beyondtrust-pra/_meta/fields.yml
@@ -58,11 +58,6 @@ beyondtrust.pra.push_agent_name:
   name: beyondtrust.pra.push_agent_name
   type: keyword
 
-beyondtrust.pra.request.duration:
-  description: ''
-  name: beyondtrust.pra.request.duration
-  type: keyword
-
 beyondtrust.pra.request.id:
   description: ''
   name: beyondtrust.pra.request.id

--- a/BeyondTrust/beyondtrust-pra/_meta/smart-descriptions.json
+++ b/BeyondTrust/beyondtrust-pra/_meta/smart-descriptions.json
@@ -103,6 +103,17 @@
     ]
   },
   {
+    "value": "{beyondtrust.pra.session_id}: {event.code} {process.command_line}",
+    "conditions": [
+      {
+        "field": "event.code"
+      },
+      {
+        "field": "process.command_line"
+      }
+    ]
+  },
+  {
     "value": "{beyondtrust.pra.session_id}: {event.code}",
     "conditions": [
       {

--- a/BeyondTrust/beyondtrust-pra/ingest/parser.yml
+++ b/BeyondTrust/beyondtrust-pra/ingest/parser.yml
@@ -113,7 +113,6 @@ stages:
           beyondtrust.pra.push_agent_name: "{{parsed_event.message.data.push_agent_name}}"
           beyondtrust.pra.jump_item_name: "{{parsed_event.message.data.jump_item_name}}"
 
-          beyondtrust.pra.request.duration: "{{parsed_event.message.data.request_duration}}" # should be event.duration?
           beyondtrust.pra.request.start_time: "{{parsed_event.message.data.request_start_time | to_rfc3339}}" # should be parsed to RFC3339? but %Z wouldn't recognize `C
 
           beyondtrust.pra.request_reason: "{{parsed_event.message.data.request_reason}}"
@@ -129,6 +128,14 @@ stages:
           source.user.email: "{{parse_requesting_user.message.requesting_email}}"
           source.user.name: "{{parse_requesting_user.message.requesting_username}}"
         filter: "{{parse_requesting_user.get('message') != None}}"
+
+      - set:
+          event.duration: "{{ parsed_event.message.data.request_duration.split(maxsplit=1) | first | int * 60 * 60 * 1_000_000}}"
+        filter: "{{ parsed_event.message.data.request_duration != null and 'hour(s)' in parsed_event.message.data.request_duration}}"
+
+      - set:
+          event.duration: "{{ parsed_event.message.data.request_duration.split(maxsplit=1) | first | int * 24 * 60 * 60 * 1_000_000}}"
+        filter: "{{ parsed_event.message.data.request_duration != null and 'day(s)' in parsed_event.message.data.request_duration}}"
 
   set_category_and_type:
     actions:

--- a/BeyondTrust/beyondtrust-pra/ingest/parser.yml
+++ b/BeyondTrust/beyondtrust-pra/ingest/parser.yml
@@ -113,7 +113,7 @@ stages:
           beyondtrust.pra.push_agent_name: "{{parsed_event.message.data.push_agent_name}}"
           beyondtrust.pra.jump_item_name: "{{parsed_event.message.data.jump_item_name}}"
 
-          beyondtrust.pra.request.start_time: "{{parsed_event.message.data.request_start_time | to_rfc3339}}" # should be parsed to RFC3339? but %Z wouldn't recognize `C
+          beyondtrust.pra.request.start_time: "{{parsed_event.message.data.request_start_time | to_rfc3339}}"
 
           beyondtrust.pra.request_reason: "{{parsed_event.message.data.request_reason}}"
           beyondtrust.pra.approver_name: "{{parsed_event.message.data.approver_name}}"
@@ -128,6 +128,14 @@ stages:
           source.user.email: "{{parse_requesting_user.message.requesting_email}}"
           source.user.name: "{{parse_requesting_user.message.requesting_username}}"
         filter: "{{parse_requesting_user.get('message') != None}}"
+
+      - set:
+          event.duration: "{{ parsed_event.message.data.request_duration.split(maxsplit=1) | first | int * 1_000_000}}"
+        filter: "{{ parsed_event.message.data.request_duration != null and 'second(s)' in parsed_event.message.data.request_duration}}"
+
+      - set:
+          event.duration: "{{ parsed_event.message.data.request_duration.split(maxsplit=1) | first | int * 60 * 1_000_000}}"
+        filter: "{{ parsed_event.message.data.request_duration != null and 'minute(s)' in parsed_event.message.data.request_duration}}"
 
       - set:
           event.duration: "{{ parsed_event.message.data.request_duration.split(maxsplit=1) | first | int * 60 * 60 * 1_000_000}}"

--- a/BeyondTrust/beyondtrust-pra/ingest/parser.yml
+++ b/BeyondTrust/beyondtrust-pra/ingest/parser.yml
@@ -78,7 +78,6 @@ stages:
           user.target.id: "{{parsed_event.message.data.user_id}}"
           user.target.name: "{{parsed_event.message.data.username}}"
           process.executable: "{{parsed_event.message.data.exeName}}"
-          process.command_line: "{{parsed_event.message.data.text}}"
           process.title: "{{parsed_event.message.data.windowName}}"
           event.action: "{{parsed_event.message.data.action_name}}"
           url.original: "{{parsed_event.message.data.download_url or parsed_event.message.data.view_url}}"
@@ -86,6 +85,10 @@ stages:
           file.name: "{{parsed_event.message.data.filename}}"
           registry.key: "{{parsed_event.message.data.key_name}}"
           registry.value: "{{parsed_event.message.data.value_name}}"
+
+      - set:
+          process.command_line: "{{parsed_event.message.data.text}}"
+        filter: "{{parsed_event.message.event_type == 'Remote Shell Event'}}"
 
       - set:
           registry.data.type: "REG_SZ"

--- a/BeyondTrust/beyondtrust-pra/ingest/parser.yml
+++ b/BeyondTrust/beyondtrust-pra/ingest/parser.yml
@@ -17,6 +17,15 @@ pipeline:
         output_field: message
         pattern: '\[?%{IP:public_ip}\]?:%{INT:public_port}'
 
+  - name: parse_requesting_user
+    filter: "{{parsed_event.message.get('data', {}).get('requesting_user') != None}}"
+    external:
+      name: grok.match
+      properties:
+        input_field: "{{parsed_event.message.data.requesting_user}}"
+        output_field: message
+        pattern: '%{DATA:requesting_username} \(%{DATA:requesting_email}\)'
+
   - name: set_ecs_fields
   - name: set_category_and_type
 
@@ -69,6 +78,7 @@ stages:
           user.target.id: "{{parsed_event.message.data.user_id}}"
           user.target.name: "{{parsed_event.message.data.username}}"
           process.executable: "{{parsed_event.message.data.exeName}}"
+          process.command_line: "{{parsed_event.message.data.text}}"
           process.title: "{{parsed_event.message.data.windowName}}"
           event.action: "{{parsed_event.message.data.action_name}}"
           url.original: "{{parsed_event.message.data.download_url or parsed_event.message.data.view_url}}"
@@ -90,6 +100,32 @@ stages:
           beyondtrust.pra.owner: "{{parsed_event.message.data.owner}}"
           beyondtrust.pra.destination_type: "{{parsed_event.message.destination.type}}"
           beyondtrust.pra.destination_name: "{{parsed_event.message.destination.name}}"
+
+      - set:
+          beyondtrust.pra.request.id: "{{parsed_event.message.data.request_id}}"
+
+          beyondtrust.pra.jump_policy_name: "{{parsed_event.message.data.jump_policy_name}}"
+          beyondtrust.pra.jump_item_type: "{{parsed_event.message.data.jump_item_type}}"
+
+          beyondtrust.pra.push_agent_name: "{{parsed_event.message.data.push_agent_name}}"
+          beyondtrust.pra.jump_item_name: "{{parsed_event.message.data.jump_item_name}}"
+
+          beyondtrust.pra.request.duration: "{{parsed_event.message.data.request_duration}}" # should be event.duration?
+          beyondtrust.pra.request.start_time: "{{parsed_event.message.data.request_start_time}}" # should be parsed to RFC3339? but %Z wouldn't recognize `C
+
+          beyondtrust.pra.request_reason: "{{parsed_event.message.data.request_reason}}"
+          beyondtrust.pra.approver_name: "{{parsed_event.message.data.approver_name}}"
+          beyondtrust.pra.request_approver: "{{parsed_event.message.data.request_approver}}"
+
+          beyondtrust.pra.approval_applies_to: "{{parsed_event.message.data.approval_applies_to}}"
+          beyondtrust.pra.approver_comments: "{{parsed_event.message.data.approver_comments}}"
+
+          source.user.id: "{{parsed_event.message.data.requesting_user_id}}"
+
+      - set:
+          source.user.email: "{{parse_requesting_user.message.requesting_email}}"
+          source.user.name: "{{parse_requesting_user.message.requesting_username}}"
+        filter: "{{parse_requesting_user.get('message') != None}}"
 
   set_category_and_type:
     actions:

--- a/BeyondTrust/beyondtrust-pra/ingest/parser.yml
+++ b/BeyondTrust/beyondtrust-pra/ingest/parser.yml
@@ -114,7 +114,7 @@ stages:
           beyondtrust.pra.jump_item_name: "{{parsed_event.message.data.jump_item_name}}"
 
           beyondtrust.pra.request.duration: "{{parsed_event.message.data.request_duration}}" # should be event.duration?
-          beyondtrust.pra.request.start_time: "{{parsed_event.message.data.request_start_time}}" # should be parsed to RFC3339? but %Z wouldn't recognize `C
+          beyondtrust.pra.request.start_time: "{{parsed_event.message.data.request_start_time | to_rfc3339}}" # should be parsed to RFC3339? but %Z wouldn't recognize `C
 
           beyondtrust.pra.request_reason: "{{parsed_event.message.data.request_reason}}"
           beyondtrust.pra.approver_name: "{{parsed_event.message.data.approver_name}}"

--- a/BeyondTrust/beyondtrust-pra/tests/test_3.json
+++ b/BeyondTrust/beyondtrust-pra/tests/test_3.json
@@ -1,0 +1,60 @@
+{
+  "input": {
+    "message": "{\"timestamp\": \"1746516527\", \"event_type\": \"Jump Item Authorization Request Utilized\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"data\": {\"request_id\": \"789\", \"request_start_time\": \"2025-05-06 09:27:40 CEST\", \"request_duration\": \"4 hour(s)\", \"jump_policy_name\": \"Some policy\", \"jump_item_type\": \"Remote RDP Jump Shortcut\", \"jump_item_name\": \"1.2.3.4\", \"push_agent_name\": \"EXAMPLE_AGENT\", \"requesting_user\": \"John Doe (john.doe@example.com)\", \"requesting_user_id\": \"123\", \"approval_applies_to\": \"John Doe\", \"request_reason\": \"\", \"approver_name\": \"Site Admin\", \"request_approver\": \"jane.doe@example2.com\", \"approver_comments\": \"\"}, \"session_id\": \"21d6f40cfb511982e4424e0e250a9557\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}}"
+  },
+  "expected": {
+    "message": "{\"timestamp\": \"1746516527\", \"event_type\": \"Jump Item Authorization Request Utilized\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"data\": {\"request_id\": \"789\", \"request_start_time\": \"2025-05-06 09:27:40 CEST\", \"request_duration\": \"4 hour(s)\", \"jump_policy_name\": \"Some policy\", \"jump_item_type\": \"Remote RDP Jump Shortcut\", \"jump_item_name\": \"1.2.3.4\", \"push_agent_name\": \"EXAMPLE_AGENT\", \"requesting_user\": \"John Doe (john.doe@example.com)\", \"requesting_user_id\": \"123\", \"approval_applies_to\": \"John Doe\", \"request_reason\": \"\", \"approver_name\": \"Site Admin\", \"request_approver\": \"jane.doe@example2.com\", \"approver_comments\": \"\"}, \"session_id\": \"21d6f40cfb511982e4424e0e250a9557\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}}",
+    "event": {
+      "category": [
+        "session"
+      ],
+      "code": "Jump Item Authorization Request Utilized",
+      "type": [
+        "info"
+      ]
+    },
+    "@timestamp": "2025-05-06T07:28:47Z",
+    "beyondtrust": {
+      "pra": {
+        "approval_applies_to": "John Doe",
+        "approver_name": "Site Admin",
+        "jump_group": {
+          "type": "shared"
+        },
+        "jump_item_name": "1.2.3.4",
+        "jump_item_type": "Remote RDP Jump Shortcut",
+        "jump_policy_name": "Some policy",
+        "performed_by": {
+          "type": "system"
+        },
+        "push_agent_name": "EXAMPLE_AGENT",
+        "request": {
+          "duration": "4 hour(s)",
+          "id": "789",
+          "start_time": "2025-05-06 09:27:40 CEST"
+        },
+        "request_approver": "jane.doe@example2.com",
+        "session_id": "21d6f40cfb511982e4424e0e250a9557"
+      }
+    },
+    "group": {
+      "name": "EXAMPLE_JUMP_GROUP"
+    },
+    "observer": {
+      "product": "Privileged Remote Access",
+      "vendor": "BeyondTrust"
+    },
+    "related": {
+      "user": [
+        "John Doe"
+      ]
+    },
+    "source": {
+      "user": {
+        "email": "john.doe@example.com",
+        "id": "123",
+        "name": "John Doe"
+      }
+    }
+  }
+}

--- a/BeyondTrust/beyondtrust-pra/tests/test_3.json
+++ b/BeyondTrust/beyondtrust-pra/tests/test_3.json
@@ -9,6 +9,7 @@
         "session"
       ],
       "code": "Jump Item Authorization Request Utilized",
+      "duration": 14400000000,
       "type": [
         "info"
       ]
@@ -29,7 +30,6 @@
         },
         "push_agent_name": "EXAMPLE_AGENT",
         "request": {
-          "duration": "4 hour(s)",
           "id": "789",
           "start_time": "2025-05-06T09:27:40.000000Z"
         },

--- a/BeyondTrust/beyondtrust-pra/tests/test_3.json
+++ b/BeyondTrust/beyondtrust-pra/tests/test_3.json
@@ -31,7 +31,7 @@
         "request": {
           "duration": "4 hour(s)",
           "id": "789",
-          "start_time": "2025-05-06 09:27:40 CEST"
+          "start_time": "2025-05-06T09:27:40.000000Z"
         },
         "request_approver": "jane.doe@example2.com",
         "session_id": "21d6f40cfb511982e4424e0e250a9557"

--- a/BeyondTrust/beyondtrust-pra/tests/test_4.json
+++ b/BeyondTrust/beyondtrust-pra/tests/test_4.json
@@ -1,0 +1,39 @@
+{
+  "input": {
+    "message": "{\"timestamp\": \"1746242657\", \"event_type\": \"Remote Shell Event\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"data\": {\"text\": \"curl 127.0.0.1/api\"}, \"session_id\": \"21d6f40cfb511982e4424e0e250a9557\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}}"
+  },
+  "expected": {
+    "message": "{\"timestamp\": \"1746242657\", \"event_type\": \"Remote Shell Event\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"data\": {\"text\": \"curl 127.0.0.1/api\"}, \"session_id\": \"21d6f40cfb511982e4424e0e250a9557\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}}",
+    "event": {
+      "category": [
+        "session"
+      ],
+      "code": "Remote Shell Event",
+      "type": [
+        "info"
+      ]
+    },
+    "@timestamp": "2025-05-03T03:24:17Z",
+    "beyondtrust": {
+      "pra": {
+        "jump_group": {
+          "type": "shared"
+        },
+        "performed_by": {
+          "type": "system"
+        },
+        "session_id": "21d6f40cfb511982e4424e0e250a9557"
+      }
+    },
+    "group": {
+      "name": "EXAMPLE_JUMP_GROUP"
+    },
+    "observer": {
+      "product": "Privileged Remote Access",
+      "vendor": "BeyondTrust"
+    },
+    "process": {
+      "command_line": "curl 127.0.0.1/api"
+    }
+  }
+}

--- a/BeyondTrust/beyondtrust-pra/tests/test_5.json
+++ b/BeyondTrust/beyondtrust-pra/tests/test_5.json
@@ -1,0 +1,39 @@
+{
+  "input": {
+    "message": "{\"timestamp\": \"1746004231\", \"event_type\": \"Remote Shell Event\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"data\": {\"text\": \"ls\"}, \"session_id\": \"21d6f40cfb511982e4424e0e250a9557\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}}"
+  },
+  "expected": {
+    "message": "{\"timestamp\": \"1746004231\", \"event_type\": \"Remote Shell Event\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"data\": {\"text\": \"ls\"}, \"session_id\": \"21d6f40cfb511982e4424e0e250a9557\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}}",
+    "event": {
+      "category": [
+        "session"
+      ],
+      "code": "Remote Shell Event",
+      "type": [
+        "info"
+      ]
+    },
+    "@timestamp": "2025-04-30T09:10:31Z",
+    "beyondtrust": {
+      "pra": {
+        "jump_group": {
+          "type": "shared"
+        },
+        "performed_by": {
+          "type": "system"
+        },
+        "session_id": "21d6f40cfb511982e4424e0e250a9557"
+      }
+    },
+    "group": {
+      "name": "EXAMPLE_JUMP_GROUP"
+    },
+    "observer": {
+      "product": "Privileged Remote Access",
+      "vendor": "BeyondTrust"
+    },
+    "process": {
+      "command_line": "ls"
+    }
+  }
+}


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/626

## Summary by Sourcery

Extend BeyondTrust PRA integration to support additional event attributes and map them to ECS fields

New Features:
- Introduce parsing and indexing for new PRA event fields (request ID, duration, start time, reason, approval target, approver name, and comments)
- Capture jump policy, item name/type, and push agent name from events into ECS fields
- Parse the requesting_user string via a grok filter and assign username and email to source.user fields

Enhancements:
- Populate process.command_line from event data

Documentation:
- Update fields.yml to register the newly supported PRA metadata fields

Tests:
- Add new JSON test fixtures to validate parsing of the added PRA fields