### PR TITLE
Winlogbeat&Azure-Windows: fix the Opcode field

### DIFF
--- a/Azure/azure-windows/_meta/fields.yml
+++ b/Azure/azure-windows/_meta/fields.yml
@@ -13,9 +13,9 @@ action.properties.Name:
   name: action.properties.Name
   type: keyword
 
-action.properties.Opcode:
+action.properties.OpcodeValue:
   description: The opcode
-  name: action.properties.Opcode
+  name: action.properties.OpcodeValue
   type: number
 
 action.properties.Type:

--- a/Azure/azure-windows/ingest/parser.yml
+++ b/Azure/azure-windows/ingest/parser.yml
@@ -289,7 +289,7 @@ stages:
       - set:
           action.record_id: "{{parse_windows_event.message.System.EventRecordID}}"
           action.properties: "{{parse_windows_event.message.EventData | string}}"
-          action.properties.Opcode: "{{parse_json.message.properties.Opcode | int}}"
+          action.properties.OpcodeValue: "{{parse_json.message.properties.Opcode | int}}"
         filter: "{{parse_json.message.properties.RawXml != null}}"
       - set:
           action.properties.Name: "{{set_custom_fields.azure_windows.user.name}}"

--- a/Azure/azure-windows/tests/Event_4719.json
+++ b/Azure/azure-windows/tests/Event_4719.json
@@ -16,7 +16,7 @@
       "properties": {
         "AuditPolicyChanges": "%%8450",
         "CategoryId": "%%8273",
-        "Opcode": 0,
+        "OpcodeValue": 0,
         "SubcategoryGuid": "{0CCE9215-69AE-11D9-BED3-505054503030}",
         "SubcategoryId": "%%12544",
         "SubjectDomainName": "ACME",

--- a/Azure/azure-windows/tests/Event_5156.json
+++ b/Azure/azure-windows/tests/Event_5156.json
@@ -27,7 +27,7 @@
         "FilterRTID": "163770",
         "LayerName": "%%14610",
         "LayerRTID": "44",
-        "Opcode": 0,
+        "OpcodeValue": 0,
         "ProcessID": "2652",
         "Protocol": "6",
         "RemoteMachineID": "S-1-0-0",

--- a/Azure/azure-windows/tests/event_4648.json
+++ b/Azure/azure-windows/tests/event_4648.json
@@ -23,7 +23,7 @@
         "IpAddress": "-",
         "IpPort": "-",
         "LogonGuid": "{bcd3f290-9f73-4e62-a998-475e7db8384c}",
-        "Opcode": 0,
+        "OpcodeValue": 0,
         "ProcessId": "0x15bc",
         "ProcessName": "C:\\Program Files (x86)\\Okta\\Okta AD Agent\\OktaAgentService.exe",
         "SubjectDomainName": "EXAMPLE",

--- a/Azure/azure-windows/tests/kerberos.json
+++ b/Azure/azure-windows/tests/kerberos.json
@@ -33,7 +33,7 @@
         "LogonProcessName": "Kerberos",
         "LogonType": "3",
         "Name": "HOSTMON",
-        "Opcode": 0,
+        "OpcodeValue": 0,
         "ProcessId": "0x0",
         "ProcessName": "-",
         "RestrictedAdminMode": "-",

--- a/Azure/azure-windows/tests/key_file_operation.json
+++ b/Azure/azure-windows/tests/key_file_operation.json
@@ -20,7 +20,7 @@
         "KeyFilePath": "C:\\ProgramData\\Microsoft\\Crypto\\RSA\\MachineKeys\\5dc8d7cc0741b353e4e980818c304a9b_f67648d5-9dc6-457b-b947-f44d21889d9b",
         "KeyName": "{3F1E0FA6-ACA6-4152-803B-976EF5816428}",
         "KeyType": "%%2499",
-        "Opcode": 0,
+        "OpcodeValue": 0,
         "Operation": "%%2458",
         "ProviderName": "Microsoft Software Key Storage Provider",
         "ReturnCode": "0x0",

--- a/Azure/azure-windows/tests/loggedoff.json
+++ b/Azure/azure-windows/tests/loggedoff.json
@@ -17,7 +17,7 @@
         "Domain": "{\"name\":\"ACME\"}",
         "LogonType": "3",
         "Name": "AZNTPI-01$",
-        "Opcode": 0,
+        "OpcodeValue": 0,
         "TargetDomainName": "ACME",
         "TargetLogonId": "0x686007f9",
         "TargetUserName": "AZNTPI-01$",

--- a/Azure/azure-windows/tests/process_operation.json
+++ b/Azure/azure-windows/tests/process_operation.json
@@ -18,7 +18,7 @@
         "MandatoryLabel": "S-1-16-16384",
         "NewProcessId": "0x50",
         "NewProcessName": "C:\\Program Files\\Microsoft Monitoring Agent\\Agent\\Health Service State\\Monitoring Host Temporary Files 52\\696\\pmfexe.exe",
-        "Opcode": 0,
+        "OpcodeValue": 0,
         "ParentProcessName": "C:\\Program Files\\Microsoft Monitoring Agent\\Agent\\MonitoringHost.exe",
         "ProcessId": "0x1568",
         "SubjectDomainName": "ACME",

--- a/Azure/azure-windows/tests/process_operation2.json
+++ b/Azure/azure-windows/tests/process_operation2.json
@@ -17,7 +17,7 @@
         "CommandLine": "\"C:\\Windows\\system32\\WindowsPowerShell\\v1.0\\powershell.exe\" \"-ExecutionPolicy\" \"Unrestricted\" \"-Noninteractive\" \"-NoProfile\" \"-NoLogo\" \"-File\" \"C:\\Program Files\\Microsoft Dependency Agent\\plugins\\AzureMetadata.ps1\"",
         "NewProcessId": "0x17b4",
         "NewProcessName": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
-        "Opcode": 0,
+        "OpcodeValue": 0,
         "ProcessId": "0x1788",
         "SubjectDomainName": "ACME",
         "SubjectLogonId": "0x3e7",

--- a/Azure/azure-windows/tests/restart_manager.json
+++ b/Azure/azure-windows/tests/restart_manager.json
@@ -14,7 +14,7 @@
       "name": "no match",
       "outcome": "success",
       "properties": {
-        "Opcode": 0
+        "OpcodeValue": 0
       },
       "record_id": 9379,
       "type": "Application"

--- a/Azure/azure-windows/tests/sysmon.json
+++ b/Azure/azure-windows/tests/sysmon.json
@@ -24,7 +24,7 @@
         "IntegrityLevel": "System",
         "LogonGuid": "{f67648d5-e752-5d68-0000-0020e7030000}",
         "LogonId": "0x3e7",
-        "Opcode": 0,
+        "OpcodeValue": 0,
         "OriginalFileName": "cscript.exe",
         "ParentCommandLine": "\"C:\\Program Files\\Microsoft Monitoring Agent\\Agent\\MonitoringHost.exe\" -Embedding",
         "ParentImage": "C:\\Program Files\\Microsoft Monitoring Agent\\Agent\\MonitoringHost.exe",

--- a/Azure/azure-windows/tests/sysmon_11.json
+++ b/Azure/azure-windows/tests/sysmon_11.json
@@ -16,7 +16,7 @@
       "properties": {
         "CreationUtcTime": "2019-11-27 15:25:45.117",
         "Image": "C:\\windows\\system32\\WindowsPowerShell\\v1.0\\powershell.exe",
-        "Opcode": 0,
+        "OpcodeValue": 0,
         "ProcessGuid": "{4A43FA81-9578-5DDE-0000-0010490B8303}",
         "ProcessId": "4000",
         "RuleName": null,

--- a/Azure/azure-windows/tests/sysmon_13.json
+++ b/Azure/azure-windows/tests/sysmon_13.json
@@ -17,7 +17,7 @@
         "Details": "Microsoft Print to PDF (redirected 5)",
         "EventType": "SetValue",
         "Image": "System",
-        "Opcode": 0,
+        "OpcodeValue": 0,
         "ProcessGuid": "{4A43FA81-9258-5E74-0000-0010EB030000}",
         "ProcessId": "4",
         "RuleName": null,

--- a/Azure/azure-windows/tests/sysmon_22.json
+++ b/Azure/azure-windows/tests/sysmon_22.json
@@ -15,7 +15,7 @@
       "outcome": "success",
       "properties": {
         "Image": "C:\\Windows\\System32\\svchost.exe",
-        "Opcode": 0,
+        "OpcodeValue": 0,
         "ProcessGuid": "{f67648d5-4d39-5e56-0000-0010ec220200}",
         "ProcessId": "3676",
         "QueryName": "v10.events.data.microsoft.com",

--- a/Azure/azure-windows/tests/sysmon_3.json
+++ b/Azure/azure-windows/tests/sysmon_3.json
@@ -21,7 +21,7 @@
         "DestinationPortName": "http",
         "Image": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
         "Initiated": "true",
-        "Opcode": 0,
+        "OpcodeValue": 0,
         "ProcessGuid": "{4A43FA81-5A68-5DFA-0000-0010A992AC18}",
         "ProcessId": "4364",
         "Protocol": "tcp",

--- a/Azure/azure-windows/tests/working_dir.json
+++ b/Azure/azure-windows/tests/working_dir.json
@@ -17,7 +17,7 @@
         "CommandLine": "C:\\Windows\\system32\\svchost.exe -k wsappx",
         "NewProcessId": "0x12f0",
         "NewProcessName": "C:\\Windows\\System32\\svchost.exe",
-        "Opcode": 0,
+        "OpcodeValue": 0,
         "ProcessId": "0x25c",
         "SubjectDomainName": "ACME",
         "SubjectLogonId": "0x3e7",

--- a/Beats/winlogbeat/_meta/fields.yml
+++ b/Beats/winlogbeat/_meta/fields.yml
@@ -291,9 +291,9 @@ action.properties.OldTime:
   name: action.properties.OldTime
   type: keyword
 
-action.properties.OpcodeValue:
+action.properties.Opcode:
   description: ''
-  name: action.properties.OpcodeValue
+  name: action.properties.Opcode
   type: keyword
 
 action.properties.OriginalFileName:

--- a/Beats/winlogbeat/ingest/parser.yml
+++ b/Beats/winlogbeat/ingest/parser.yml
@@ -133,7 +133,7 @@ stages:
           user.target.domain: "{{json.event.winlog.event_data.TargetUserDomain}}"
 
       - set:
-          action.properties.OpcodeValue: "{{json.event.winlog.opcode}}"
+          action.properties.Opcode: "{{json.event.winlog.opcode}}"
           action.properties.Keywords: "{{json.event.winlog.keywords}}"
           action.properties.ProviderGUID: "{{json.event.winlog.provider_guid}}"
           action.properties.SourceName: "{{json.event.winlog.provider_name}}"

--- a/Beats/winlogbeat/tests/auth.json
+++ b/Beats/winlogbeat/tests/auth.json
@@ -27,7 +27,7 @@
         ],
         "LayerName": "%%14610",
         "LayerRTID": "44",
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "ProcessID": "4",
         "Protocol": "6",
         "ProviderGUID": "{54849625-5478-4994-a5ba-3e3b0328c30d}",

--- a/Beats/winlogbeat/tests/auth2.json
+++ b/Beats/winlogbeat/tests/auth2.json
@@ -35,7 +35,7 @@
         "LogonGuid": "{FBEAEF6D-F1DA-F8AD-A2B2-A3A9AAC706AD}",
         "LogonProcessName": "Kerberos",
         "LogonType": "3",
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "ProcessId": "0x0",
         "ProcessName": "-",
         "ProviderGUID": "{54849625-5478-4994-A5BA-3E3B0328C30D}",

--- a/Beats/winlogbeat/tests/event_file_created.json
+++ b/Beats/winlogbeat/tests/event_file_created.json
@@ -17,7 +17,7 @@
       "properties": {
         "CreationUtcTime": "2023-10-19 11:22:01.885",
         "Image": "C:\\WINDOWS\\system32\\svchost.exe",
-        "OpcodeValue": "Informations",
+        "Opcode": "Informations",
         "ProcessGuid": "{abcdef01-2345-6789-abcd-000000000000}",
         "ProcessId": "4504",
         "ProviderGUID": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",

--- a/Beats/winlogbeat/tests/event_process_create_1.json
+++ b/Beats/winlogbeat/tests/event_process_create_1.json
@@ -25,7 +25,7 @@
         "IntegrityLevel": "Low",
         "LogonGuid": "{abcdef01-b1c2-d3c4-1234-123400000000}",
         "LogonId": "0x1234abc",
-        "OpcodeValue": "Informations",
+        "Opcode": "Informations",
         "OriginalFileName": "Teams.exe",
         "ParentCommandLine": "\"C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\Teams.exe\" ",
         "ParentImage": "C:\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\Teams.exe",

--- a/Beats/winlogbeat/tests/event_process_create_2.json
+++ b/Beats/winlogbeat/tests/event_process_create_2.json
@@ -29,7 +29,7 @@
         "IntegrityLevel": "Low",
         "LogonGuid": "{abcdef01-b1c2-d3c4-1234-123400000000}",
         "LogonId": "0x1234abc",
-        "OpcodeValue": "Informations",
+        "Opcode": "Informations",
         "ParentUser": "COMPANY\\asmithee",
         "Product": "Microsoft Teams",
         "ProviderGUID": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",

--- a/Beats/winlogbeat/tests/event_registry_1.json
+++ b/Beats/winlogbeat/tests/event_registry_1.json
@@ -25,7 +25,7 @@
       "properties": {
         "Details": "Binary Data",
         "EventType": "SetValue",
-        "OpcodeValue": "Informations",
+        "Opcode": "Informations",
         "ProviderGUID": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
         "SourceName": "Microsoft-Windows-Sysmon",
         "TargetObject": "target\\System\\CurrentControlSet\\Services\\bam\\State\\UserSettings\\S-1-2-3-4-012345678-123456789-876543210-12345\\\\Device\\HarddiskVolume3\\Users\\asmithee\\AppData\\Local\\Microsoft\\Teams\\current\\Teams.exe",

--- a/Beats/winlogbeat/tests/event_registry_2.json
+++ b/Beats/winlogbeat/tests/event_registry_2.json
@@ -25,7 +25,7 @@
       "properties": {
         "Details": "WORD (0x00000000-0x12345678)",
         "EventType": "SetValue",
-        "OpcodeValue": "Informations",
+        "Opcode": "Informations",
         "ProviderGUID": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
         "SourceName": "Microsoft-Windows-Sysmon",
         "TargetObject": "HKLM\\SOFTWARE\\Microsoft\\Windows Advanced Threat Protection\\TelLib\\LastSuccessfulUploadTime",

--- a/Beats/winlogbeat/tests/powershell_event_0400.json
+++ b/Beats/winlogbeat/tests/powershell_event_0400.json
@@ -21,7 +21,7 @@
         "Keywords": [
           "Classic"
         ],
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "SourceName": "PowerShell"
       },
       "record_id": 1492,

--- a/Beats/winlogbeat/tests/powershell_event_0403.json
+++ b/Beats/winlogbeat/tests/powershell_event_0403.json
@@ -21,7 +21,7 @@
         "Keywords": [
           "Classic"
         ],
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "SourceName": "PowerShell"
       },
       "record_id": 18592,

--- a/Beats/winlogbeat/tests/powershell_event_0600.json
+++ b/Beats/winlogbeat/tests/powershell_event_0600.json
@@ -21,7 +21,7 @@
         "Keywords": [
           "Classic"
         ],
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "SourceName": "PowerShell"
       },
       "record_id": 1089,

--- a/Beats/winlogbeat/tests/powershell_event_0800.json
+++ b/Beats/winlogbeat/tests/powershell_event_0800.json
@@ -21,7 +21,7 @@
         "Keywords": [
           "Classic"
         ],
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "SourceName": "PowerShell"
       },
       "record_id": 1846,

--- a/Beats/winlogbeat/tests/powershell_event_4103.json
+++ b/Beats/winlogbeat/tests/powershell_event_4103.json
@@ -18,7 +18,7 @@
     "action": {
       "id": 4103,
       "properties": {
-        "OpcodeValue": "To be used when operation is just executing a method",
+        "Opcode": "To be used when operation is just executing a method",
         "ProviderGUID": "{a0c1853b-5c40-4b15-8766-3cf1c58f985a}",
         "SourceName": "Microsoft-Windows-PowerShell"
       },

--- a/Beats/winlogbeat/tests/powershell_event_4104.json
+++ b/Beats/winlogbeat/tests/powershell_event_4104.json
@@ -18,7 +18,7 @@
     "action": {
       "id": 4104,
       "properties": {
-        "OpcodeValue": "On create calls",
+        "Opcode": "On create calls",
         "ProviderGUID": "{a0c1853b-5c40-4b15-8766-3cf1c58f985a}",
         "SourceName": "Microsoft-Windows-PowerShell"
       },

--- a/Beats/winlogbeat/tests/powershell_event_4105.json
+++ b/Beats/winlogbeat/tests/powershell_event_4105.json
@@ -18,7 +18,7 @@
     "action": {
       "id": 4105,
       "properties": {
-        "OpcodeValue": "On create calls",
+        "Opcode": "On create calls",
         "ProviderGUID": "{a0c1853b-5c40-4b15-8766-3cf1c58f985a}",
         "SourceName": "Microsoft-Windows-PowerShell"
       },

--- a/Beats/winlogbeat/tests/powershell_event_4106.json
+++ b/Beats/winlogbeat/tests/powershell_event_4106.json
@@ -18,7 +18,7 @@
     "action": {
       "id": 4106,
       "properties": {
-        "OpcodeValue": "On create calls",
+        "Opcode": "On create calls",
         "ProviderGUID": "{a0c1853b-5c40-4b15-8766-3cf1c58f985a}",
         "SourceName": "Microsoft-Windows-PowerShell"
       },

--- a/Beats/winlogbeat/tests/security_event_1100.json
+++ b/Beats/winlogbeat/tests/security_event_1100.json
@@ -27,7 +27,7 @@
         "Keywords": [
           "Audit Success"
         ],
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "ProviderGUID": "{fc65ddd8-d6ef-4962-83d5-6e5cfe9ce148}",
         "SourceName": "Microsoft-Windows-Eventlog"
       },

--- a/Beats/winlogbeat/tests/security_event_1102.json
+++ b/Beats/winlogbeat/tests/security_event_1102.json
@@ -28,7 +28,7 @@
         "Keywords": [
           "Audit Success"
         ],
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "ProviderGUID": "{fc65ddd8-d6ef-4962-83d5-6e5cfe9ce148}",
         "SourceName": "Microsoft-Windows-Eventlog"
       },

--- a/Beats/winlogbeat/tests/security_event_4624.json
+++ b/Beats/winlogbeat/tests/security_event_4624.json
@@ -41,7 +41,7 @@
         "LogonGuid": "{00000000-0000-0000-0000-000000000000}",
         "LogonProcessName": "Process ",
         "LogonType": "3",
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "ProcessId": "0x2f0",
         "ProcessName": "C:\\Windows\\System32\\executable.exe",
         "ProviderGUID": "{54849625-5478-4994-a5ba-3e3b0328c30d}",

--- a/Beats/winlogbeat/tests/security_event_4625.json
+++ b/Beats/winlogbeat/tests/security_event_4625.json
@@ -41,7 +41,7 @@
         "LmPackageName": "-",
         "LogonProcessName": "Channel",
         "LogonType": "3",
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "ProcessId": "0x338",
         "ProcessName": "C:\\Windows\\System32\\executable.exe",
         "ProviderGUID": "{54849625-5478-4994-A5BA-3E3B0328C30D}",

--- a/Beats/winlogbeat/tests/security_event_4634.json
+++ b/Beats/winlogbeat/tests/security_event_4634.json
@@ -28,7 +28,7 @@
           "Audit Success"
         ],
         "LogonType": "3",
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "ProviderGUID": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
         "SourceName": "Microsoft-Windows-Security-Auditing",
         "TargetDomainName": "J_DOE",

--- a/Beats/winlogbeat/tests/security_event_4648.json
+++ b/Beats/winlogbeat/tests/security_event_4648.json
@@ -24,7 +24,7 @@
           "Audit Success"
         ],
         "LogonGuid": "{00000000-0000-0000-0000-000000000000}",
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "ProcessId": "0x8314",
         "ProcessName": "D:\\\\Program Files (x86)\\\\Process\\\\Test\\\\processname.exe",
         "ProviderGUID": "{54849625-5478-4994-A5BA-3E3B0328C30D}",

--- a/Beats/winlogbeat/tests/security_event_4662.json
+++ b/Beats/winlogbeat/tests/security_event_4662.json
@@ -34,7 +34,7 @@
         "ObjectName": "%{12345678-abcd-ef90-1234-abcdef123456}",
         "ObjectServer": "DS",
         "ObjectType": "%{11111111-aaaa-2222-bbbb-333333333333}",
-        "OpcodeValue": "Informations",
+        "Opcode": "Informations",
         "OperationType": "Object Access",
         "Properties": "%%7688\n\t\t{abcdefab-1234-cdef-5678-901234abcdef}\n\t{11111111-aaaa-2222-bbbb-333333333333}",
         "ProviderGUID": "{54849625-5478-4994-a5ba-3e3b0328c30d}",

--- a/Beats/winlogbeat/tests/security_event_4672.json
+++ b/Beats/winlogbeat/tests/security_event_4672.json
@@ -27,7 +27,7 @@
         "Keywords": [
           "Succ\u00e8s de l\u2019audit"
         ],
-        "OpcodeValue": "Informations",
+        "Opcode": "Informations",
         "PrivilegeList": "SeSecurityPrivilege\n\t\t\tSeBackupPrivilege\n\t\t\tSeRestorePrivilege\n\t\t\tSeTakeOwnershipPrivilege\n\t\t\tSeDebugPrivilege\n\t\t\tSeSystemEnvironmentPrivilege\n\t\t\tSeLoadDriverPrivilege\n\t\t\tSeImpersonatePrivilege\n\t\t\tSeDelegateSessionUserImpersonatePrivilege",
         "ProviderGUID": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
         "SourceName": "Microsoft-Windows-Security-Auditing",

--- a/Beats/winlogbeat/tests/security_event_4688.json
+++ b/Beats/winlogbeat/tests/security_event_4688.json
@@ -25,7 +25,7 @@
         "MandatoryLabel": "S-1-2-3",
         "NewProcessId": "0x1d9c",
         "NewProcessName": "C:\\\\Windows\\\\System32\\\\wbem\\\\WmiApSrv.exe",
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "ParentProcessName": "C:\\\\Windows\\\\System32\\\\services.exe",
         "ProcessId": "0x2a0",
         "ProviderGUID": "{54849625-5478-4994-a5ba-3e3b0328c30d}",

--- a/Beats/winlogbeat/tests/security_event_4689.json
+++ b/Beats/winlogbeat/tests/security_event_4689.json
@@ -27,7 +27,7 @@
         "Keywords": [
           "Succ\u00e8s de l\u2019audit"
         ],
-        "OpcodeValue": "Informations",
+        "Opcode": "Informations",
         "ProcessId": "0x1df8",
         "ProcessName": "C:\\Windows\\System32\\process.exe",
         "ProviderGUID": "{54849625-5478-4994-a5ba-3e3b0328c30d}",

--- a/Beats/winlogbeat/tests/security_event_4720.json
+++ b/Beats/winlogbeat/tests/security_event_4720.json
@@ -45,7 +45,7 @@
         ],
         "NewUacValue": "0x214",
         "OldUacValue": "0x0",
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "PasswordLastSet": "%%1794",
         "PrimaryGroupId": "513",
         "PrivilegeList": "-",

