### PR TITLE
AWS: fix the connector identifier associated to the AWS CloudTrail format

### DIFF
--- a/AWS/aws-cloudtrail/_meta/manifest.yml
+++ b/AWS/aws-cloudtrail/_meta/manifest.yml
@@ -1,5 +1,5 @@
 uuid: d3a813ac-f9b5-451c-a602-a5994544d9ed
-automation_connector_uuid: 6427c49a-2f36-4ffa-8513-9ac4cc653fea
+automation_connector_uuid: 0f58c96a-d4f0-4076-bea2-7e774ee43a1e
 automation_module_uuid: b4462429-6f0f-42b5-87b8-430111697d28
 name: AWS CloudTrail
 slug: aws-cloudtrail


### PR DESCRIPTION
The connector associated to the AWS CloudTrail format isn't the correct one. Fix the link.

## Summary by Sourcery

Bug Fixes:
- Correct the automation_connector_uuid for AWS CloudTrail in manifest.yml