### PR TITLE
PaloAlto: Update Prisma Access format

### DIFF
--- a/Palo Alto Networks/paloalto-prisma-access/_meta/fields.yml
+++ b/Palo Alto Networks/paloalto-prisma-access/_meta/fields.yml
@@ -13,6 +13,11 @@ email.to.address:
   name: email.to.address
   type: keyword
 
+paloalto:
+  description: Root of paloalto custom fields
+  name: paloalto
+  type: dict
+
 paloalto.ContentType:
   description: Paloalto content type
   name: paloalto.ContentType
@@ -253,6 +258,11 @@ paloalto.authentication.method:
   name: paloalto.authentication.method
   type: keyword
 
+paloalto.authentication.profile:
+  description: The authentication profile
+  name: paloalto.authentication.profile
+  type: keyword
+
 paloalto.connection.method:
   description: Identifies how the GlobalProtect app connected to the the Gateway
   name: paloalto.connection.method
@@ -261,6 +271,11 @@ paloalto.connection.method:
 paloalto.connection.stage:
   description: The stage of the GlobalProtect connection
   name: paloalto.connection.stage
+  type: keyword
+
+paloalto.destination.region:
+  description: Destination IP address range
+  name: paloalto.destination.region
   type: keyword
 
 paloalto.dns.category:
@@ -273,13 +288,28 @@ paloalto.endpoint.serial_number:
   name: paloalto.endpoint.serial_number
   type: keyword
 
+paloalto.server.profile:
+  description: The server profile
+  name: paloalto.server.profile
+  type: keyword
+
+paloalto.session.end_reason:
+  description: The session end reason
+  name: paloalto.session.end_reason
+  type: keyword
+
+paloalto.session.id:
+  description: The session id
+  name: paloalto.session.id
+  type: integer
+
 paloalto.source.private.ip:
   description: Private IP address
   name: paloalto.source.private.ip
   type: keyword
 
 paloalto.source.region:
-  description: IP address range
+  description: Source IP address range
   name: paloalto.source.region
   type: keyword
 
@@ -298,6 +328,11 @@ paloalto.threat.name:
   name: paloalto.threat.name
   type: keyword
 
+paloalto.threat.type:
+  description: The type of the threat
+  name: paloalto.threat.type
+  type: keyword
+
 paloalto.tls.chain_status:
   description: The trust in the TLS chain
   name: paloalto.tls.chain_status
@@ -311,4 +346,9 @@ paloalto.tls.root_status:
 paloalto.tls.sni:
   description: The server name indication
   name: paloalto.tls.sni
+  type: keyword
+
+paloalto.vsys:
+  description: the virtual system
+  name: paloalto.vsys
   type: keyword

--- a/Palo Alto Networks/paloalto-prisma-access/_meta/manifest.yml
+++ b/Palo Alto Networks/paloalto-prisma-access/_meta/manifest.yml
@@ -1,6 +1,7 @@
+automation_module_uuid: 64a3b634-605d-4d69-a203-3a53c0474cae
 uuid: 5b885ad1-72fc-4620-8472-f8537d5efcf6
-name: Palo Alto Prisma access Test
-slug: paloalto-prisma-access-test
+name: Palo Alto Prisma access
+slug: paloalto-prisma-access
 description: >-
   Palo Alto Prisma Access is a cloud-delivered security platform that provides secure access to applications and data, using a scalable network to protect users and devices across all locations. It integrates advanced threat prevention and access controls to ensure consistent security policies.
 

--- a/Palo Alto Networks/paloalto-prisma-access/_meta/smart-descriptions.json
+++ b/Palo Alto Networks/paloalto-prisma-access/_meta/smart-descriptions.json
@@ -1,9 +1,61 @@
 [
   {
-    "value": "{event.reason}",
+    "value": "Authentication succeed for user {user.name} connecting to {destination.ip} from {source.ip}",
     "conditions": [
       {
-        "field": "event.reason"
+        "field": "action.name",
+        "value": "auth-success"
+      },
+      {
+        "field": "source.ip"
+      },
+      {
+        "field": "destination.ip"
+      }
+    ]
+  },
+  {
+    "value": "Authentication failed for user {user.name} connecting to {destination.ip} from {source.ip}",
+    "conditions": [
+      {
+        "field": "action.name",
+        "value": "auth-fail"
+      },
+      {
+        "field": "source.ip"
+      },
+      {
+        "field": "destination.ip"
+      }
+    ]
+  },
+  {
+    "value": "Authentication succeed for user {user.name} connecting to {destination.domain} from {source.ip}",
+    "conditions": [
+      {
+        "field": "action.name",
+        "value": "auth-success"
+      },
+      {
+        "field": "source.ip"
+      },
+      {
+        "field": "destination.domain"
+      }
+    ]
+  },
+  {
+    "value": "Authentication failed for user {user.name} connecting to {destination.domain} from {source.ip}",
+    "conditions": [
+      {
+        "field": "action.name",
+        "value": "auth-fail"
+      },
+      {
+        "field": "source.ip"
+      },
+      {
+        "field": "destination.domain"
       }
     ]
   },
@@ -715,6 +767,52 @@
         "source": "source.address",
         "target": "dns.resolved_ip",
         "type": "queried dns resolution for"
+      }
+    ]
+  },
+  {
+    "value": "{user.name} {action.name} the configuration successfully",
+    "conditions": [
+      {
+        "field": "user.name"
+      },
+      {
+        "field": "action.name"
+      },
+      {
+        "field": "event.outcome",
+        "value": "success"
+      },
+      {
+        "field": "event.dataset",
+        "value": "config"
+      }
+    ]
+  },
+  {
+    "value": "{user.name} failed to {action.name} the configuration",
+    "conditions": [
+      {
+        "field": "user.name"
+      },
+      {
+        "field": "action.name"
+      },
+      {
+        "field": "event.outcome",
+        "value": "failure"
+      },
+      {
+        "field": "event.dataset",
+        "value": "config"
+      }
+    ]
+  },
+  {
+    "value": "{event.reason}",
+    "conditions": [
+      {
+        "field": "event.reason"
       }
     ]
   }

--- a/Palo Alto Networks/paloalto-prisma-access/ingest/parser.yml
+++ b/Palo Alto Networks/paloalto-prisma-access/ingest/parser.yml
@@ -315,7 +315,7 @@ pipeline:
           - cpadding
           - ContentType
           - PcapID
-          - FileDigest
+          - FileHash
           - Cloud
           - URLID
           - UserAgent
@@ -543,6 +543,46 @@ pipeline:
           - ClusterName
         delimiter: ","
 
+  # DECRYPTION CONFIG
+  # https://docs.paloaltonetworks.com/pan-os/10-1/pan-os-admin/monitoring/use-syslog-for-monitoring/syslog-field-descriptions/config-log-fields
+  - name: parsed_event
+    filter: "{{parsed_dsv.message.Type == 'CONFIG'}}"
+    external:
+      name: dsv.parse-dsv
+      properties:
+        input_field: original.message
+        output_field: message
+        columnnames:
+          - FutureUse
+          - ReceiveTime
+          - DeviceSN
+          - Type
+          - Subtype
+          - GenerateTime
+          - FutureUse
+          - SourceHostname
+          - VirtualSystemName
+          - Action
+          - SourceUser
+          - Client
+          - Result
+          - ConfigurationPath
+          - BeforeChangeDetail
+          - AfterChangeDetail
+          - SequenceNumber
+          - ActionFlags
+          - DGHierarchyLevel1
+          - DGHierarchyLevel2
+          - DGHierarchyLevel3
+          - DGHierarchyLevel4
+          - VirtualSystemName
+          - DeviceName
+          - DeviceGroup
+          - AuditComment
+          - FutureUse
+          - HighResTimestamp
+        delimiter: ","
+
   - name: parsed_timestamp
     external:
       name: date.parse
@@ -597,10 +637,10 @@ pipeline:
     external:
       name: grok.match
       properties:
+        raise_errors: false
         input_field: "{{parsed_event.message.EventDescription}}"
-        pattern: "%{SYSTEM_AUTH_AUTHENTICATION_FOR}|%{CONNECTION}|%{CONTENT}|%{WILDFIRE}|%{NETWORK}|%{PANDB_GENERIC}|%{CLOUD_ELECTION}|%{AUTHENTICATION}"
+        pattern: "%{CONNECTION}|%{CONTENT}|%{WILDFIRE}|%{NETWORK}|%{PANDB_GENERIC}|%{CLOUD_ELECTION}|%{AUTHENTICATION}|%{REASON}"
         custom_patterns:
-          SYSTEM_AUTH_AUTHENTICATION_FOR: "authenticated for user '%{USERNAME:user}'.   auth profile '%{DATA:auth_profile}', vsys '%{DATA:vsys}', server profile '%{DATA:server_profile}', server address '%{HOSTNAME:server_address}', From: %{IP:src}."
           CONNECTION: "%{CONNECTION_SUCCESS}|%{CONNECTION_TO_SERVER}|%{CONNECTION_REGISTERED}"
           CONNECTION_SUCCESS: "Successfully connect to address: %{IP:dst} port: %{NUMBER:dport}, conn id: %{DATA:connection_id}"
           CONNECTION_TO_SERVER: "Connection to %{DATA} server: %{DATA:dst_addr} completed successfully, initiated by %{IP:src}"
@@ -623,14 +663,37 @@ pipeline:
           AUTHENTICATION: "%{AUTHENTICATION_CONSOLE}|%{AUTHENTICATION_WEB}"
           AUTHENTICATION_CONSOLE: "authenticated for user '%{USERNAME:user}'.   From: %{IP:src}."
           AUTHENTICATION_WEB: "User %{USERNAME:user} logged in via %{DATA} from %{IP:src} using %{DATA:proto}"
+          REASON: "%{REASON1}|%{REASON2}|%{REASON3}|%{REASON4}|%{REASON5}|%{REASON6}|%{REASON7}"
+          REASON1: 'User-ID server monitor %{HOSTNAME:hostname}\(%{WORD:vsys}\) %{GREEDYDATA:message}'
+          REASON2: "ldap cfg %{WORD:config_name} connected to server %{IP:destination_ip}:%{INT:port}, initiated by: %{IP:source_ip}"
+          REASON3: "When authenticating user '?%{WORD:user}'? from '?%{IP:source_ip}'?, a less secure authentication method %{WORD:auth_method} is used. Please migrate to %{WORD:recommended_methods1} or %{DATA:recommended_methods2}. Authentication Profile '?%{WORD:auth_profile}'?, vsys '?%{WORD:vsys}'?, Server Profile '?%{WORD:server_profile}'?, Server Address '?%{IPORHOST:dst}'?"
+          REASON4: "failed authentication for user '?%{USERNAME:user}'?.%{DATA}Reason: %{GREEDYDATA:reason} auth profile '?%{DATA:auth_profile}'?,( vsys '?%{WORD:vsys}'?,)?( server profile '?%{DATA:server_profile}'?,)?( server address '?%{IPORHOST:dst}'?,)?( auth protocol '?%{DATA:auth_protocol}'?,)?( admin role '?%{DATA:admin_role}'?,)? From: '?%{IP:source_ip}'?."
+          REASON5: "authenticated for user '?%{USERNAME:user}'?\\.\\s+auth profile '?%{DATA:auth_profile}'?,( vsys '?%{WORD:vsys}'?,)?( server profile '?%{DATA:server_profile}'?,)?( server address '?%{IPORHOST:dst}'?,)?( auth protocol '?%{DATA:auth_protocol}'?,)?( admin role '?%{DATA:admin_role}'?,)? From: '?%{IP:source_ip}'?\\."
+          REASON6: "failed authentication for user '?%{USERNAME:user}'?.%{DATA}Reason: %{DATA:reason} From: '?%{IP:source_ip}'?."
+          REASON7: "failed authentication for user '?%{USERNAME:user}'?.%{DATA}Reason: %{DATA:reason}"
     filter: '{{parsed_event.message.get("EventDescription") != None}}'
 
   - name: parsed_threat
     external:
       name: grok.match
       properties:
+        raise_errors: false
         input_field: "{{parsed_event.message.Threat_ContentName}}"
         pattern: '%{DATA:threat_description}?\(%{NUMBER:threat_code}\)'
+
+  - name: parsed_ip_range_destination
+    external:
+      name: grok.match
+      properties:
+        input_field: "{{parsed_event.message.DestinationLocation or parsed_event.message.PanOSDestinationLocation}}"
+        pattern: "(%{IP:range_1}-%{IP:range_2})|%{GREEDYDATA:geoname}"
+
+  - name: parsed_ip_range_source
+    external:
+      name: grok.match
+      properties:
+        input_field: "{{parsed_event.message.SourceRegion or parsed_event.message.SourceLocation}}"
+        pattern: "%{IP:range_1}-%{IP:range_2}|%{GREEDYDATA:geoname}"
 
   - name: set_extracted_fields
   - name: set_finalize_user_name
@@ -664,11 +727,11 @@ stages:
   set_action_outcome:
     actions:
       - set:
-          action.outcome: "{{parsed_event.message.Status}}"
-        filter: "{{parsed_event.message.Status != None}}"
-      - set:
           action.outcome: "success"
-        filter: "{{parsed_event.message.Action != null}}"
+        filter: "{{parsed_event.message.get('Action') != None}}"
+      - set:
+          action.outcome: "{{parsed_event.message.Status or parsed_event.message.PanOSEventStatus}}"
+        filter: "{{parsed_event.message.Status != None or parsed_event.message.PanOSEventStatus != None}}"
 
   set_extracted_fields:
     actions:
@@ -682,9 +745,14 @@ stages:
           destination.address: "{{parsed_event.message.DestinationAddress or parsed_event.message.dst or parsed_description.message.dst_addr}}"
           destination.bytes: "{{parsed_event.message.BytesReceived or parsed_event.message.out}}"
           destination.domain: "{{parsed_description.message.dst_domain}}"
+
+      - set:
+          source.ip: "{{parsed_event.message.SourceHostname}}"
+        filter: "{{parsed_event.message.SourceHostname | is_ipaddress}}"
+
       - set:
           destination.ip: "{{parsed_event.message.DestinationAddress}}"
-        filter: "{{parsed_event.message.DestinationAddress| is_ipaddress}}"
+        filter: "{{parsed_event.message.DestinationAddress | is_ipaddress}}"
 
       - set:
           destination.ip: "{{parsed_event.message.dst}}"
@@ -693,6 +761,14 @@ stages:
       - set:
           destination.ip: "{{parsed_description.message.dst}}"
         filter: "{{parsed_description.message.dst  | is_ipaddress}}"
+
+      - set:
+          destination.domain: "{{parsed_description.message.dst}}"
+        filter: "{{parsed_description.message.dst | length > 0 and not parsed_description.message.dst  | is_ipaddress}}"
+
+      - set:
+          destination.ip: "{{parsed_description.message.destination_ip}}"
+        filter: "{{parsed_description.message.destination_ip  | is_ipaddress}}"
 
       - set:
           destination.nat.ip: "{{parsed_event.message.destinationTranslatedAddress}}"
@@ -719,12 +795,20 @@ stages:
         filter: "{{ (parsed_event.message.get('PacketsTotal') != None and (parsed_event.message.PacketsTotal is number or parsed_event.message.PacketsTotal.isdigit())) or (parsed_event.message.get('Packets') != None and (parsed_event.message.Packets is number or parsed_event.message.Packets.isdigit())) }}"
 
       - set:
+          observer.ingress.vlan.name: "{{parsed_event.message.SourceZone}}"
+          observer.egress.vlan.name: "{{parsed_event.message.DestinationZone}}"
+
+      - set:
           event.reason: "{{parsed_event.message.reason or parsed_event.message.EventDescription or parsed_event.message.PanOSConnectionError or parsed_event.message.Description}}"
 
       - set:
           event.reason: "{{ parsed_threat.message.threat_description }}"
           event.code: "{{ parsed_threat.message.threat_code }}"
         filter: "{{ parsed_threat.get('message') != None }}"
+
+      - set:
+          event.reason: "{{ parsed_description.message.reason }}"
+        filter: "{{ parsed_description.message.get('reason') != None }}"
 
       - set:
           destination.port: "{{parsed_event.message.DestinationPort or parsed_event.message.dpt or parsed_description.message.dport}}"
