### PR TITLE
Duo Security - add event.outcome

### DIFF
--- a/Duo/duo-security/ingest/parser.yml
+++ b/Duo/duo-security/ingest/parser.yml
@@ -25,9 +25,16 @@ pipeline:
   - name: set_timestamp
   - name: set_event_data
   - name: parse_auth_log
+    filter: "{{ parsed_event.message.eventtype == 'auth_log' }}"
+
   - name: parse_admin_log
+    filter: "{{ parsed_event.message.eventtype == 'admin_log' }}"
+
   - name: parse_telephony_log
+    filter: "{{ parsed_event.message.eventtype == 'telephony_log' }}"
+
   - name: parse_offline_log
+    filter: "{{ parsed_event.message.eventtype == 'offline_log' }}"
 
 stages:
   set_timestamp:
@@ -41,11 +48,19 @@ stages:
           observer.vendor: "Duo"
           observer.product: "Duo Security"
 
+      - set:
+          event.outcome: "success"
+        filter: "{{ parsed_event.message.result == 'success' }}"
+
+      - set:
+          event.outcome: "failure"
+        filter: "{{ parsed_event.message.get('result') != None and parsed_event.message.result != 'success' }}"
+
   parse_auth_log:
     actions:
       - set:
           event.category: ["authentication"]
-          event.type: ["info"]
+          event.type: ["start"]
           event.dataset: "auth_log"
           observer.hostname: "{{ parsed_event.message.host }}"
 
@@ -80,7 +95,18 @@ stages:
           duo.security.object: "{{ parsed_event.message.object }}"
           duo.security.telephony.phone_number: "{{ parse_description.description.device }}"
           event.action: "{{ parsed_event.message.action }}"
-        filter: "{{ parsed_event.message.eventtype == 'admin_log' }}"
+
+      - set:
+          event.category: ["authentication"]
+          event.type: ["start"]
+          event.outcome: "success"
+        filter: "{{ parsed_event.message.action == 'admin_login'}}"
+
+      - set:
+          event.category: ["authentication"]
+          event.type: ["start"]
+          event.outcome: "failure"
+        filter: "{{ parsed_event.message.action == 'admin_login_error'}}"
 
   parse_telephony_log:
     actions:
@@ -92,7 +118,6 @@ stages:
           event.reason: "{{ parsed_event.message.context }}"
           duo.security.telephony.type: "{{ parsed_event.message.type }}"
           duo.security.telephony.phone_number: "{{ parsed_event.message.phone }}"
-        filter: "{{ parsed_event.message.eventtype == 'telephony_log' }}"
 
   parse_offline_log:
     actions:
@@ -107,5 +132,3 @@ stages:
 
           user_agent.original: "{{ parse_description.description.user_agent }}"
           host.name: "{{ parse_description.description.hostname  }}"
-
-        filter: "{{ parsed_event.message.eventtype == 'offline_log' }}"

--- a/Duo/duo-security/tests/test_admin_log.json
+++ b/Duo/duo-security/tests/test_admin_log.json
@@ -7,11 +7,12 @@
     "event": {
       "action": "admin_login",
       "category": [
-        "iam"
+        "authentication"
       ],
       "dataset": "admin_log",
+      "outcome": "success",
       "type": [
-        "admin"
+        "start"
       ]
     },
     "@timestamp": "2024-08-06T09:52:42Z",

--- a/Duo/duo-security/tests/test_admin_log_error.json
+++ b/Duo/duo-security/tests/test_admin_log_error.json
@@ -7,12 +7,13 @@
     "event": {
       "action": "admin_login_error",
       "category": [
-        "iam"
+        "authentication"
       ],
       "dataset": "admin_log",
+      "outcome": "failure",
       "reason": "SAML login is disabled",
       "type": [
-        "admin"
+        "start"
       ]
     },
     "@timestamp": "2020-01-23T16:18:58Z",

--- a/Duo/duo-security/tests/test_auth_log.json
+++ b/Duo/duo-security/tests/test_auth_log.json
@@ -9,8 +9,9 @@
         "authentication"
       ],
       "dataset": "auth_log",
+      "outcome": "success",
       "type": [
-        "info"
+        "start"
       ]
     },
     "@timestamp": "2020-02-13T18:56:20.351346Z",

--- a/Duo/duo-security/tests/test_auth_log_2.json
+++ b/Duo/duo-security/tests/test_auth_log_2.json
@@ -9,8 +9,9 @@
         "authentication"
       ],
       "dataset": "auth_log",
+      "outcome": "success",
       "type": [
-        "info"
+        "start"
       ]
     },
     "@timestamp": "2024-08-06T13:06:35.435426Z",


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/585
Added for admin and auth logs according to https://duo.com/docs/adminapi

Telephone type events don't need "outcome" because they're just showing the fact some 2FA attempt took place.
Offline enrolment logs isn't quite clear to me - they seem to show only enrolment ("o2fa_user_provisioned", "o2fa_user_deprovisioned", or "o2fa_user_reenrolled") not an actual logon attempt