### PR TITLE
WatchGuard: fix the automation module uuid

### DIFF
--- a/WatchGuard/watchguard-epdr/_meta/manifest.yml
+++ b/WatchGuard/watchguard-epdr/_meta/manifest.yml
@@ -1,7 +1,7 @@
 uuid: 4f9ea4fb-e8b8-4001-822a-4c7a547c31d6
 name: Watchguard EPDR [BETA]
 slug: watchguard-epdr
-automation_module_uuid: b3ab7e1c-c6cd-4bcd-90cd-b3f7a1e0989
+automation_module_uuid: b3ab7e1c-c6cd-4bcd-90cd-b3f7a1e09891
 automation_connector_uuid: 1e5eeb82-9561-452c-ada0-da9b3a56d2c5
 
 description: >-


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the automation_module_uuid in watchguard-epdr/_meta/manifest.yml