### PR TITLE
Mimecast - parse more fields

### DIFF
--- a/Mimecast/mimecast-email-security/_meta/fields.yml
+++ b/Mimecast/mimecast-email-security/_meta/fields.yml
@@ -45,6 +45,11 @@ mimecast.siem.scan_results:
   name: mimecast.siem.scan_results
   type: keyword
 
+mimecast.siem.subtype:
+  description: ''
+  name: mimecast.siem.subtype
+  type: keyword
+
 mimecast.siem.virus_found:
   description: The name of the virus found on the email, if applicable.
   name: mimecast.siem.virus_found

--- a/Mimecast/mimecast-email-security/ingest/parser.yml
+++ b/Mimecast/mimecast-email-security/ingest/parser.yml
@@ -56,9 +56,20 @@ stages:
           mimecast.siem.delivery_errors: "{{parse_event.message.deliveryErrors}}"
 
           mimecast.siem.scan_results: "{{parse_event.message.scanResults}}"
+          mimecast.siem.subtype: "{{parse_event.message.subtype}}"
 
           destination.ip: "{{parse_event.message.destinationIp}}"
           url.original: "{{parse_event.message.url}}"
+
+          organization.id: "{{parse_event.message.accountId}}"
+
+      - set:
+          network.direction: "{{parse_event.message.route.lower()}}"
+        filter: "{{parse_event.message.route.lower() in ['inbound', 'outbound']}}"
+
+      - set:
+          email.to.address: ["{{parse_event.message.recipient}}"]
+        filter: "{{parse_event.message.get('recipient') != None}}"
 
       - set:
           email.to.address: ["{{parse_event.message.recipients}}"]
@@ -95,11 +106,11 @@ stages:
                     }
                   },
             ]
-        filter: '{{parse_event.message.eventType in ["av", "attachment protect"]}}'
+        filter: '{{final.event.dataset in ["av", "attachment protect"]}}'
 
       - set:
           file.name: "{{(final.email.attachments | first).file.name}}"
-        filter: '{{parse_event.message.eventType in ["av", "attachment protect"] and final.email.attachments | length > 0}}'
+        filter: '{{final.event.dataset in ["av", "attachment protect"] and final.email.attachments | length > 0}}'
 
       - set:
           url.original: "{{ parse_rejectioninfo.message.Url }}"

--- a/Mimecast/mimecast-email-security/tests/test_attachment_protect.json
+++ b/Mimecast/mimecast-email-security/tests/test_attachment_protect.json
@@ -37,6 +37,9 @@
         "aggregate_id": "aggregateId",
         "processing_id": "processingId"
       }
+    },
+    "organization": {
+      "id": "C0A0"
     }
   }
 }

--- a/Mimecast/mimecast-email-security/tests/test_attachment_protect_2.json
+++ b/Mimecast/mimecast-email-security/tests/test_attachment_protect_2.json
@@ -1,0 +1,69 @@
+{
+  "input": {
+    "message": "{\"aggregateId\": \"aggregate_id\", \"processingId\": \"processing_id\", \"accountId\": \"ACCOUNT\", \"timestamp\": 1751448649657, \"senderEnvelope\": \"jane.doe@acme.com\", \"messageId\": \"<11111111111111111111111111111111111111@mail.gmail.com>\", \"subject\": \"RE: TPS REPORT\", \"recipient\": \"john.doe@example.com\", \"fileName\": \"tps_report.pdf\", \"sha256\": \"b3e4b1b4d1229793a049b474550529fc3a71376e7b3301299c7a3307cef9387b\", \"sizeAttachment\": \"71825\", \"senderIp\": \"1.2.3.4\", \"senderDomain\": \"acme.com\", \"fileExtension\": \"pdf\", \"sha1\": \"3784d86bcdeda760b85b3ec8075e2a31917e6896\", \"fileMime\": \"application/pdf\", \"route\": \"inbound\", \"md5\": \"c4737450d1aaaf05478e0d5137a97d1c\", \"type\": \"attachment protect\", \"subtype\": null}"
+  },
+  "expected": {
+    "message": "{\"aggregateId\": \"aggregate_id\", \"processingId\": \"processing_id\", \"accountId\": \"ACCOUNT\", \"timestamp\": 1751448649657, \"senderEnvelope\": \"jane.doe@acme.com\", \"messageId\": \"<11111111111111111111111111111111111111@mail.gmail.com>\", \"subject\": \"RE: TPS REPORT\", \"recipient\": \"john.doe@example.com\", \"fileName\": \"tps_report.pdf\", \"sha256\": \"b3e4b1b4d1229793a049b474550529fc3a71376e7b3301299c7a3307cef9387b\", \"sizeAttachment\": \"71825\", \"senderIp\": \"1.2.3.4\", \"senderDomain\": \"acme.com\", \"fileExtension\": \"pdf\", \"sha1\": \"3784d86bcdeda760b85b3ec8075e2a31917e6896\", \"fileMime\": \"application/pdf\", \"route\": \"inbound\", \"md5\": \"c4737450d1aaaf05478e0d5137a97d1c\", \"type\": \"attachment protect\", \"subtype\": null}",
+    "event": {
+      "category": [
+        "email"
+      ],
+      "dataset": "attachment protect",
+      "provider": "Mimecast",
+      "type": [
+        "info"
+      ]
+    },
+    "@timestamp": "2025-07-02T09:30:49.657000Z",
+    "email": {
+      "attachments": [
+        {
+          "file": {
+            "hash": {
+              "md5": "c4737450d1aaaf05478e0d5137a97d1c",
+              "sha1": "3784d86bcdeda760b85b3ec8075e2a31917e6896",
+              "sha256": "b3e4b1b4d1229793a049b474550529fc3a71376e7b3301299c7a3307cef9387b"
+            },
+            "name": "tps_report.pdf"
+          }
+        }
+      ],
+      "from": {
+        "address": [
+          "jane.doe@acme.com"
+        ]
+      },
+      "message_id": "11111111111111111111111111111111111111@mail.gmail.com",
+      "subject": "RE: TPS REPORT",
+      "to": {
+        "address": [
+          "john.doe@example.com"
+        ]
+      }
+    },
+    "file": {
+      "name": "tps_report.pdf"
+    },
+    "mimecast": {
+      "siem": {
+        "aggregate_id": "aggregate_id",
+        "processing_id": "processing_id"
+      }
+    },
+    "network": {
+      "direction": "inbound"
+    },
+    "organization": {
+      "id": "ACCOUNT"
+    },
+    "related": {
+      "ip": [
+        "1.2.3.4"
+      ]
+    },
+    "source": {
+      "address": "1.2.3.4",
+      "ip": "1.2.3.4"
+    }
+  }
+}