@@ -737,7 +821,7 @@ stages:
           event.dataset: "{{parsed_event.message.DeviceEventClassID|lower or parsed_event.message.Type|lower or parsed_event.message.LogType|lower}}"
           event.module: "{{parsed_description.message.module}}"
           host.hostname: "{{parsed_event.message.dvchost or parsed_event.message.PanOSEndpointDeviceName}}"
-          host.name: "{{parsed_event.message.dvchost or parsed_event.message.PanOSEndpointDeviceName or parsed_event.message.LogSourceName or parsed_event.message.MachineName or parsed_event.message.shost or parsed_event.message.EndpointDeviceName or parsed_event.message.SourceDeviceHost}}"
+          host.name: "{{parsed_event.message.dvchost or parsed_event.message.PanOSEndpointDeviceName or parsed_event.message.LogSourceName or parsed_event.message.MachineName or parsed_event.message.shost or parsed_event.message.EndpointDeviceName or parsed_event.message.SourceDeviceHost or parsed_description.message.hostname}}"
           host.id: "{{parsed_event.message.deviceExternalId or parsed_event.message.HostID}}"
           host.mac: "{{parsed_event.message.PanOSSourceDeviceMac or parsed_event.message.SourceDeviceMac}}"
           host.os.family: "{{parsed_event.message.PanOSSourceDeviceOSFamily}}"
@@ -777,23 +861,16 @@ stages:
       - set:
           file.path: "{{parsed_event.message.URLFilename}}"
           file.name: "{{parsed_event.message.FileName or parsed_event.message.URLFilename or parsed_description.message.filename}}"
+          file.hash.sha256: "{{parsed_event.message.FileHash}}"
         filter: "{{final.action.type != 'url'}}"
 
       - set:
           url.original: "{{parsed_event.message.URL}}"
 
       - set:
-          url.original: "{{parsed_event.message.FileName or parsed_event.message.URLFilename}}"
-          url.domain: '{{final.url.original.split("/")[0].split(":")[0]}}'
-          destination.domain: '{{final.url.original.split("/")[0].split(":")[0]}}'
-          url.port: '{{final.url.original.split("/")[0].split(":")[1]}}'
-          url.path: '{{final.url.original.split("?")[0].split("/")[1:] | join("/")}}'
-          url.query: '{{final.url.original.split("?")[1]}}'
-        filter: "{{final.action.type == 'url'}}"
-
-      - delete:
-          - url.original
-        filter: "{{final.action.type == 'url'}}"
+          url.original: "https://{{parsed_event.message.URL or parsed_event.message.FileName or parsed_event.message.URLFilename}}"
+          destination.domain: '{{final.url.original.split("://")[1].split("/")[0].split(":")[0]}}'
+        filter: "{{final.action.type == 'url' and (parsed_event.message.URL != None or parsed_event.message.FileName != None or parsed_event.message.URLFilename != None)}}"
 
       - set:
           source.ip: "{{parsed_event.message.PublicIPv4}}"
@@ -840,6 +917,10 @@ stages:
         filter: "{{parsed_description.message.src | is_ipaddress}}"
 
       - set:
+          source.ip: "{{parsed_description.message.source_ip}}"
+        filter: "{{parsed_description.message.source_ip | is_ipaddress}}"
+
+      - set:
           source.nat.ip: "{{parsed_event.message.NATSource}}"
         filter: "{{parsed_event.message.NATSource | is_ipaddress}}"
 
@@ -869,9 +950,21 @@ stages:
       - set:
           destination.geo.country_iso_code: "{{parsed_event.message.PanOSDestinationLocation or parsed_event.message.DestinationLocation}}"
         filter: "{{parsed_event.message.DestinationLocation | length == 2 or parsed_event.message.PanOSDestinationLocation | length == 2}}"
+
       - set:
-          action.name: "{{parsed_event.message.EventID or parsed_event.message.PanOSEventIDValue}}"
-        filter: '{{final.action.name == null and (parsed_event.message.EventID not in [null, "0"] or parsed_event.message.PanOSEventIDValue not in [null, "0"])}}'
+          source.geo.name: "{{parsed_event.message.SourceRegion or parsed_event.message.SourceLocation}}"
+        filter: "{{parsed_event.message.SourceLocation | length != 2 and parsed_event.message.PanOSSourceLocation | length != 2 and parsed_ip_range_source.message.get('geoname') != None}}"
+      - set:
+          destination.geo.name: "{{parsed_event.message.PanOSDestinationLocation or parsed_event.message.DestinationLocation}}"
+        filter: "{{(parsed_event.message.DestinationLocation | length != 2 and parsed_event.message.PanOSDestinationLocation | length != 2) and parsed_ip_range_destination.message.get('geoname') != None}}"
+
+      - set:
+          action.name: "{{parsed_event.message.EventID}}"
+        filter: '{{parsed_event.message.EventID not in ["0",0,None]}}'
+
+      - set:
+          action.name: "{{parsed_event.message.PanOSEventIDValue}}"
+        filter: '{{parsed_event.message.PanOSEventIDValue not in ["0",0,None]}}'
 
       - set:
           source.nat.port: "{{parsed_event.message.NATSourcePort or parsed_event.message.sourceTranslatedPort}}"
@@ -882,51 +975,15 @@ stages:
           user_agent.os.name: "{{parsed_event.message.ClientOS}}"
           user_agent.os.version: "{{parsed_event.message.ClientOSVersion}}"
           user.name: "{{parsed_event.message.User or parsed_event.message.suser or parsed_event.message.PanOSSourceUserName or parsed_description.message.user}}"
