### PR TITLE
O365 - fix category for UserLoginFailed

### DIFF
--- a/Office 365/o365/ingest/parser.yml
+++ b/Office 365/o365/ingest/parser.yml
@@ -581,6 +581,18 @@ stages:
         mapping:
           event.action: event.type
         fallback: '["info"]'
+      - translate:
+        dictionary:
+          "UserLoggedIn": "success"
+          "UserLoginFailed": "failure"
+        mapping:
+          event.action: event.outcome
+      - translate:
+        dictionary:
+          "UserLoggedIn": "success"
+          "UserLoginFailed": "failure"
+        mapping:
+          event.action: action.outcome
 
       - set:
           event.category: ["iam"]

--- a/Office 365/o365/ingest/parser.yml
+++ b/Office 365/o365/ingest/parser.yml
@@ -570,12 +570,14 @@ stages:
       - translate:
         dictionary:
           "UserLoggedIn": '["authentication"]'
+          "UserLoginFailed": '["authentication"]'
         mapping:
           event.action: event.category
         fallback: '["iam"]'
       - translate:
         dictionary:
           "UserLoggedIn": '["start"]'
+          "UserLoginFailed": '["end"]'
         mapping:
           event.action: event.type
         fallback: '["info"]'

--- a/Office 365/o365/ingest/parser.yml
+++ b/Office 365/o365/ingest/parser.yml
@@ -577,7 +577,7 @@ stages:
       - translate:
         dictionary:
           "UserLoggedIn": '["start"]'
-          "UserLoginFailed": '["end"]'
+          "UserLoginFailed": '["start"]'
         mapping:
           event.action: event.type
         fallback: '["info"]'

--- a/Office 365/o365/tests/user_login_failed.json
+++ b/Office 365/o365/tests/user_login_failed.json
@@ -7,12 +7,12 @@
     "event": {
       "action": "UserLoginFailed",
       "category": [
-        "iam"
+        "authentication"
       ],
       "code": "15",
       "outcome": "success",
       "type": [
-        "info"
+        "end"
       ]
     },
     "@timestamp": "2022-10-14T13:48:03Z",

--- a/Office 365/o365/tests/user_login_failed.json
+++ b/Office 365/o365/tests/user_login_failed.json
@@ -10,7 +10,7 @@
         "authentication"
       ],
       "code": "15",
-      "outcome": "success",
+      "outcome": "failure",
       "type": [
         "start"
       ]
@@ -19,7 +19,7 @@
     "action": {
       "id": 15,
       "name": "UserLoginFailed",
-      "outcome": "success",
+      "outcome": "failure",
       "target": "network-traffic"
     },
     "host": {

--- a/Office 365/o365/tests/user_login_failed.json
+++ b/Office 365/o365/tests/user_login_failed.json
@@ -12,7 +12,7 @@
       "code": "15",
       "outcome": "success",
       "type": [
-        "end"
+        "start"
       ]
     },
     "@timestamp": "2022-10-14T13:48:03Z",


### PR DESCRIPTION
I wasn't able to neither find `event.outcome` in the parser nor affect it by setting directly. I believe it's set on the backend somehow.

https://github.com/SekoiaLab/integration/issues/652