### PR TITLE
PaloAlto - fix event.outcome

### DIFF
--- a/Palo Alto Networks/paloalto-ngfw/ingest/parser.yml
+++ b/Palo Alto Networks/paloalto-ngfw/ingest/parser.yml
@@ -703,6 +703,7 @@ pipeline:
   - name: set_ecs_deviceInboundInterface
     filter: '{{parsed_event.message.get("deviceInboundInterface") != None}}'
   - name: set_action_outcome
+  - name: set_event_outcome
   - name: set_csv_severity
 
 stages:
@@ -732,6 +733,32 @@ stages:
       - set:
           action.outcome: "{{parsed_event.message.Status or parsed_event.message.PanOSEventStatus}}"
         filter: "{{parsed_event.message.Status != None or parsed_event.message.PanOSEventStatus != None}}"
+
+  set_event_outcome:
+    actions:
+      - set:
+          event.outcome: "failure"
+        filter: "{{ 'failed authentication' in parsed_event.message.EventDescription }}"
+
+      - set:
+          event.outcome: "success"
+        filter: "{{ 'authenticated for user' in parsed_event.message.EventDescription }}"
+
+      - set:
+          event.outcome: "success"
+        filter: "{{parsed_event.message.EventID == 'auth-success' and 'failed' not in parsed_event.message.EventDescription}}"
+
+      - set:
+          event.outcome: "success"
+        filter: "{{parsed_event.message.Type == 'USERID' and parsed_event.message.Subtype in ('login', 'logout')}}"
+
+      - set:
+          event.outcome: "success"
+        filter: "{{parsed_event.message.DeviceEventClassID == 'USERID' and parsed_event.message.Name in ('login', 'logout')}}"
+
+      - set:
+          event.outcome: "failure"
+        filter: "{{'Invalid' in parsed_event.message.msg}}"
 
   set_extracted_fields:
     actions:

--- a/Palo Alto Networks/paloalto-ngfw/tests/User_id_1_csv.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/User_id_1_csv.json
@@ -9,6 +9,7 @@
         "authentication"
       ],
       "dataset": "userid",
+      "outcome": "success",
       "type": [
         "start"
       ]

--- a/Palo Alto Networks/paloalto-ngfw/tests/User_id_2_csv.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/User_id_2_csv.json
@@ -9,6 +9,7 @@
         "authentication"
       ],
       "dataset": "userid",
+      "outcome": "success",
       "type": [
         "start"
       ]

--- a/Palo Alto Networks/paloalto-ngfw/tests/auth_cef.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/auth_cef.json
@@ -9,6 +9,7 @@
         "authentication"
       ],
       "dataset": "auth",
+      "outcome": "failure",
       "severity": 3,
       "start": "2021-02-28T18:20:40Z",
       "timezone": "UTC",

--- a/Palo Alto Networks/paloalto-ngfw/tests/system_csv.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/system_csv.json
@@ -9,6 +9,7 @@
         "authentication"
       ],
       "dataset": "system",
+      "outcome": "success",
       "reason": "authenticated for user 'user1'.   auth profile 'GP', vsys 'vsys123', server profile 'LDAP', server address 'srv01.entreprise.local', From: 1.2.3.4.",
       "type": [
         "start"

--- a/Palo Alto Networks/paloalto-ngfw/tests/test_auth_fail.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/test_auth_fail.json
@@ -9,6 +9,7 @@
         "authentication"
       ],
       "dataset": "system",
+      "outcome": "failure",
       "reason": "Authentication request is timed out.",
       "type": [
         "info"

--- a/Palo Alto Networks/paloalto-ngfw/tests/test_auth_fail1.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/test_auth_fail1.json
@@ -9,6 +9,7 @@
         "authentication"
       ],
       "dataset": "system",
+      "outcome": "failure",
       "reason": "User is not in allowlist.",
       "type": [
         "info"

--- a/Palo Alto Networks/paloalto-ngfw/tests/test_auth_fail10.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/test_auth_fail10.json
@@ -9,6 +9,7 @@
         "authentication"
       ],
       "dataset": "system",
+      "outcome": "failure",
       "reason": "Invalid username/password.",
       "type": [
         "info"

--- a/Palo Alto Networks/paloalto-ngfw/tests/test_auth_fail11.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/test_auth_fail11.json
@@ -9,6 +9,7 @@
         "authentication"
       ],
       "dataset": "system",
+      "outcome": "failure",
       "reason": "Authentication request is timed out.",
       "type": [
         "start"

--- a/Palo Alto Networks/paloalto-ngfw/tests/test_auth_fail2.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/test_auth_fail2.json
@@ -9,6 +9,7 @@
         "authentication"
       ],
       "dataset": "system",
+      "outcome": "failure",
       "reason": "Authentication request is timed out.",
       "type": [
         "info"

--- a/Palo Alto Networks/paloalto-ngfw/tests/test_auth_fail3.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/test_auth_fail3.json
@@ -9,6 +9,7 @@
         "authentication"
       ],
       "dataset": "system",
+      "outcome": "failure",
       "reason": "Invalid username/password.",
       "type": [
         "info"

--- a/Palo Alto Networks/paloalto-ngfw/tests/test_auth_fail4.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/test_auth_fail4.json
@@ -9,6 +9,7 @@
         "authentication"
       ],
       "dataset": "system",
+      "outcome": "failure",
       "reason": "Invalid username/password.",
       "type": [
         "info"

--- a/Palo Alto Networks/paloalto-ngfw/tests/test_auth_fail5.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/test_auth_fail5.json
@@ -9,6 +9,7 @@
         "authentication"
       ],
       "dataset": "system",
