### PR TITLE
Apache: add timestamp field and enhance actions.timestamp for errors

### DIFF
--- a/Apache/apache/ingest/parser.yml
+++ b/Apache/apache/ingest/parser.yml
@@ -11,13 +11,13 @@ pipeline:
         pattern: "(%{MODSECAPACHEERROR}|%{HTTPD24_ERRORLOG}|%{HTTPD20_ERRORLOG}|%{HTTPD_COMBINEDLOG}|%{HTTPD_COMMONLOG})"
         custom_patterns:
           # HTTPD standard logs
-          HTTPD20_ERRORLOG: '\[%{HTTPDERROR_DATE}\] \[%{LOGLEVEL:action_name}\] (?:\[client (%{IP:source_ip}|%{HOSTNAME:source_domain})?\] ){0,1}%{GREEDYDATA:action_outcome_reason}'
-          HTTPD24_ERRORLOG: '\[%{HTTPDERROR_DATE}\] \[%{WORD}?:%{LOGLEVEL:action_name}\] \[pid %{POSINT:process_id}(:tid %{NUMBER:process_thread_id})?\]( \(%{POSINT}\)%{DATA}:)?( \[client (%{IP:source_ip}|%{HOSTNAME:source_domain})?(:%{POSINT:source_port})?\])?( %{DATA}:)? %{GREEDYDATA:action_outcome_reason}'
+          HTTPD20_ERRORLOG: '\[%{HTTPDERROR_DATE:error_timestamp}\] \[%{LOGLEVEL:action_name}\] (?:\[client (%{IP:source_ip}|%{HOSTNAME:source_domain})?\] ){0,1}%{GREEDYDATA:action_outcome_reason}'
+          HTTPD24_ERRORLOG: '\[%{HTTPDERROR_DATE:error_timestamp}\] \[%{WORD}?:%{LOGLEVEL:action_name}\] \[pid %{POSINT:process_id}(:tid %{NUMBER:process_thread_id})?\]( \(%{POSINT}\)%{DATA}:)?( \[client (%{IP:source_ip}|%{HOSTNAME:source_domain})?(:%{POSINT:source_port})?\])?( %{DATA}:)? %{GREEDYDATA:action_outcome_reason}'
           HTTPD_COMBINEDLOG: '%{HTTPD_COMMONLOG} "%{DATA:http_request_referrer}" "%{DATA:user_agent_original}"'
           HTTPD_COMMONLOG: >-
             ((%{IPORHOST:destination_address}(:%{NUMBER:destination_port})|-)? )?%{IPORHOST:source_ip} (?:(\()?-(\))?|%{HTTPDUSER:apache_access_user_identity}) (?:-( -)*|%{HTTPDUSER:user_name}) \[%{HTTPDATE:timestamp}]\ "(?:%{WORD:http_request_method} %{NOTSPACE:url_original}(?: HTTP/%{NUMBER:http_version})?|%{DATA})" (?:-|%{INT:http_response_status_code:int}) (?:-|%{INT:http_response_body_bytes:int})%{GREEDYDATA}
           # Apache ModSecurity logs
-          APACHEERRORPREFIX: '(\[%{HTTPDERROR_DATE:timestamp}\] )?(\[%{WORD}?:%{LOGLEVEL:action_name}\] )?(\[pid %{POSINT:process_pid}(:tid %{NUMBER:process_thread_id})?\] )?(\[client (%{IP:source_ip}|%{HOSTNAME:source_domain})?(:%{NUMBER:source_port})?\])?.*'
+          APACHEERRORPREFIX: '(\[%{HTTPDERROR_DATE:error_timestamp}\] )?(\[%{WORD}?:%{LOGLEVEL:action_name}\] )?(\[pid %{POSINT:process_pid}(:tid %{NUMBER:process_thread_id})?\] )?(\[client (%{IP:source_ip}|%{HOSTNAME:source_domain})?(:%{NUMBER:source_port})?\])?.*'
           MODSECHOSTNAME: '\[hostname "?%{DATA:destination_domain}"?\]'
           MODSECMATCHOFFSET: '\[offset "?%{DATA:matchoffset}"?\]'
           MODSECPREFIX: '%{APACHEERRORPREFIX} ModSecurity: %{NOTSPACE:action_type}\. %{GREEDYDATA:modsecmessage}'