--- a/Beats/winlogbeat/tests/security_event_4722.json
+++ b/Beats/winlogbeat/tests/security_event_4722.json
@@ -27,7 +27,7 @@
         "Keywords": [
           "Audit Success"
         ],
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "ProviderGUID": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
         "SourceName": "Microsoft-Windows-Security-Auditing",
         "SubjectDomainName": "DOMAIN",

--- a/Beats/winlogbeat/tests/security_event_4723.json
+++ b/Beats/winlogbeat/tests/security_event_4723.json
@@ -27,7 +27,7 @@
         "Keywords": [
           "Audit Success"
         ],
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "PrivilegeList": "-",
         "ProviderGUID": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
         "SourceName": "Microsoft-Windows-Security-Auditing",

--- a/Beats/winlogbeat/tests/security_event_4725.json
+++ b/Beats/winlogbeat/tests/security_event_4725.json
@@ -27,7 +27,7 @@
         "Keywords": [
           "Audit Success"
         ],
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "ProviderGUID": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
         "SourceName": "Microsoft-Windows-Security-Auditing",
         "SubjectDomainName": "DOMAIN",

--- a/Beats/winlogbeat/tests/security_event_4742.json
+++ b/Beats/winlogbeat/tests/security_event_4742.json
@@ -42,7 +42,7 @@
         ],
         "NewUacValue": "0x84",
         "OldUacValue": "0x85",
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "PasswordLastSet": "-",
         "PrimaryGroupId": "-",
         "PrivilegeList": [

--- a/Beats/winlogbeat/tests/security_event_4744.json
+++ b/Beats/winlogbeat/tests/security_event_4744.json
@@ -28,7 +28,7 @@
         "Keywords": [
           "Audit Success"
         ],
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "PrivilegeList": "-",
         "ProviderGUID": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
         "SamAccountName": "testdistlocal",

--- a/Beats/winlogbeat/tests/security_event_4750.json
+++ b/Beats/winlogbeat/tests/security_event_4750.json
@@ -28,7 +28,7 @@
         "Keywords": [
           "Audit Success"
         ],
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "PrivilegeList": "-",
         "ProviderGUID": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
         "SamAccountName": "testglobal1",

--- a/Beats/winlogbeat/tests/security_event_4768.json
+++ b/Beats/winlogbeat/tests/security_event_4768.json
@@ -29,7 +29,7 @@
         "Keywords": [
           "Succ\u00e8s de l\u2019audit"
         ],
-        "OpcodeValue": "Informations",
+        "Opcode": "Informations",
         "PreAuthType": "2",
         "ProviderGUID": "{54849625-5478-4994-A5BA-3E3B0328C30D}",
         "ServiceName": "service",

--- a/Beats/winlogbeat/tests/security_event_4769.json
+++ b/Beats/winlogbeat/tests/security_event_4769.json
@@ -30,7 +30,7 @@
           "Succ\u00e8s de l\u2019audit"
         ],
         "LogonGuid": "{12345678-ABCD-EF90-1234-123456ABCDEF}",
