### PR TITLE
fix(tests): fix following command_line url extraction change

### DIFF
--- a/SentinelOne/cloud_funnel2.0/tests/process_processcreation_2.json
+++ b/SentinelOne/cloud_funnel2.0/tests/process_processcreation_2.json
@@ -87,8 +87,8 @@
     },
     "url": {
       "domain": "test.test",
-      "original": "https://test.test/test-org/test-registry/releases/download/2024-12-05-doting-coil/registry.json.zip",
-      "path": "/test-org/test-registry/releases/download/2024-12-05-doting-coil/registry.json.zip",
+      "original": "https://test.test/tttttttt/test.nvim)",
+      "path": "/tttttttt/test.nvim)",
       "port": 443,
       "scheme": "https",
       "subdomain": "test"

--- a/Tehtris/tehtris-edr/tests/test_policy_alert.json
+++ b/Tehtris/tehtris-edr/tests/test_policy_alert.json
@@ -102,6 +102,13 @@
         "name": "User Execution: Web requests from unusual sources"
       }
     },
+    "url": {
+      "domain": "astgedgecp.region.local",
+      "original": "http://astgedgecp.region.local",
+      "port": 80,
+      "scheme": "http",
+      "subdomain": "astgedgecp.region"
+    },
     "user": {
       "domain": "EXAMPLE-NT",
       "name": "doe-j"


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Update process_processcreation_2.json and test_policy_alert.json fixtures to match new URL extraction output in command_line values.