@@ -32,6 +32,14 @@ pipeline:
           MODSECUID: '\[unique_id "?%{DATA:uniqueid}"?\]'
           MODSECURI: '\[uri "?%{DATA:url_original}"?\]'
           MODSECAPACHEERROR: "%{MODSECPREFIX} %{MODSECRULEFILE} %{MODSECRULELINE} (?:%{MODSECMATCHOFFSET} )?(?:%{MODSECRULEID} )?(?:%{MODSECRULEREV} )?(?:%{MODSECRULEMSG} )?(?:%{MODSECRULEDATA} )?(?:%{MODSECRULESEVERITY} )?%{MODSECRULETAGS}.*%{MODSECHOSTNAME} %{MODSECURI} %{MODSECUID}.*"
+
+  - name: parse_date
+    external:
+      name: date.parse
+      properties:
+        input_field: "{{grok.event.timestamp}}"
+        output_field: timestamp
+        format: "%d/%b/%Y:%H:%M:%S %z"
 
   - name: set_apache_fields
   - name: set_action_properties
@@ -50,7 +58,7 @@ stages:
           action.properties.ruleline: "{{grok.event.ruleline}}"
           action.properties.rulerev: "{{grok.event.rulerev}}"
           action.properties.ruleseverity: "{{grok.event.ruleseverity}}"
-          action.properties.timestamp: "{{grok.event.timestamp}}"
+          action.properties.timestamp: "{{grok.event.timestamp or grok.event.error_timestamp}}"
           action.properties.uniqueid: "{{grok.event.uniqueid}}"
 
   finalizer:
@@ -93,6 +101,7 @@ stages:
   set_apache_fields:
     actions:
       - set:
+          "@timestamp": "{{parse_date.timestamp}}"
           event.category: ["web"]
           action.name: "{{grok.event.action_name or grok.event.http_request_method}}"
           action.outcome_reason: "{{grok.event.action_outcome_reason}}"

--- a/Apache/apache/tests/access_combined.json
+++ b/Apache/apache/tests/access_combined.json
@@ -13,6 +13,7 @@
         "access"
       ]
     },
+    "@timestamp": "2000-10-10T20:55:36Z",
     "action": {
       "name": "GET",
       "outcome": "success",

--- a/Apache/apache/tests/access_extended.json
+++ b/Apache/apache/tests/access_extended.json
@@ -19,6 +19,7 @@
         "access"
       ]
     },
+    "@timestamp": "2024-07-31T14:41:52Z",
     "action": {
       "name": "GET",
       "outcome": "success",

--- a/Apache/apache/tests/access_failure_1.json
+++ b/Apache/apache/tests/access_failure_1.json
@@ -19,6 +19,7 @@
         "access"
       ]
     },
+    "@timestamp": "2024-10-01T08:22:11Z",
     "action": {
       "name": "GET",
       "outcome": "failure",

--- a/Apache/apache/tests/access_failure_2.json
+++ b/Apache/apache/tests/access_failure_2.json
@@ -1,0 +1,66 @@
+{
+  "input": {
+    "message": "1.2.3.4 - - [14/Dec/2023:14:19:32 +0100] \"GET /robots.txt.exe HTTP/1.1\" 404 7363 \"-\" \"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.6045.159 Safari/537.36\"",
+    "sekoiaio": {
+      "intake": {
+        "dialect": "Apache HTTP Server",
+        "dialect_uuid": "6c2a44e3-a86a-4d98-97a6-d575ffcb29f7"
+      }
+    }
+  },
+  "expected": {
+    "message": "1.2.3.4 - - [14/Dec/2023:14:19:32 +0100] \"GET /robots.txt.exe HTTP/1.1\" 404 7363 \"-\" \"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.6045.159 Safari/537.36\"",
+    "event": {
+      "category": [
+        "web"
+      ],
+      "outcome": "failure",
+      "type": [
+        "access"
+      ]
+    },
+    "@timestamp": "2023-12-14T13:19:32Z",
+    "action": {
+      "name": "GET",
+      "outcome": "failure",
+      "properties": {
+        "timestamp": "14/Dec/2023:14:19:32 +0100"
+      }
+    },
+    "http": {
+      "request": {
+        "method": "GET"
+      },
+      "response": {
+        "bytes": 7363,
+        "status_code": 404
+      },
+      "version": "1.1"
+    },
+    "related": {
+      "ip": [
+        "1.2.3.4"
+      ]
+    },
+    "source": {
+      "address": "1.2.3.4",
+      "ip": "1.2.3.4"
+    },
+    "url": {
+      "original": "/robots.txt.exe",
+      "path": "/robots.txt.exe"
+    },
+    "user_agent": {
+      "device": {
+        "name": "Other"
+      },
+      "name": "Chrome",
+      "original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.6045.159 Safari/537.36",
+      "os": {
+        "name": "Windows",
+        "version": "10"
+      },
+      "version": "119.0.6045"
+    }
+  }
+}

--- a/Apache/apache/tests/access_redirect.json
+++ b/Apache/apache/tests/access_redirect.json
@@ -19,6 +19,7 @@
         "access"
       ]
     },