-        "OpcodeValue": "Informations",
+        "Opcode": "Informations",
         "ProviderGUID": "{54849625-5478-4994-A5BA-3E3B0328C30D}",
         "ServiceName": "SERVICE$",
         "ServiceSid": "S-1-2-3",

--- a/Beats/winlogbeat/tests/security_event_4771.json
+++ b/Beats/winlogbeat/tests/security_event_4771.json
@@ -27,7 +27,7 @@
         "Keywords": [
           "Audit Failure"
         ],
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "PreAuthType": "0",
         "ProviderGUID": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
         "ServiceName": "krbtgt/test.saas",

--- a/Beats/winlogbeat/tests/security_event_4776.json
+++ b/Beats/winlogbeat/tests/security_event_4776.json
@@ -27,7 +27,7 @@
         "Keywords": [
           "Audit Success"
         ],
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "PackageName": "MICROSOFT_AUTHENTICATION_PACKAGE_V1_0",
         "ProviderGUID": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
         "SourceName": "Microsoft-Windows-Security-Auditing",

--- a/Beats/winlogbeat/tests/security_event_4778.json
+++ b/Beats/winlogbeat/tests/security_event_4778.json
@@ -32,7 +32,7 @@
           "Audit Success"
         ],
         "LogonID": "0x5c7c095",
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "ProviderGUID": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
         "SessionName": "Console",
         "SourceName": "Microsoft-Windows-Security-Auditing"