-          paloalto.ContentType: "{{parsed_event.message.ContentType | replace('\\x00', '')}}"
-          paloalto.DGHierarchyLevel1: "{{parsed_event.message.DGHierarchyLevel1 | replace('\\x00', '')}}"
-          paloalto.DGHierarchyLevel2: "{{parsed_event.message.DGHierarchyLevel2 | replace('\\x00', '')}}"
-          paloalto.DGHierarchyLevel3: "{{parsed_event.message.DGHierarchyLevel3 | replace('\\x00', '')}}"
-          paloalto.DGHierarchyLevel4: "{{parsed_event.message.DGHierarchyLevel4 | replace('\\x00', '')}}"
-          paloalto.DirectionOfAttack: "{{parsed_event.message.DirectionOfAttack | replace('\\x00', '')}}"
-          paloalto.EventID: "{{parsed_event.message.EventID | replace('\\x00', '')}}"
-          paloalto.PanOSContainerName: "{{parsed_event.message.PanOSContainerName | replace('\\x00', '')}}"
-          paloalto.PanOSContainerNameSpace: "{{parsed_event.message.PanOSContainerNameSpace | replace('\\x00', '')}}"
-          paloalto.PanOSDestinationDeviceCategory: "{{parsed_event.message.PanOSDestinationDeviceCategory | replace('\\x00', '')}}"
-          paloalto.PanOSDestinationDeviceHost: "{{parsed_event.message.PanOSDestinationDeviceHost | replace('\\x00', '')}}"
-          paloalto.PanOSDestinationDeviceMac: "{{parsed_event.message.PanOSDestinationDeviceMac | replace('\\x00', '')}}"
-          paloalto.PanOSDestinationDeviceModel: "{{parsed_event.message.PanOSDestinationDeviceModel | replace('\\x00', '')}}"
-          paloalto.PanOSDestinationDeviceOSFamily: "{{parsed_event.message.PanOSDestinationDeviceOSFamily | replace('\\x00', '')}}"
-          paloalto.PanOSDestinationDeviceOSVersion: "{{parsed_event.message.PanOSDestinationDeviceOSVersion | replace('\\x00', '')}}"
-          paloalto.PanOSDestinationDeviceProfile: "{{parsed_event.message.PanOSDestinationDeviceProfile | replace('\\x00', '')}}"
-          paloalto.PanOSDestinationDeviceVendor: "{{parsed_event.message.PanOSDestinationDeviceVendor | replace('\\x00', '')}}"
-          paloalto.PanOSDestinationEDL: "{{parsed_event.message.PanOSDestinationEDL | replace('\\x00', '')}}"
-          paloalto.PanOSDestinationUUID: "{{parsed_event.message.PanOSDestinationUUID | replace('\\x00', '')}}"
-          paloalto.PanOSEndpointSerialNumber: "{{parsed_event.message.PanOSEndpointSerialNumber | replace('\\x00', '')}}"
-          paloalto.PanOSGPHostID: "{{parsed_event.message.PanOSGPHostID | replace('\\x00', '')}}"
-          paloalto.PanOSHASessionOwner: "{{parsed_event.message.PanOSHASessionOwner | replace('\\x00', '')}}"
-          paloalto.PanOSQuarantineReason: "{{parsed_event.message.PanOSQuarantineReason | replace('\\x00', '')}}"
-          paloalto.PanOSSDWANCluster: "{{parsed_event.message.PanOSSDWANCluster | replace('\\x00', '')}}"
-          paloalto.PanOSSDWANClusterType: "{{parsed_event.message.PanOSSDWANClusterType | replace('\\x00', '')}}"
-          paloalto.PanOSSDWANDeviceType: "{{parsed_event.message.PanOSSDWANDeviceType | replace('\\x00', '')}}"
-          paloalto.PanOSSDWANPolicyName: "{{parsed_event.message.PanOSSDWANPolicyName | replace('\\x00', '')}}"
-          paloalto.PanOSSDWANSite: "{{parsed_event.message.PanOSSDWANSite | replace('\\x00', '')}}"
-          paloalto.PanOSSessionStartTime: "{{parsed_event.message.PanOSSessionStartTime | replace('\\x00', '')}}"
-          paloalto.PanOSSourceDeviceHost: "{{parsed_event.message.PanOSSourceDeviceHost | replace('\\x00', '')}}"
-          paloalto.PanOSSourceDeviceModel: "{{parsed_event.message.PanOSSourceDeviceModel | replace('\\x00', '')}}"
-          paloalto.PanOSSourceDeviceProfile: "{{parsed_event.message.PanOSSourceDeviceProfile | replace('\\x00', '')}}"
-          paloalto.PanOSSourceDeviceVendor: "{{parsed_event.message.PanOSSourceDeviceVendor | replace('\\x00', '')}}"
-          paloalto.PanOSSourceDynamicAddressGroup: "{{parsed_event.message.PanOSSourceDynamicAddressGroup | replace('\\x00', '')}}"
-          paloalto.PanOSSourceEDL: "{{parsed_event.message.PanOSSourceEDL | replace('\\x00', '')}}"
-          paloalto.PanOSSourceLocation: "{{parsed_event.message.PanOSSourceLocation | replace('\\x00', '')}}"
-          paloalto.PanOSSourceUUID: "{{parsed_event.message.PanOSSourceUUID | replace('\\x00', '')}}"
-          paloalto.PanOSThreatCategory: "{{parsed_event.message.PanOSThreatCategory | replace('\\x00', '')}}"
-          paloalto.PanOSThreatID: "{{parsed_event.message.PanOSThreatID | replace('\\x00', '')}}"
-          paloalto.PanOSVirtualSystemName: "{{parsed_event.message.PanOSVirtualSystemName | replace('\\x00', '')}}"
-          paloalto.PanOSX-Forwarded-ForIP: "{{parsed_event.message['PanOSX-Forwarded-ForIP'] | replace('\\x00', '')}}"
-          paloalto.URLCategory: "{{parsed_event.message.URLCategory | replace('\\x00', '')}}"
-          paloalto.VirtualLocation: "{{parsed_event.message.VirtualLocation | replace('\\x00', '')}}"
-          paloalto.VirtualSystemID: "{{parsed_event.message.VirtualSystemID | replace('\\x00', '')}}"
-          paloalto.VirtualSystemName: "{{parsed_event.message.VirtualSystemName | replace('\\x00', '')}}"
+          paloalto: >-
+            {
+              {%- for key, value in parsed_event.message.items() -%}
+                {%- if value not in ["null", "", None] -%}                  
+                  {{key|tojson}}: {{(value | replace('\x00', ''))|tojson}},
+                {%- endif -%}
+              {%- endfor -%}
+            }
+
           paloalto.Threat_ContentType: "{{parsed_event.message.Subtype}}"
           paloalto.connection.stage: "{{parsed_event.message.Stage or parsed_event.message.PanOSStage}}"
           paloalto.authentication.method: "{{parsed_event.message.AuthMethod or parsed_event.message.PanOSAuthMethod}}"
@@ -934,9 +991,36 @@ stages:
           paloalto.endpoint.serial_number: "{{parsed_event.message.EndpointSerialNumber or parsed_event.message.PanOSEndpointSerialNumber}}"
           paloalto.threat.id: "{{parsed_event.message.ThreatID or parsed_event.message.PanOSThreatID or parsed_threat.message.threat_code}}"
           paloalto.threat.name: "{{parsed_threat.message.threat_description}}"
+          paloalto.vsys: "{{parsed_description.message.vsys}}"
+          paloalto.authentication.profile: "{{parsed_description.message.auth_profile}}"
+          paloalto.server.profile: "{{parsed_description.message.server_profile}}"
           paloalto.tls.chain_status: "{{parsed_event.message.ChainStatus}}"
           paloalto.tls.root_status: "{{parsed_event.message.RootStatus}}"
           paloalto.tls.sni: "{{parsed_event.message.ServerNameIndication}}"
+          paloalto.session.id: "{{parsed_event.message.SessionID}}"
+          paloalto.session.end_reason: "{{parsed_event.message.SessionEndReason}}"
+      - set:
+          paloalto.threat.type: >
+            {%- set id = parsed_threat.message.threat_code | int -%}
+            {%- if 8000 <= id < 8100 -%}
+            {%- set name = 'scan detection' -%}
+            {%- elif 8500 <= id < 8600 -%}
+            {%- set name = 'flood detection' -%}
+            {%- elif id == 9999 -%}
+            {%- set name = 'URL filtering log' -%}
+            {%- elif 10000 <= id < 20000 -%}
+            {%- set name = 'spyware phone home detection' -%}
+            {%- elif 20000 <= id < 30000 -%}
+            {%- set name = 'spyware download detection' -%}
+            {%- elif 30000 <= id < 45000 -%}
+            {%- set name = 'vulnerability exploit detection' -%}
+            {%- elif 52000 <= id < 53000 -%}
+            {%- set name = 'filetype detection' -%}
+            {%- elif 60000 <= id < 70000 -%}
+            {%- set name = 'data filtering detection' -%}
+            {%- endif -%}
+            {{name | default('custom threat')}}
+        filter: "{{parsed_threat.message.get('threat_code') != None}}"
       - set:
           source.user.name: "{{parsed_event.message.SourceUser}}"
           user.name: "{{parsed_event.message.SourceUser}}"
@@ -949,11 +1033,15 @@ stages:
       - set:
           paloalto.dns.category: "{{parsed_event.message.DNSCategory}}"
           dns.question.type: "{{parsed_event.message.RecordType}}"
-          dns.resolved_ip: "{{parsed_event.message.DNSResponse}}"
 
       - set:
-          paloalto.source.region: "{{parsed_event.message.SourceRegion}}"
-        filter: "{{parsed_event.message.Subtype == 'globalprotect'}}"
+          dns.resolved_ip: >
+            {%- set dns_response = [] -%}
+            {%- for item in parsed_event.message.DNSResponse -%}
+              {%- if item | is_ipaddress -%}{%- set dns_response = dns_response.append(item) -%}{%- endif -%}
+            {%- endfor -%}
+            {%- if dns_response | length > 0 -%}{{ dns_response }}{%- endif -%}
+        filter: '{{parsed_event.message.get("DNSResponse") != None}}'
 
       - set:
           paloalto.source.private.ip: "{{parsed_event.message.PrivateIPv4}}"
@@ -966,24 +1054,32 @@ stages:
       - set:
           threat.indicator.name: "{{parsed_event.message.URL}}"
 
+      - set:
+          paloalto.source.region: "{{parsed_event.message.SourceRegion or parsed_event.message.SourceLocation}}"
+        filter: "{{parsed_ip_range_source.message.get('range_1') != None and parsed_ip_range_source.message.get('range_2') != None}}"
+
+      - set:
+          paloalto.destination.region: "{{parsed_event.message.PanOSDestinationLocation or parsed_event.message.DestinationLocation}}"
+        filter: "{{parsed_ip_range_destination.message.get('range_1') != None and parsed_ip_range_destination.message.get('range_2') != None}}"
+
   set_finalize_user_name:
     actions:
       - set:
