### PR TITLE
Fix: Rollback UUID Generation Bitdefender (726)

### DIFF
--- a/Bitdefender/_meta/manifest.yml
+++ b/Bitdefender/_meta/manifest.yml
@@ -1,4 +1,4 @@
-uuid: 3df6efcf-f44d-4dc8-b5d0-e92e8c124260
+uuid: 26277889-b91b-46d0-8bac-7f6b2f6fb9a3
 name: Bitdefender
 slug: "bitdefender"
 description: >-


### PR DESCRIPTION
Fix regarding comment in [726](https://github.com/SekoiaLab/integration/issues/726)

## Summary by Sourcery

Bug Fixes:
- Restore the previous UUID in the Bitdefender manifest