+      "outcome": "failure",
       "reason": "User is in locked users list.",
       "type": [
         "info"

--- a/Palo Alto Networks/paloalto-ngfw/tests/test_auth_fail6.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/test_auth_fail6.json
@@ -9,6 +9,7 @@
         "authentication"
       ],
       "dataset": "system",
+      "outcome": "failure",
       "reason": "User is in locked users list.",
       "type": [
         "info"

--- a/Palo Alto Networks/paloalto-ngfw/tests/test_auth_fail7.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/test_auth_fail7.json
@@ -9,6 +9,7 @@
         "authentication"
       ],
       "dataset": "system",
+      "outcome": "failure",
       "reason": "Authentication profile not found for the user.",
       "type": [
         "info"

--- a/Palo Alto Networks/paloalto-ngfw/tests/test_auth_fail8.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/test_auth_fail8.json
@@ -9,6 +9,7 @@
         "authentication"
       ],
       "dataset": "system",
+      "outcome": "failure",
       "reason": "Internal error, e.g. network connection, DNS failure or remote server down. auth profile 'ESA-AUTH',",
       "type": [
         "info"

--- a/Palo Alto Networks/paloalto-ngfw/tests/test_auth_fail9.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/test_auth_fail9.json
@@ -9,6 +9,7 @@
         "authentication"
       ],
       "dataset": "system",
+      "outcome": "failure",
       "reason": "Invalid username/password.",
       "type": [
         "info"

--- a/Palo Alto Networks/paloalto-ngfw/tests/test_auth_success1.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/test_auth_success1.json
@@ -9,6 +9,7 @@
         "authentication"
       ],
       "dataset": "system",
+      "outcome": "success",
       "reason": "authenticated for user 'test_user'. auth profile 'FWPA', vsys 'shared', server profile 'RADIUS_RSA', server address '1.2.3.4', auth protocol 'PAP', admin role 'superreader', From: 3.4.5.6.",
       "type": [
         "start"

--- a/Palo Alto Networks/paloalto-ngfw/tests/test_auth_success_2.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/test_auth_success_2.json
@@ -9,6 +9,7 @@
         "authentication"
       ],
       "dataset": "system",
+      "outcome": "success",
       "reason": "authenticated for user 'jane.doe'.   auth profile 'ESA-AUTH', vsys 'vsys1', server profile 'ESA', server address '1.2.3.4', auth protocol 'PAP', From: 5.6.7.8.",
       "type": [
         "start"

--- a/Palo Alto Networks/paloalto-ngfw/tests/test_event_reason2.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/test_event_reason2.json
@@ -15,6 +15,7 @@
         "authentication"
       ],
       "dataset": "system",
+      "outcome": "success",
       "reason": "When authenticating user joe1595 from 1.2.3.4, a less secure authentication method PAP is used. Please migrate to PEAP or EAP-TTLS. Authentication Profile FFFF, vsys shared, Server Profile SERVER_TEST, Server Address 5.6.7.8",
       "type": [
         "start"

--- a/Palo Alto Networks/paloalto-ngfw/tests/test_event_reason3.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/test_event_reason3.json
@@ -15,6 +15,7 @@
         "authentication"
       ],
       "dataset": "system",
+      "outcome": "success",
       "reason": "authenticated for user joe979.   auth profile FFFF, vsys shared, server profile server-test, server address 1.7.4.4, auth protocol PAP, admin role superuser, From: 1.2.2.7.",
       "type": [
         "start"

--- a/Palo Alto Networks/paloalto-ngfw/tests/test_system_event_13.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/test_system_event_13.json
@@ -15,6 +15,7 @@
         "authentication"
       ],
       "dataset": "system",
+      "outcome": "success",
       "reason": "When authenticating user 'test000555' from '1.2.5.5', a less secure authentication method PAP is used. Please migrate to PEAP or EAP-TTLS. Authentication Profile 'FWPA', vsys 'shared', Server Profile 'RADIUS_RSA', Server Address '1.7.4.2'",
       "type": [
         "start"

--- a/Palo Alto Networks/paloalto-ngfw/tests/test_system_event_14.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/test_system_event_14.json
@@ -15,6 +15,7 @@
         "authentication"
       ],
       "dataset": "system",
+      "outcome": "failure",
       "reason": "Authentication request is timed out.",
       "type": [
         "info"

--- a/Palo Alto Networks/paloalto-ngfw/tests/test_system_event_15.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/test_system_event_15.json
@@ -15,6 +15,7 @@
         "authentication"
       ],
       "dataset": "system",
+      "outcome": "failure",
       "reason": "Authentication request is timed out.",
       "type": [
         "info"

--- a/Palo Alto Networks/paloalto-ngfw/tests/test_user_authentication_json.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/test_user_authentication_json.json
@@ -9,6 +9,7 @@
         "authentication"
       ],
       "dataset": "system",
+      "outcome": "success",
       "reason": "authenticated for user 'admin'.   From: 1.2.3.4.",
       "type": [
         "info"

--- a/Palo Alto Networks/paloalto-ngfw/tests/test_userid.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/test_userid.json
@@ -9,6 +9,7 @@
         "authentication"
       ],
       "dataset": "userid",
+      "outcome": "success",
       "type": [
         "start"
       ]

--- a/Palo Alto Networks/paloalto-ngfw/tests/userid_cef.json
+++ b/Palo Alto Networks/paloalto-ngfw/tests/userid_cef.json
@@ -9,6 +9,7 @@
         "authentication"
       ],
       "dataset": "userid",
+      "outcome": "success",
       "severity": 3,
       "start": "2021-03-01T21:06:02Z",
       "timezone": "UTC",


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/597
1. Palo Alto Networks/paloalto-ngfw/tests/auth_cef.json - need more samples like this with different `msg=`