-          user.domain: '{{final.user.name.split("\\") | last}}'
-          user.name: '{{final.user.name.split("\\") | first}}'
-        filter: '{{final.user.name != null and "\\" in final.user.name}}'
+          user.domain: '{{final.user.name.split("\\") | first}}'
+          user.name: '{{final.user.name.split("\\") | last}}'
+        filter: '{{final.user.name != None and "\\" in final.user.name}}'
       - set:
-          user.domain: '{{final.user.email.split("@") | first}}'
-          user.name: '{{final.user.email.split("@") | last}}'
-        filter: '{{final.user.email != null and "@" in final.user.email}}'
+          user.domain: '{{final.user.email.split("@") | last}}'
+          user.name: '{{final.user.email.split("@") | first}}'
+        filter: '{{final.user.email != None and "@" in final.user.email}}'
       - set:
           source.user.domain: '{{final.source.user.name.split("\\") | first}}'
           source.user.name: '{{final.source.user.name.split("\\") | last}}'
-        filter: '{{final.source.user.name != null and "\\" in final.source.user.name}}'
+        filter: '{{final.source.user.name != None and "\\" in final.source.user.name}}'
       - set:
           destination.user.domain: '{{final.destination.user.name.split("\\") | first}}'
           destination.user.name: '{{final.destination.user.name.split("\\") | last}}'
-        filter: '{{final.destination.user.name != null and "\\" in final.destination.user.name}}'
+        filter: '{{final.destination.user.name != None and "\\" in final.destination.user.name}}'
 
   set_category_fields:
     actions:

--- a/Palo Alto Networks/paloalto-prisma-access/tests/decryption_cef.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/decryption_cef.json
@@ -62,14 +62,16 @@
       "version": "2.0"
     },
     "paloalto": {
-      "VirtualLocation": "vsys1"
+      "VirtualLocation": "vsys1",
+      "session": {
+        "id": "106112"
+      }
     },
     "related": {
       "ip": [
         "1.1.1.1"
       ],
       "user": [
-        "paloaltonetwork",
         "xxxxx"
       ]
     },
@@ -91,8 +93,8 @@
       }
     },
     "user": {
-      "domain": "xxxxx",
-      "name": "paloaltonetwork"
+      "domain": "paloaltonetwork",
+      "name": "xxxxx"
     }
   }
 }

--- a/Palo Alto Networks/paloalto-prisma-access/tests/file_cef.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/file_cef.json
@@ -69,8 +69,14 @@
       "PanOSSourceLocation": "1.1.1.1-1.1.1.1",
       "URLCategory": "any",
       "VirtualLocation": "smtp",
+      "destination": {
+        "region": "1.1.1.1-1.1.1.1"
+      },
       "endpoint": {
         "serial_number": "xxxxxxxxxxxxxx"
+      },
+      "session": {
+        "id": "4016143"
       }
     },
     "related": {

--- a/Palo Alto Networks/paloalto-prisma-access/tests/fix_bug_with_int.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/fix_bug_with_int.json
@@ -47,13 +47,33 @@
       "transport": "tcp"
     },
     "observer": {
+      "egress": {
+        "vlan": {
+          "name": "INFRA_ADM"
+        }
+      },
+      "ingress": {
+        "vlan": {
+          "name": "PDT_STD"
+        }
+      },
       "name": "FWPA01",
       "product": "PAN-OS",
       "serial_number": "001701003551"
     },
     "paloalto": {
       "Threat_ContentType": "end",
-      "VirtualLocation": "vsys1"
+      "VirtualLocation": "vsys1",
+      "destination": {
+        "region": "10.0.0.0-10.255.255.255"
+      },
+      "session": {
+        "end_reason": "tcp-fin",
+        "id": "234981"
+      },
+      "source": {
+        "region": "10.0.0.0-10.255.255.255"
+      }
     },
     "related": {
       "ip": [
@@ -62,7 +82,6 @@
         "5.6.7.8"
       ],
       "user": [
-        "domain",
         "pusername",
         "userdest"
       ]
@@ -87,8 +106,8 @@
       }
     },
     "user": {
-      "domain": "pusername",
-      "name": "domain"
+      "domain": "domain",
+      "name": "pusername"
     }
   }
 }

--- a/Palo Alto Networks/paloalto-prisma-access/tests/fix_bug_without_int.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/fix_bug_without_int.json
@@ -47,13 +47,33 @@
       "transport": "tcp"
     },
     "observer": {
+      "egress": {
+        "vlan": {
+          "name": "INFRA_ADM"
+        }
+      },
+      "ingress": {
+        "vlan": {
+          "name": "PDT_STD"
+        }
+      },
       "name": "FWPA01",
       "product": "PAN-OS",
       "serial_number": "001701003551"
     },
     "paloalto": {
       "Threat_ContentType": "end",
-      "VirtualLocation": "vsys1"
+      "VirtualLocation": "vsys1",
+      "destination": {
+        "region": "10.0.0.0-10.255.255.255"
+      },
+      "session": {
+        "end_reason": "tcp-fin",
+        "id": "234981"
+      },
+      "source": {
+        "region": "10.0.0.0-10.255.255.255"
+      }
     },
     "related": {
       "ip": [

--- a/Palo Alto Networks/paloalto-prisma-access/tests/globalprotect_cef.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/globalprotect_cef.json
@@ -9,6 +9,7 @@
         "session"
       ],
       "dataset": "globalprotect",
+      "outcome": "failure",
       "reason": "Client cert not present",
       "severity": 3,
       "start": "2021-03-01T20:35:54Z",
@@ -20,6 +21,7 @@
     "@timestamp": "2021-03-01T20:35:54Z",
     "action": {
       "name": "satellite-gateway-update-route",
+      "outcome": "failure",
       "type": "globalprotect"
     },
     "host": {

--- a/Palo Alto Networks/paloalto-prisma-access/tests/globalprotect_csv_2.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/globalprotect_csv_2.json
@@ -47,7 +47,6 @@
         "88.120.236.74"
       ],
       "user": [
-        "example.org",
         "test"
       ]
     },
