### PR TITLE
fix(pre-commit): rm prettier, update pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,5 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0 # Use the ref you want to point at
+    rev: v5.0.0 # Use the ref you want to point at
     hooks:
       - id: check-yaml
-
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v3.0.0-alpha.9-for-vscode" # Use the sha or tag you want to point at
-    hooks:
-      - id: prettier


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/f67dae54-8e4c-439d-afd2-578a1302f4bd)

## Summary by Sourcery

Update pre-commit configuration to remove the prettier hook and upgrade pre-commit-hooks to v5.0.0

Enhancements:
- Upgrade pre-commit-hooks to v5.0.0

Chores:
- Remove the prettier hook from pre-commit configuration