+    "@timestamp": "2024-10-01T08:22:01Z",
     "action": {
       "name": "GET",
       "outcome": "redirect",

--- a/Apache/apache/tests/access_success.json
+++ b/Apache/apache/tests/access_success.json
@@ -19,6 +19,7 @@
         "access"
       ]
     },
+    "@timestamp": "2024-10-01T08:22:45Z",
     "action": {
       "name": "POST",
       "outcome": "success",

--- a/Apache/apache/tests/common_log_format.json
+++ b/Apache/apache/tests/common_log_format.json
@@ -13,6 +13,7 @@
         "access"
       ]
     },
+    "@timestamp": "2000-10-10T20:55:36Z",
     "action": {
       "name": "GET",
       "outcome": "success",

--- a/Apache/apache/tests/error.json
+++ b/Apache/apache/tests/error.json
@@ -16,7 +16,10 @@
     "action": {
       "name": "error",
       "outcome": "failure",
-      "outcome_reason": "client denied by server configuration: /export/home/live/ap/htdocs/test"
+      "outcome_reason": "client denied by server configuration: /export/home/live/ap/htdocs/test",
+      "properties": {
+        "timestamp": "Wed Oct 11 14:32:52 2000"
+      }
     },
     "related": {
       "ip": [

--- a/Apache/apache/tests/error_2.json
+++ b/Apache/apache/tests/error_2.json
@@ -16,7 +16,10 @@
     "action": {
       "name": "error",
       "outcome": "failure",
-      "outcome_reason": "/usr/local/apache2/htdocs/favicon.ico"
+      "outcome_reason": "/usr/local/apache2/htdocs/favicon.ico",
+      "properties": {
+        "timestamp": "Fri Sep 09 10:42:29.902022 2011"
+      }
     },
     "process": {
       "id": 35708,

--- a/Apache/apache/tests/needs_striping.json
+++ b/Apache/apache/tests/needs_striping.json
@@ -16,7 +16,10 @@
     "action": {
       "name": "info",
       "outcome": "success",
-      "outcome_reason": "Connection to child 114 established (server app.corp.com:443)"
+      "outcome_reason": "Connection to child 114 established (server app.corp.com:443)",
+      "properties": {
+        "timestamp": "Thu Feb 29 11:47:27.072780 2024"
+      }
     },
     "process": {
       "id": 12596

--- a/Apache/apache/tests/process_id.json
+++ b/Apache/apache/tests/process_id.json
@@ -16,7 +16,10 @@
     "action": {
       "name": "info",
       "outcome": "success",
-      "outcome_reason": "SSL input filter read failed."
+      "outcome_reason": "SSL input filter read failed.",
+      "properties": {
+        "timestamp": "Thu Feb 29 14:23:43.643358 2024"
+      }
     },
     "process": {
       "id": 24237


### PR DESCRIPTION
Related to [this issue](https://github.com/SekoiaLab/integration/issues/736)

## Summary by Sourcery

Capture and normalize timestamps from both access and error logs by enhancing grok patterns, introducing a date parsing stage, and applying the parsed timestamp to event @timestamp and action properties

New Features:
- Add a date.parse stage to extract and normalize Apache log timestamps into a unified timestamp field

Enhancements:
- Update grok patterns to capture error log timestamps into an error_timestamp field
- Fallback to error_timestamp for action.properties.timestamp when the standard timestamp is missing
- Set the parsed date as the event’s @timestamp

Tests:
- Update Apache log test fixtures to reflect the new timestamp handling and add a new access_failure_2.json test case