@@ -63,8 +62,8 @@
       }
     },
     "user": {
-      "domain": "test",
-      "name": "example.org"
+      "domain": "example.org",
+      "name": "test"
     },
     "user_agent": {
       "os": {

--- a/Palo Alto Networks/paloalto-prisma-access/tests/icmp_allow_csv.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/icmp_allow_csv.json
@@ -25,6 +25,9 @@
     "destination": {
       "address": "4.3.2.1",
       "bytes": 0,
+      "geo": {
+        "name": "France"
+      },
       "ip": "4.3.2.1",
       "nat": {
         "ip": "10.0.1.2",
@@ -44,13 +47,27 @@
       "transport": "icmp"
     },
     "observer": {
+      "egress": {
+        "vlan": {
+          "name": "Zone1"
+        }
+      },
+      "ingress": {
+        "vlan": {
+          "name": "AAAAA"
+        }
+      },
       "name": "PA",
       "product": "PAN-OS",
       "serial_number": "1801017000"
     },
     "paloalto": {
       "Threat_ContentType": "start",
-      "VirtualLocation": "vsys"
+      "VirtualLocation": "vsys",
+      "session": {
+        "end_reason": "n/a",
+        "id": "24100"
+      }
     },
     "related": {
       "ip": [
@@ -65,6 +82,9 @@
     "source": {
       "address": "1.2.3.4",
       "bytes": 222,
+      "geo": {
+        "name": "Spain"
+      },
       "ip": "1.2.3.4",
       "nat": {
         "ip": "1.2.3.4",

--- a/Palo Alto Networks/paloalto-prisma-access/tests/network_threat_alert_1.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/network_threat_alert_1.json
@@ -65,7 +65,10 @@
       "DirectionOfAttack": "client to server",
       "Threat_ContentType": "url",
       "URLCategory": "computer-and-internet-info",
-      "VirtualLocation": "vsys1"
+      "VirtualLocation": "vsys1",
+      "session": {
+        "id": 155600
+      }
     },
     "related": {
       "hosts": [
@@ -84,6 +87,9 @@
     },
     "source": {
       "address": "1.2.3.4",
+      "geo": {
+        "name": "AZURE-EU-WEST-CBS-BELLEM"
+      },
       "ip": "1.2.3.4",
       "nat": {
         "ip": "4.3.2.1",
@@ -98,7 +104,10 @@
     },
     "url": {
       "domain": "www.example.org",
+      "original": "https://www.example.org",
+      "port": 443,
       "registered_domain": "example.org",
+      "scheme": "https",
       "subdomain": "www",
       "top_level_domain": "org"
     }

--- a/Palo Alto Networks/paloalto-prisma-access/tests/network_threat_alert_2.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/network_threat_alert_2.json
@@ -71,7 +71,13 @@
       "DirectionOfAttack": "client to server",
       "Threat_ContentType": "url",
       "URLCategory": "computer-and-internet-info",
-      "VirtualLocation": "vsys1"
+      "VirtualLocation": "vsys1",
+      "session": {
+        "id": 1787364
+      },
+      "source": {
+        "region": "10.0.0.0-10.255.255.255"
+      }
     },
     "related": {
       "hosts": [
@@ -84,7 +90,7 @@
         "8.7.6.5"
       ],
       "user": [
-        "example.org",
+        "jdoe",
         "jdoe@example.org"
       ]
     },
@@ -111,15 +117,18 @@
     },
     "url": {
       "domain": "www.example.com",
-      "path": "connecttest.txt",
+      "original": "https://www.example.com/connecttest.txt",
+      "path": "/connecttest.txt",
+      "port": 443,
       "registered_domain": "example.com",
+      "scheme": "https",
       "subdomain": "www",
       "top_level_domain": "com"
     },
     "user": {
-      "domain": "jdoe",
+      "domain": "example.org",
       "email": "jdoe@example.org",
-      "name": "example.org"
+      "name": "jdoe"
     },
     "user_agent": {
       "name": "Microsoft NCSI"

--- a/Palo Alto Networks/paloalto-prisma-access/tests/system_csv.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/system_csv.json
@@ -19,6 +19,11 @@
       "name": "auth-success",
       "type": "auth"
     },
+    "destination": {
+      "address": "srv01.entreprise.local",
+      "domain": "srv01.entreprise.local",
+      "subdomain": "srv01.entreprise"
+    },
     "log": {
       "hostname": "fw1",
       "level": "informational",
@@ -35,9 +40,19 @@
       "DGHierarchyLevel3": "0",
       "DGHierarchyLevel4": "0",
       "EventID": "auth-success",
-      "Threat_ContentType": "auth"
+      "Threat_ContentType": "auth",
+      "authentication": {
+        "profile": "GP"
+      },
+      "server": {
+        "profile": "LDAP"
+      },
+      "vsys": "vsys123"
     },
     "related": {
+      "hosts": [
+        "srv01.entreprise.local"
+      ],
       "ip": [
         "1.2.3.4"
       ],

--- a/Palo Alto Networks/paloalto-prisma-access/tests/tcp_allow_csv.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/tcp_allow_csv.json
@@ -44,13 +44,33 @@
       "transport": "tcp"
     },
     "observer": {
+      "egress": {
+        "vlan": {
+          "name": "zone1"
+        }
+      },
+      "ingress": {
+        "vlan": {
+          "name": "v10213"
+        }
+      },
       "name": "PP",
       "product": "PAN-OS",
       "serial_number": "1801016000"
     },
     "paloalto": {
       "Threat_ContentType": "start",
-      "VirtualLocation": "vsys1234"
+      "VirtualLocation": "vsys1234",
+      "destination": {
+        "region": "10.0.0.0-10.255.255.255"
+      },
+      "session": {
+        "end_reason": "n/a",
+        "id": "60000"
+      },
+      "source": {
+        "region": "10.0.0.0-10.255.255.255"
+      }
     },
     "related": {
       "ip": [

--- a/Palo Alto Networks/paloalto-prisma-access/tests/test_decryption_csv.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/test_decryption_csv.json
@@ -45,6 +45,16 @@
       "transport": "tcp"
     },
     "observer": {
+      "egress": {
+        "vlan": {
+          "name": "INTERNET"
+        }
+      },
+      "ingress": {
+        "vlan": {
+          "name": "VPN-SSL"
+        }
+      },
       "name": "NFW-OUT-DCA",
       "product": "PAN-OS",
       "serial_number": "111111111111"
@@ -57,6 +67,9 @@
       "Threat_ContentType": "0",
       "VirtualLocation": "vsys1",
       "VirtualSystemID": "1",
+      "session": {
+        "id": "2020391"
+      },
       "tls": {
         "chain_status": "Uninspected",
         "root_status": "uninspected"

--- a/Palo Alto Networks/paloalto-prisma-access/tests/test_decryption_json.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/test_decryption_json.json
@@ -59,6 +59,9 @@
     "paloalto": {
       "Threat_ContentType": "start",
       "VirtualLocation": "vsys1",
+      "session": {
+        "id": 2222222
+      },
       "tls": {
         "chain_status": "Trusted",
         "root_status": "trusted",
@@ -76,7 +79,6 @@
         "8.7.6.5"
       ],
       "user": [
-        "example",
         "jdoe"
       ]
     },
@@ -112,8 +114,8 @@
       "version": "1.2"
     },
     "user": {
-      "domain": "jdoe",
-      "name": "example"
+      "domain": "example",
+      "name": "jdoe"
     }
   }
 }

--- a/Palo Alto Networks/paloalto-prisma-access/tests/test_file_alert_json.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/test_file_alert_json.json
@@ -67,7 +67,10 @@
       "DirectionOfAttack": "server to client",
       "Threat_ContentType": "file",
       "URLCategory": "computer-and-internet-info",
-      "VirtualLocation": "vsys1"
+      "VirtualLocation": "vsys1",
+      "session": {
+        "id": 1450762
+      }
     },
     "related": {
       "ip": [
@@ -76,7 +79,7 @@
         "9.10.11.12"
       ],
       "user": [
-        "example.com",
+        "john.doe",
         "john.doe@example.com"
       ]
     },
@@ -86,6 +89,9 @@
     },
     "source": {
       "address": "1.2.3.4",
+      "geo": {
+        "name": "Prisma-Mobile-Users-EMEA"
+      },
       "ip": "1.2.3.4",
       "nat": {
         "ip": "9.10.11.12",
@@ -97,9 +103,9 @@
       }
     },
     "user": {
-      "domain": "john.doe",
+      "domain": "example.com",
       "email": "john.doe@example.com",
-      "name": "example.com"
+      "name": "john.doe"
     }
   }
 }

--- a/Palo Alto Networks/paloalto-prisma-access/tests/test_globalprotect.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/test_globalprotect.json
@@ -50,8 +50,7 @@
         "1.2.3.4"
       ],
       "user": [
-        "JDOE",
-        "test.fr"
+        "JDOE"
       ]
     },
     "source": {
@@ -66,8 +65,8 @@
       }
     },
     "user": {
-      "domain": "JDOE",
-      "name": "test.fr"
+      "domain": "test.fr",
+      "name": "JDOE"
     },
     "user_agent": {
       "os": {

--- a/Palo Alto Networks/paloalto-prisma-access/tests/test_hipmatch_json.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/test_hipmatch_json.json
@@ -53,7 +53,7 @@
         "1.2.3.4"
       ],
       "user": [
-        "example.org",
+        "jdoe",
         "jdoe@example.org"
       ]
     },
@@ -68,9 +68,9 @@
       }
     },
     "user": {
-      "domain": "jdoe",
+      "domain": "example.org",
       "email": "jdoe@example.org",
-      "name": "example.org"
+      "name": "jdoe"
     }
   }
 }