--- a/Beats/winlogbeat/tests/security_event_4798.json
+++ b/Beats/winlogbeat/tests/security_event_4798.json
@@ -29,7 +29,7 @@
         "Keywords": [
           "Audit Success"
         ],
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "ProviderGUID": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
         "SourceName": "Microsoft-Windows-Security-Auditing",
         "SubjectDomainName": "DOMAIN",

--- a/Beats/winlogbeat/tests/security_event_4964.json
+++ b/Beats/winlogbeat/tests/security_event_4964.json
@@ -29,7 +29,7 @@
           "Audit Success"
         ],
         "LogonGuid": "{00000000-0000-0000-0000-000000000000}",
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "ProviderGUID": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
         "SidList": "\n\t\t%{S-1-5-21-101361758-2486510592-3018839910-519}",
         "SourceName": "Microsoft-Windows-Security-Auditing",

--- a/Beats/winlogbeat/tests/security_event_5140.json
+++ b/Beats/winlogbeat/tests/security_event_5140.json
@@ -26,7 +26,7 @@
           "Audit Success"
         ],
         "ObjectType": "File",
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "ProviderGUID": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
         "ShareName": "\\\\\\\\*\\\\IPC$",
         "SourceName": "Microsoft-Windows-Security-Auditing",

--- a/Beats/winlogbeat/tests/security_event_5145.json
+++ b/Beats/winlogbeat/tests/security_event_5145.json
@@ -27,7 +27,7 @@
           "Audit Success"
         ],
         "ObjectType": "File",
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "ProviderGUID": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
         "RelativeTargetName": "company.test\\\\scripts\\\\TargetName.cmd",
         "ShareLocalPath": "\\\\??\\\\C:\\\\Windows\\\\SYSVOL\\\\sysvol",