--- a/Mimecast/mimecast-email-security/tests/test_av_logs.json
+++ b/Mimecast/mimecast-email-security/tests/test_av_logs.json
@@ -51,6 +51,12 @@
         "virus_found": "bad.virus.found"
       }
     },
+    "network": {
+      "direction": "inbound"
+    },
+    "organization": {
+      "id": "C0A0"
+    },
     "related": {
       "ip": [
         "123.123.123.123"

--- a/Mimecast/mimecast-email-security/tests/test_delivery.json
+++ b/Mimecast/mimecast-email-security/tests/test_delivery.json
@@ -38,8 +38,12 @@
       "siem": {
         "aggregate_id": "aggregateId",
         "delivered": true,
-        "processing_id": "processingId"
+        "processing_id": "processingId",
+        "subtype": "true"
       }
+    },
+    "organization": {
+      "id": "C0A0"
     },
     "related": {
       "ip": [

--- a/Mimecast/mimecast-email-security/tests/test_delivery_wo_sender_address.json
+++ b/Mimecast/mimecast-email-security/tests/test_delivery_wo_sender_address.json
@@ -37,8 +37,12 @@
       "siem": {
         "aggregate_id": "aggregateId",
         "delivered": true,
-        "processing_id": "processingId"
+        "processing_id": "processingId",
+        "subtype": "true"
       }
+    },
+    "organization": {
+      "id": "ACCOUNT"
     },
     "related": {
       "ip": [

--- a/Mimecast/mimecast-email-security/tests/test_impersonation_protect.json
+++ b/Mimecast/mimecast-email-security/tests/test_impersonation_protect.json
@@ -35,6 +35,12 @@
         "processing_id": "processingId"
       }
     },
+    "network": {
+      "direction": "inbound"
+    },
+    "organization": {
+      "id": "C0A0"
+    },
     "related": {
       "ip": [
         "123.123.123.123"

--- a/Mimecast/mimecast-email-security/tests/test_internal_email_project.json
+++ b/Mimecast/mimecast-email-security/tests/test_internal_email_project.json
@@ -35,6 +35,9 @@
         "processing_id": "processingId",
         "scan_results": "Restricted File Type - Found executable extension: dll"
       }
+    },
+    "organization": {
+      "id": "C0A0"
     }
   }
 }

--- a/Mimecast/mimecast-email-security/tests/test_journal.json
+++ b/Mimecast/mimecast-email-security/tests/test_journal.json
@@ -33,6 +33,9 @@
         "aggregate_id": "aggregateId",
         "processing_id": "processingId"
       }
+    },
+    "organization": {
+      "id": "ACCOUNT"
     }
   }
 }

