### PR TITLE
PaloAlto: fix the identifier of the format

### DIFF
--- a/Palo Alto Networks/paloalto-prisma-access/_meta/manifest.yml
+++ b/Palo Alto Networks/paloalto-prisma-access/_meta/manifest.yml
@@ -1,5 +1,5 @@
 automation_module_uuid: 64a3b634-605d-4d69-a203-3a53c0474cae
-uuid: 5b885ad1-72fc-4620-8472-f8537d5efcf6
+uuid: ea265b9d-fb48-4e92-9c26-dcfbf937b630
 name: Palo Alto Prisma access
 slug: paloalto-prisma-access
 description: >-


### PR DESCRIPTION
revert 3d21cf91cf7d0738cc04e289468b7132180a577d

## Summary by Sourcery

Bug Fixes:
- Correct the module UUID in the Palo Alto Prisma Access manifest