--- a/Beats/winlogbeat/tests/security_event_5381.json
+++ b/Beats/winlogbeat/tests/security_event_5381.json
@@ -30,7 +30,7 @@
         "Keywords": [
           "Audit Success"
         ],
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "ProcessCreationTime": "2023-01-17T21:15:02.4069136Z",
         "ProviderGUID": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
         "SourceName": "Microsoft-Windows-Security-Auditing",

--- a/Beats/winlogbeat/tests/sysmon09_1.json
+++ b/Beats/winlogbeat/tests/sysmon09_1.json
@@ -21,7 +21,7 @@
       "id": 16,
       "properties": {
         "Configuration": "C:\\Users\\vagrant\\Downloads\\\"C:\\Users\\vagrant\\Downloads\\Sysmon.exe\"  -i -n",
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "ProviderGUID": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
         "SourceName": "Microsoft-Windows-Sysmon"
       },

--- a/Beats/winlogbeat/tests/sysmon09_2.json
+++ b/Beats/winlogbeat/tests/sysmon09_2.json
@@ -26,7 +26,7 @@
         "IntegrityLevel": "System",
         "LogonGuid": "{42f11c3b-6e1a-5c8c-0000-0020e7030000}",
         "LogonId": "0x3e7",
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "Product": "Sysinternals Sysmon",
         "ProviderGUID": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
         "SourceName": "Microsoft-Windows-Sysmon",

