### PR TITLE
HornetSecurity: remove email.attachment 

### DIFF
--- a/Hornetsecurity/hornetsecurity-spam-malware-protection/ingest/parser.yml
+++ b/Hornetsecurity/hornetsecurity-spam-malware-protection/ingest/parser.yml
@@ -68,7 +68,3 @@ stages:
       - set:
           hornetsecurity.spam_malware_protection.size: "{{ parse_event.message.size.value }} {{ parse_event.message.size.unit }}"
         filter: "{{ parse_event.message.size.get('value') != None and parse_event.message.size.get('unit') != None }}"
-
-      - set:
-          email.attachments: "{{ parse_event.message.attachments }}"
-        filter: "{{ parse_event.message.attachments not in [null, '', 'no'] }}"

--- a/Hornetsecurity/hornetsecurity-spam-malware-protection/tests/test_event_incoming.json
+++ b/Hornetsecurity/hornetsecurity-spam-malware-protection/tests/test_event_incoming.json
@@ -26,7 +26,6 @@
       "ip": "5.6.7.8"
     },
     "email": {
-      "attachments": [],
       "direction": "Incoming",
       "from": {
         "address": [

--- a/Hornetsecurity/hornetsecurity-spam-malware-protection/tests/test_event_outgoing.json
+++ b/Hornetsecurity/hornetsecurity-spam-malware-protection/tests/test_event_outgoing.json
@@ -26,7 +26,6 @@
       "ip": "5.6.7.8"
     },
     "email": {
-      "attachments": [],
       "direction": "Outgoing",
       "from": {
         "address": [


### PR DESCRIPTION
AS we are unable to know the content of the attachment array, in the samples we got, I remove this field.
We will set it later when we have more information about it.