### PR TITLE
Fix: Bitdefender Gravityzone Domain Name (709)

### DIFF
--- a/Bitdefender/gravityzone/ingest/parser.yml
+++ b/Bitdefender/gravityzone/ingest/parser.yml
@@ -104,6 +104,10 @@ stages:
           bitdefender.gravityzone.exploit.type: "{{parse_event.message.BitdefenderGZExploitType}}"
 
       - set:
+          url.original: "{{parse_event.message.BitdefenderGZApplicationControlType}}://{{parse_event.message.request}}"
+        filter: "{{parse_event.message.get('BitdefenderGZApplicationControlType') != None and parse_event.message.get('request') != None}}"
+
+      - set:
           "@timestamp": "{{parsed_date.datetime}}"
         filter: "{{parse_event.message.get('eventdate') != None or parse_event.message.get('BitdefenderGZDetectionTime') != None}}"
 

--- a/Bitdefender/gravityzone/tests/uc_event.json
+++ b/Bitdefender/gravityzone/tests/uc_event.json
@@ -58,8 +58,14 @@
       }
     },
     "url": {
-      "original": "external-content.domain.com/ip3/www.test_request.com",
-      "path": "external-content.domain.com/ip3/www.test_request.com"
+      "domain": "external-content.domain.com",
+      "original": "http://external-content.domain.com/ip3/www.test_request.com",
+      "path": "/ip3/www.test_request.com",
+      "port": 80,
+      "registered_domain": "domain.com",
+      "scheme": "http",
+      "subdomain": "external-content",
+      "top_level_domain": "com"
     }
   }
 }


### PR DESCRIPTION
Closes [709](https://github.com/SekoiaLab/integration/issues/709)