--- a/Beats/winlogbeat/tests/sysmon10_1.json
+++ b/Beats/winlogbeat/tests/sysmon10_1.json
@@ -22,7 +22,7 @@
     "action": {
       "id": 22,
       "properties": {
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "ProviderGUID": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
         "SourceName": "Microsoft-Windows-Sysmon"
       },

--- a/Beats/winlogbeat/tests/sysmon10_2.json
+++ b/Beats/winlogbeat/tests/sysmon10_2.json
@@ -15,7 +15,7 @@
       "id": 22,
       "properties": {
         "Image": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "ProcessGuid": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
         "ProcessId": "2736",
         "ProviderGUID": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",

--- a/Beats/winlogbeat/tests/sysmon11_file_deleted.json
+++ b/Beats/winlogbeat/tests/sysmon11_file_deleted.json
@@ -15,7 +15,7 @@
       "id": 22,
       "properties": {
         "Image": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "ProcessGuid": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
         "ProcessId": "2736",
         "ProviderGUID": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",

--- a/Beats/winlogbeat/tests/sysmon11_registry.json
+++ b/Beats/winlogbeat/tests/sysmon11_registry.json
@@ -22,7 +22,7 @@
       "id": 13,
       "properties": {
         "EventType": "SetValue",
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "ProviderGUID": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
         "SourceName": "Microsoft-Windows-Sysmon"
       },

--- a/Beats/winlogbeat/tests/sysmon13.json
+++ b/Beats/winlogbeat/tests/sysmon13.json
@@ -21,7 +21,7 @@
     "action": {
       "id": 25,
       "properties": {
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "ProviderGUID": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
         "SourceName": "Microsoft-Windows-Sysmon"
       },

--- a/Beats/winlogbeat/tests/sysmon_10_1.json
+++ b/Beats/winlogbeat/tests/sysmon_10_1.json
@@ -22,7 +22,7 @@
     "action": {
       "id": 22,
       "properties": {
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "ProviderGUID": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
         "SourceName": "Microsoft-Windows-Sysmon"
       },

--- a/Beats/winlogbeat/tests/sysmon_10_2.json
+++ b/Beats/winlogbeat/tests/sysmon_10_2.json
@@ -15,7 +15,7 @@
       "id": 22,
       "properties": {
         "Image": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "ProcessGuid": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
         "ProcessId": "2736",
         "ProviderGUID": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",

--- a/Beats/winlogbeat/tests/sysmon_11_file_deleted.json
+++ b/Beats/winlogbeat/tests/sysmon_11_file_deleted.json
@@ -15,7 +15,7 @@
       "id": 22,
       "properties": {
         "Image": "C:\\Program Files (x86)\\Internet Explorer\\iexplore.exe",
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "ProcessGuid": "{fa4a0de6-e8a9-5d2f-0000-001053699900}",
         "ProcessId": "2736",
         "ProviderGUID": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",

--- a/Beats/winlogbeat/tests/sysmon_no_event.json
+++ b/Beats/winlogbeat/tests/sysmon_no_event.json
@@ -21,7 +21,7 @@
     "action": {
       "id": 22,
       "properties": {
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "ProviderGUID": "{00000000-0000-0000-0000-000000000000}",
         "SourceName": "Microsoft-Windows-Sysmon"
       },

--- a/Beats/winlogbeat/tests/test_filtering.json
+++ b/Beats/winlogbeat/tests/test_filtering.json
@@ -27,7 +27,7 @@
         ],
         "LayerName": "%%14610",
         "LayerRTID": "44",
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "ProcessID": "4",
         "Protocol": "6",
         "ProviderGUID": "{54849625-5478-4994-a5ba-3e3b0328c30d}",

--- a/Beats/winlogbeat/tests/test_logon.json
+++ b/Beats/winlogbeat/tests/test_logon.json
@@ -18,7 +18,7 @@
         "Keywords": [
           "Audit Success"
         ],
-        "OpcodeValue": "Info",
+        "Opcode": "Info",
         "PrivilegeList": "SeSecurityPrivilege\n\t\t\tSeBackupPrivilege\n\t\t\tSeRestorePrivilege\n\t\t\tSeTakeOwnershipPrivilege\n\t\t\tSeDebugPrivilege\n\t\t\tSeSystemEnvironmentPrivilege\n\t\t\tSeLoadDriverPrivilege\n\t\t\tSeImpersonatePrivilege\n\t\t\tSeDelegateSessionUserImpersonatePrivilege",
         "ProviderGUID": "{54849625-5478-4994-A5BA-3E3B0328C30D}",
         "SourceName": "Microsoft-Windows-Security-Auditing",


### PR DESCRIPTION
`action.properties.OpcodeValue` is defined as a number in the Windows format.
`action.properties.Opcode` is defined as a string in the Stormshield SES format.

Align Azure-Windows and WinlogBeat according to these two statements.

## Summary by Sourcery

Align Azure-Windows and Winlogbeat modules to correctly map the opcode field with appropriate names and types

Enhancements:
- Rename action.properties.Opcode to action.properties.OpcodeValue as a numeric field in Azure-Windows mapping and parser
- Rename action.properties.OpcodeValue to action.properties.Opcode as a keyword field in Winlogbeat mapping and parser

Tests:
- Update Azure-Windows and Winlogbeat test fixtures to reflect the renamed opcode field