--- a/Palo Alto Networks/paloalto-prisma-access/tests/test_ldap_brute_force.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/test_ldap_brute_force.json
@@ -46,6 +46,16 @@
       "transport": "tcp"
     },
     "observer": {
+      "egress": {
+        "vlan": {
+          "name": "LAN"
+        }
+      },
+      "ingress": {
+        "vlan": {
+          "name": "VPN"
+        }
+      },
       "name": "hostname_example",
       "product": "PAN-OS",
       "serial_number": "012001002253"
@@ -57,9 +67,19 @@
       "DGHierarchyLevel4": "0",
       "Threat_ContentType": "vulnerability",
       "VirtualLocation": "vsys1",
+      "destination": {
+        "region": "172.16.0.0-172.31.255.255"
+      },
+      "session": {
+        "id": "110079"
+      },
+      "source": {
+        "region": "192.168.0.0-192.168.255.255"
+      },
       "threat": {
         "id": "40005",
-        "name": "LDAP: User Login Brute Force Attempt"
+        "name": "LDAP: User Login Brute Force Attempt",
+        "type": "vulnerability exploit detection"
       }
     },
     "related": {

--- a/Palo Alto Networks/paloalto-prisma-access/tests/test_new_file_type.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/test_new_file_type.json
@@ -80,7 +80,13 @@
       "DirectionOfAttack": "server to client",
       "Threat_ContentType": "file",
       "URLCategory": "business-and-economy",
-      "VirtualLocation": "vsys1"
+      "VirtualLocation": "vsys1",
+      "session": {
+        "id": 6111111
+      },
+      "source": {
+        "region": "1.2.0.0-1.2.255.255"
+      }
     },
     "related": {
       "ip": [

--- a/Palo Alto Networks/paloalto-prisma-access/tests/test_new_threat_type.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/test_new_threat_type.json
@@ -69,6 +69,12 @@
       "DirectionOfAttack": "client to server",
       "Threat_ContentType": "vulnerability",
       "VirtualLocation": "vsys1",
+      "session": {
+        "id": 72837
+      },
+      "source": {
+        "region": "1.0.0.0-1.255.255.255"
+      },
       "threat": {
         "category": "brute-force",
         "id": "SSH User Authentication Brute Force Attempt(40015)"

--- a/Palo Alto Networks/paloalto-prisma-access/tests/test_new_url_type.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/test_new_url_type.json
@@ -71,7 +71,13 @@
       "DirectionOfAttack": "client to server",
       "Threat_ContentType": "url",
       "URLCategory": "computer-and-internet-info",
-      "VirtualLocation": "vsys1"
+      "VirtualLocation": "vsys1",
+      "session": {
+        "id": 816808
+      },
+      "source": {
+        "region": "19.18.0.0-19.18.255.255"
+      }
     },
     "related": {
       "hosts": [
@@ -103,7 +109,11 @@
     },
     "url": {
       "domain": "test.gstatic.com",
+      "original": "https://test.gstatic.com/",
+      "path": "/",
+      "port": 443,
       "registered_domain": "gstatic.com",
+      "scheme": "https",
       "subdomain": "test",
       "top_level_domain": "com"
     }

--- a/Palo Alto Networks/paloalto-prisma-access/tests/test_threat.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/test_threat.json
@@ -25,6 +25,9 @@
     "destination": {
       "address": "5.6.7.8",
       "domain": "test.fr",
+      "geo": {
+        "name": "France"
+      },
       "ip": "5.6.7.8",
       "nat": {
         "ip": "0.0.0.0",
@@ -42,6 +45,16 @@
       "transport": "tcp"
     },
     "observer": {
+      "egress": {
+        "vlan": {
+          "name": "test-Externe"
+        }
+      },
+      "ingress": {
+        "vlan": {
+          "name": "Outside"
+        }
+      },
       "name": "TEST-01",
       "product": "PAN-OS",
       "serial_number": "016201000000"
@@ -53,8 +66,12 @@
       "DGHierarchyLevel4": "0",
       "Threat_ContentType": "url",
       "VirtualLocation": "vsys1",
+      "session": {
+        "id": "200000"
+      },
       "threat": {
-        "id": "9999"
+        "id": "9999",
+        "type": "URL filtering log"
       }
     },
     "related": {
@@ -86,8 +103,11 @@
     },
     "url": {
       "domain": "test.fr",
+      "original": "https://test.fr:9999/",
+      "path": "/",
       "port": 9999,
       "registered_domain": "test.fr",
+      "scheme": "https",
       "top_level_domain": "fr"
     }
   }

--- a/Palo Alto Networks/paloalto-prisma-access/tests/test_threat_02.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/test_threat_02.json
@@ -31,6 +31,9 @@
     },
     "destination": {
       "address": "5.6.7.8",
+      "geo": {
+        "name": "France"
+      },
       "ip": "5.6.7.8",
       "nat": {
         "ip": "5.6.7.8",
@@ -52,6 +55,16 @@
       "transport": "tcp"
     },
     "observer": {
+      "egress": {
+        "vlan": {
+          "name": "INTERNET"
+        }
+      },
+      "ingress": {
+        "vlan": {
+          "name": "INTERNET"
+        }
+      },
       "name": "site1-FW01",
       "product": "PAN-OS",
       "serial_number": "012345678910"
@@ -63,9 +76,13 @@
       "DGHierarchyLevel4": "0",
       "Threat_ContentType": "vulnerability",
       "VirtualLocation": "vsys1",
+      "session": {
+        "id": "113535"
+      },
       "threat": {
         "id": "95187",
-        "name": "Palo Alto Networks GlobalProtect OS Command Injection Vulnerability"
+        "name": "Palo Alto Networks GlobalProtect OS Command Injection Vulnerability",
+        "type": "custom threat"
       }
     },
     "related": {
@@ -80,6 +97,9 @@
     },
     "source": {
       "address": "1.2.3.4",
+      "geo": {
+        "name": "United States"
+      },
       "ip": "1.2.3.4",
       "nat": {
         "ip": "1.2.3.4",

--- a/Palo Alto Networks/paloalto-prisma-access/tests/test_traffic_event_1_json.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/test_traffic_event_1_json.json
@@ -65,7 +65,14 @@
       "DGHierarchyLevel4": "0",
       "Threat_ContentType": "end",
       "URLCategory": "any",
-      "VirtualLocation": "vsys1"
+      "VirtualLocation": "vsys1",
+      "session": {
+        "end_reason": "aged-out",
+        "id": 17635
+      },
+      "source": {
+        "region": "1.2.0.0-1.2.255.255"
+      }
     },
     "related": {
       "ip": [

--- a/Palo Alto Networks/paloalto-prisma-access/tests/test_traffic_event_2_json.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/test_traffic_event_2_json.json
@@ -65,7 +65,14 @@
       "DGHierarchyLevel4": "0",
       "Threat_ContentType": "end",
       "URLCategory": "any",
-      "VirtualLocation": "vsys1"
+      "VirtualLocation": "vsys1",
+      "session": {
+        "end_reason": "aged-out",
+        "id": 17634
+      },
+      "source": {
+        "region": "1.2.0.0-1.2.255.255"
+      }
     },
     "related": {
       "ip": [

--- a/Palo Alto Networks/paloalto-prisma-access/tests/test_userid.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/test_userid.json
@@ -44,7 +44,7 @@
         "1.2.3.4"
       ],
       "user": [
-        "test.fr"
+        "JDOE"
       ]
     },
     "source": {
@@ -53,8 +53,8 @@
       "port": 0
     },
     "user": {
-      "domain": "JDOE",
-      "name": "test.fr"
+      "domain": "test.fr",
+      "name": "JDOE"
     }
   }
 }

--- a/Palo Alto Networks/paloalto-prisma-access/tests/threat-url-xff.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/threat-url-xff.json
@@ -54,6 +54,16 @@
       "transport": "tcp"
     },
     "observer": {
+      "egress": {
+        "vlan": {
+          "name": "zone2"
+        }
+      },
+      "ingress": {
+        "vlan": {
+          "name": "env"
+        }
+      },
       "name": "FW",
       "product": "PAN-OS",
       "serial_number": "016401004874"
@@ -66,8 +76,18 @@
       "Threat_ContentType": "url",
       "VirtualLocation": "vsys",
       "VirtualSystemName": "VSYS",
+      "destination": {
+        "region": "192.168.0.0-192.168.255.255"
+      },
+      "session": {
+        "id": "1384927"
+      },
+      "source": {
+        "region": "10.0.0.0-10.255.255.255"
+      },
       "threat": {
-        "id": "9999"
+        "id": "9999",
+        "type": "URL filtering log"
       }
     },
     "related": {
@@ -95,10 +115,12 @@
     },
     "url": {
       "domain": "www.sekoia.io",
-      "path": "catalog/integrations",
+      "original": "https://www.sekoia.io:443/catalog/integrations?query=this",
+      "path": "/catalog/integrations",
       "port": 443,
       "query": "query=this",
       "registered_domain": "sekoia.io",
+      "scheme": "https",
       "subdomain": "www",
       "top_level_domain": "io"
     },

--- a/Palo Alto Networks/paloalto-prisma-access/tests/threat_cef.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/threat_cef.json
@@ -87,10 +87,14 @@
       "PanOSSourceDeviceProfile": "x-profile",
       "PanOSSourceDeviceVendor": "Lenovo",
       "PanOSSourceLocation": "LY",
+      "PanOSThreatCategory": "unknown",
       "PanOSThreatID": "27379(27379)",
       "VirtualLocation": "vsys1",
       "endpoint": {
         "serial_number": "xxxxxxxxxxxxxx"
+      },
+      "session": {
+        "id": "947181"
       },
       "threat": {
         "id": "27379(27379)"

--- a/Palo Alto Networks/paloalto-prisma-access/tests/threat_csv.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/threat_csv.json
@@ -46,6 +46,16 @@
       "transport": "tcp"
     },
     "observer": {
+      "egress": {
+        "vlan": {
+          "name": "zone2"
+        }
+      },
+      "ingress": {
+        "vlan": {
+          "name": "env"
+        }
+      },
       "name": "FW",
       "product": "PAN-OS",
       "serial_number": "001701000000"
@@ -57,9 +67,19 @@
       "DGHierarchyLevel4": "0",
       "Threat_ContentType": "vulnerability",
       "VirtualLocation": "vsys",
+      "destination": {
+        "region": "10.0.0.0-10.255.255.255"
+      },
+      "session": {
+        "id": "279429"
+      },
+      "source": {
+        "region": "10.0.0.0-10.255.255.255"
+      },
       "threat": {
         "id": "34805",
-        "name": "PDF Exploit Evasion Found"
+        "name": "PDF Exploit Evasion Found",
+        "type": "vulnerability exploit detection"
       }
     },
     "related": {

--- a/Palo Alto Networks/paloalto-prisma-access/tests/traffic1_csv.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/traffic1_csv.json
@@ -76,7 +76,10 @@
       "PanOSSessionStartTime": "Jul 31 2022 12:43:06",
       "PanOSSourceLocation": "10.0.0.0-10.255.255.255",
       "URLCategory": "computer-and-internet-info",
-      "VirtualLocation": "vsys1"
+      "VirtualLocation": "vsys1",
+      "session": {
+        "id": "595456"
+      }
     },
     "related": {
       "hosts": [

--- a/Palo Alto Networks/paloalto-prisma-access/tests/traffic2_csv.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/traffic2_csv.json
@@ -76,7 +76,10 @@
       "PanOSSessionStartTime": "Aug 02 2022 06:41:44",
       "PanOSSourceLocation": "10.0.0.0-10.255.255.255",
       "URLCategory": "low-risk",
-      "VirtualLocation": "vsys1"
+      "VirtualLocation": "vsys1",
+      "session": {
+        "id": "689028"
+      }
     },
     "related": {
       "hosts": [

--- a/Palo Alto Networks/paloalto-prisma-access/tests/traffic_cef.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/traffic_cef.json
@@ -103,6 +103,9 @@
       "VirtualLocation": "vsys1",
       "endpoint": {
         "serial_number": "xxxxxxxxxxxxxx"
+      },
+      "session": {
+        "id": "25596"
       }
     },
     "related": {

--- a/Palo Alto Networks/paloalto-prisma-access/tests/traffic_with_resotimestamp.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/traffic_with_resotimestamp.json
@@ -25,6 +25,9 @@
     "destination": {
       "address": "5.6.7.8",
       "bytes": 5015,
+      "geo": {
+        "name": "United States"
+      },
       "ip": "5.6.7.8",
       "nat": {
         "ip": "0.0.0.0",
@@ -44,13 +47,30 @@
       "transport": "tcp"
     },
     "observer": {
+      "egress": {
+        "vlan": {
+          "name": "Z_INTERCO_WAN"
+        }
+      },
+      "ingress": {
+        "vlan": {
+          "name": "Z_DMZ_PROXY"
+        }
+      },
       "name": "PA2314-CD",
       "product": "PAN-OS",
       "serial_number": "026701002040"
     },
     "paloalto": {
       "Threat_ContentType": "end",
-      "VirtualLocation": "vsys1"
+      "VirtualLocation": "vsys1",
+      "session": {
+        "end_reason": "tcp-fin",
+        "id": "219781"
+      },
+      "source": {
+        "region": "10.0.0.0-10.255.255.255"
+      }
     },
     "related": {
       "ip": [

--- a/Palo Alto Networks/paloalto-prisma-access/tests/udp_deny_csv.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/udp_deny_csv.json
@@ -25,6 +25,9 @@
     "destination": {
       "address": "1.2.3.4",
       "bytes": 0,
+      "geo": {
+        "name": "Spain"
+      },
       "ip": "1.2.3.4",
       "nat": {
         "ip": "5.4.3.2",
@@ -44,13 +47,30 @@
       "transport": "udp"
     },
     "observer": {
+      "egress": {
+        "vlan": {
+          "name": "AAAAA"
+        }
+      },
+      "ingress": {
+        "vlan": {
+          "name": "DNS"
+        }
+      },
       "name": "PA-1",
       "product": "PAN-OS",
       "serial_number": "1801017000"
     },
     "paloalto": {
       "Threat_ContentType": "deny",
-      "VirtualLocation": "vsys1"
+      "VirtualLocation": "vsys1",
+      "session": {
+        "end_reason": "policy-deny",
+        "id": "11111"
+      },
+      "source": {
+        "region": "10.0.0.0-10.255.255.255"
+      }
     },
     "related": {
       "ip": [

--- a/Palo Alto Networks/paloalto-prisma-access/tests/url_cef.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/url_cef.json
@@ -98,6 +98,9 @@
       "VirtualLocation": "vsys1",
       "endpoint": {
         "serial_number": "xxxxxxxxxxxxxx"
+      },
+      "session": {
+        "id": "980296"
       }
     },
     "related": {
@@ -127,6 +130,11 @@
       "user": {
         "name": "xxxxx xxxxx"
       }
+    },
+    "url": {
+      "original": "https://",
+      "port": 443,
+      "scheme": "https"
     },
     "user": {
       "name": "xxxxx xxxxx"

--- a/Palo Alto Networks/paloalto-prisma-access/tests/wildfire1_json.json
+++ b/Palo Alto Networks/paloalto-prisma-access/tests/wildfire1_json.json
@@ -34,6 +34,9 @@
       "port": 80
     },
     "file": {
+      "hash": {
+        "sha256": "adc83b19e793491b1c6ea0fd8b46cd9f32e592fc"
+      },
       "name": "mp3.exe"
     },
     "log": {
@@ -70,11 +73,20 @@
       "endpoint": {
         "serial_number": "xxxxxxxxxxx"
       },
+      "session": {
+        "id": 444444
+      },
+      "source": {
+        "region": "10.0.0.0-10.255.255.255"
+      },
       "threat": {
         "id": "Windows Executable (EXE)(52020)"
       }
     },
     "related": {
+      "hash": [
+        "adc83b19e793491b1c6ea0fd8b46cd9f32e592fc"
+      ],
       "ip": [
         "1.2.3.4",
         "4.3.2.1",
@@ -82,7 +94,7 @@
         "8.7.6.5"
       ],
       "user": [
-        "example.org",
+        "john.doe",
         "john.doe@example.org"
       ]
     },
@@ -103,9 +115,9 @@
       }
     },
     "user": {
-      "domain": "john.doe",
+      "domain": "example.org",
       "email": "john.doe@example.org",
-      "name": "example.org"
+      "name": "john.doe"
     }
   }
 }


### PR DESCRIPTION
Update the prisma access format according to the latest changes on NGFW

## Summary by Sourcery

Update Prisma Access parser to align with latest NGFW format changes by renaming fields, adding new parsing stages, enriching metadata, and updating schema definitions.

New Features:
- Add CONFIG log decryption parser with detailed DSV column mapping
- Support IP range parsing for source/destination and associated geo names
- Construct full URL original fields and improve domain extraction logic
- Dynamically consolidate all paloalto.* fields into a JSON dict for extensibility

Enhancements:
- Rename FileDigest to FileHash and map it to file.hash.sha256
- Enhance grok matching with new REASON patterns and suppress parsing errors
- Introduce observer VLAN fields and refine host.name and user/domain resolution logic
- Add dynamic threat.type mapping and new metadata fields (authentication.profile, server.profile, session.id, session.end_reason, vsys)