--- a/Mimecast/mimecast-email-security/tests/test_process.json
+++ b/Mimecast/mimecast-email-security/tests/test_process.json
@@ -29,8 +29,12 @@
       "siem": {
         "aggregate_id": "aggregateId",
         "hold_reason": "Spm",
-        "processing_id": "processingId"
+        "processing_id": "processingId",
+        "subtype": "Hld"
       }
+    },
+    "organization": {
+      "id": "ACCOUNT"
     }
   }
 }

--- a/Mimecast/mimecast-email-security/tests/test_process_with_attachment.json
+++ b/Mimecast/mimecast-email-security/tests/test_process_with_attachment.json
@@ -37,6 +37,9 @@
         "aggregate_id": "aggregateId",
         "processing_id": "processingId"
       }
+    },
+    "organization": {
+      "id": "ACCOUNT"
     }
   }
 }

--- a/Mimecast/mimecast-email-security/tests/test_process_with_multiple_attachments.json
+++ b/Mimecast/mimecast-email-security/tests/test_process_with_multiple_attachments.json
@@ -105,8 +105,12 @@
     "mimecast": {
       "siem": {
         "aggregate_id": "aggId1",
-        "processing_id": "AAA_123"
+        "processing_id": "AAA_123",
+        "subtype": "Acc"
       }
+    },
+    "organization": {
+      "id": "ACCOUNT1"
     }
   }
 }

--- a/Mimecast/mimecast-email-security/tests/test_receipt.json
+++ b/Mimecast/mimecast-email-security/tests/test_receipt.json
@@ -34,8 +34,12 @@
     "mimecast": {
       "siem": {
         "aggregate_id": "aggregateId",
-        "processing_id": "processingId"
+        "processing_id": "processingId",
+        "subtype": "Acc"
       }
+    },
+    "organization": {
+      "id": "ACCOUNT"
     },
     "related": {
       "ip": [

--- a/Mimecast/mimecast-email-security/tests/test_receipt_rej.json
+++ b/Mimecast/mimecast-email-security/tests/test_receipt_rej.json
@@ -33,8 +33,12 @@
           "info": "sip.invaluement.mimecast.org Blocked by ivmSIP and/or ivmSIP/24 - see https://www.invaluement.com/lookup/?item=1.2.3.4.",
           "type": "IP Found in RBL"
         },
+        "subtype": "Rej",
         "virus_found": "sip.invaluement.mimecast.org Blocked by ivmSIP and/or ivmSIP/24 - see https://www.invaluement.com/lookup/?item=1.2.3.4."
       }
+    },
+    "organization": {
+      "id": "ACCOUNT"
     },
     "related": {
       "ip": [

--- a/Mimecast/mimecast-email-security/tests/test_receipt_urls.json
+++ b/Mimecast/mimecast-email-security/tests/test_receipt_urls.json
@@ -39,8 +39,12 @@
           "code": 554,
           "info": "[Type: [Phishing & Fraud],Url: [https://assistance-mon-espace.com/pages/billing.php],UrlBlock: [ORIGINAL:https://assistance-mon-espace.com/pages/billin]",
           "type": "Malicious QRCode Detection"
-        }
+        },
+        "subtype": "Rej"
       }
+    },
+    "organization": {
+      "id": "ACCOUNT"
     },
     "related": {
       "ip": [

--- a/Mimecast/mimecast-email-security/tests/test_spam.json
+++ b/Mimecast/mimecast-email-security/tests/test_spam.json
@@ -35,6 +35,12 @@
         "processing_id": "processingId"
       }
     },
+    "network": {
+      "direction": "inbound"
+    },
+    "organization": {
+      "id": "C0A0"
+    },
     "related": {
       "ip": [
         "1.2.3.4"

--- a/Mimecast/mimecast-email-security/tests/test_url_protect_blocked.json
+++ b/Mimecast/mimecast-email-security/tests/test_url_protect_blocked.json
@@ -33,8 +33,15 @@
     "mimecast": {
       "siem": {
         "aggregate_id": "aggregateId",
-        "processing_id": "processingId"
+        "processing_id": "processingId",
+        "subtype": "Block"
       }
+    },
+    "network": {
+      "direction": "inbound"
+    },
+    "organization": {
+      "id": "ACCOUNT"
     },
     "url": {
       "domain": "www.mimcast.com",


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/737

## Summary by Sourcery

Enhance the Mimecast email security parser to extract additional message fields (subtype, accountId, route, recipient) and refine filtering logic for antivirus and attachment protection events.

New Features:
- Parse event subtype into mimecast.siem.subtype
- Map accountId to organization.id
- Set network.direction from message.route for inbound/outbound
- Extract single recipient into email.to.address when provided

Enhancements:
- Use final.event.dataset instead of raw eventType for AV and attachment protect filters

Tests:
- Update existing fixtures and add test_attachment_protect_2.json