### PR TITLE
Fix: Harfanglab Smart Descriptions (768)

### DIFF
--- a/HarfangLab/harfanglab/_meta/smart-descriptions.json
+++ b/HarfangLab/harfanglab/_meta/smart-descriptions.json
@@ -174,6 +174,40 @@
     ]
   },
   {
+    "value": "User {user.name} of computer {host.hostname} handles network traffic from {source.ip}:{source.port} to {destination.ip}:{destination.port}",
+    "conditions": [
+      {
+        "field": "event.category",
+        "value": "network"
+      },
+      {
+          "field": "user.name"
+      },
+      {
+          "field": "host.hostname"
+      },
+      {
+          "field": "source.ip"
+      },
+      {
+          "field": "source.port"
+      },
+      {
+          "field": "destination.ip"
+      },
+      {
+          "field": "destination.port"
+      }
+    ],
+    "relationships": [
+      {
+        "source": "source.ip",
+        "target": "destination.ip",
+        "type": "connected to"
+      }
+    ]
+  },
+  {
     "value": "User {user.name} (ip: {source.ip}) requested resource {url.path}",
     "conditions": [
       {

--- a/HarfangLab/harfanglab/tests/network3.json
+++ b/HarfangLab/harfanglab/tests/network3.json
@@ -1,0 +1,75 @@
+{
+  "input": {
+    "message": "{\n  \"log_type\": \"network\",\n  \"process_unique_id\": \"00000000-0000-0000-0000-000000000001\",\n  \"groups\": [\n    {\n      \"id\": \"00000000-0000-0000-0000-000000000002\",\n      \"name\": \"SERVERS\"\n    }\n  ],\n  \"conn_type\": 0,\n  \"daddr\": \"1.2.3.4\",\n  \"dport\": 2049,\n  \"daddr_geoip\": {},\n  \"saddr\": \"5.6.7.8\",\n  \"sport\": 685,\n  \"saddr_geoip\": {},\n  \"direction\": \"in\",\n  \"image_name\": \"\",\n  \"pid\": 4533,\n  \"username\": \"user\",\n  \"event_id\": 3,\n  \"is_ipv6\": false,\n  \"initiated\": false,\n  \"timestamp\": \"2025-07-21T13:01:35Z\",\n  \"@event_create_date\": \"2025-07-21T13:01:35Z\",\n  \"@timestamp\": \"2025-07-21T13:01:35.545551+00:00\",\n  \"tenant\": \"dummy-tenant-id\",\n  \"agent\": {\n    \"agentid\": \"00000000-0000-0000-0000-000000000003\",\n    \"hostname\": \"test-host.test.com\",\n    \"domain\": \"test.com\",\n    \"domainname\": \"test.com\",\n    \"dnsdomainname\": \"test.com\",\n    \"ostype\": \"linux\",\n    \"osversion\": \"5.14.0-dummy-version\",\n    \"distroid\": \"generic-linux\",\n    \"osproducttype\": \"Generic Linux 9.3\",\n    \"version\": \"x.y.z\",\n    \"additional_info\": {},\n    \"ipaddress\": \"0.0.0.0\",\n    \"producttype\": \"test-type\"\n  }\n}"
+  },
+  "expected": {
+    "message": "{\n  \"log_type\": \"network\",\n  \"process_unique_id\": \"00000000-0000-0000-0000-000000000001\",\n  \"groups\": [\n    {\n      \"id\": \"00000000-0000-0000-0000-000000000002\",\n      \"name\": \"SERVERS\"\n    }\n  ],\n  \"conn_type\": 0,\n  \"daddr\": \"1.2.3.4\",\n  \"dport\": 2049,\n  \"daddr_geoip\": {},\n  \"saddr\": \"5.6.7.8\",\n  \"sport\": 685,\n  \"saddr_geoip\": {},\n  \"direction\": \"in\",\n  \"image_name\": \"\",\n  \"pid\": 4533,\n  \"username\": \"user\",\n  \"event_id\": 3,\n  \"is_ipv6\": false,\n  \"initiated\": false,\n  \"timestamp\": \"2025-07-21T13:01:35Z\",\n  \"@event_create_date\": \"2025-07-21T13:01:35Z\",\n  \"@timestamp\": \"2025-07-21T13:01:35.545551+00:00\",\n  \"tenant\": \"dummy-tenant-id\",\n  \"agent\": {\n    \"agentid\": \"00000000-0000-0000-0000-000000000003\",\n    \"hostname\": \"test-host.test.com\",\n    \"domain\": \"test.com\",\n    \"domainname\": \"test.com\",\n    \"dnsdomainname\": \"test.com\",\n    \"ostype\": \"linux\",\n    \"osversion\": \"5.14.0-dummy-version\",\n    \"distroid\": \"generic-linux\",\n    \"osproducttype\": \"Generic Linux 9.3\",\n    \"version\": \"x.y.z\",\n    \"additional_info\": {},\n    \"ipaddress\": \"0.0.0.0\",\n    \"producttype\": \"test-type\"\n  }\n}",
+    "event": {
+      "category": [
+        "network"
+      ],
+      "dataset": "network",
+      "type": [
+        "connection"
+      ]
+    },
+    "@timestamp": "2025-07-21T13:01:35Z",
+    "agent": {
+      "id": "00000000-0000-0000-0000-000000000003",
+      "name": "harfanglab"
+    },
+    "destination": {
+      "address": "1.2.3.4",
+      "ip": "1.2.3.4",
+      "port": 2049
+    },
+    "harfanglab": {
+      "groups": [
+        "{\"id\":\"00000000-0000-0000-0000-000000000002\",\"name\":\"SERVERS\"}"
+      ]
+    },
+    "host": {
+      "domain": "test.com",
+      "hostname": "test-host.test.com",
+      "name": "test-host.test.com",
+      "os": {
+        "full": "Generic Linux 9.3",
+        "type": "linux",
+        "version": "5.14.0-dummy-version"
+      }
+    },
+    "log": {
+      "hostname": "test-host.test.com"
+    },
+    "network": {
+      "direction": "inbound"
+    },
+    "organization": {
+      "id": "dummy-tenant-id"
+    },
+    "process": {
+      "pid": 4533
+    },
+    "related": {
+      "hosts": [
+        "test-host.test.com"
+      ],
+      "ip": [
+        "1.2.3.4",
+        "5.6.7.8"
+      ],
+      "user": [
+        "user"
+      ]
+    },
+    "source": {
+      "address": "5.6.7.8",
+      "ip": "5.6.7.8",
+      "port": 685
+    },
+    "user": {
+      "name": "user",
+      "roles": "SERVERS"
+    }
+  }
+}

--- a/HarfangLab/harfanglab/tests/network4.json
+++ b/HarfangLab/harfanglab/tests/network4.json
@@ -1,0 +1,75 @@
+{
+  "input": {
+    "message": "{\n  \"log_type\": \"network\",\n  \"process_unique_id\": \"00000000-0000-0000-0000-000000000001\",\n  \"groups\": [\n    {\n      \"id\": \"00000000-0000-0000-0000-000000000002\",\n      \"name\": \"SERVERS\"\n    }\n  ],\n  \"conn_type\": 0,\n  \"daddr\": \"1.2.3.4\",\n  \"dport\": 443,\n  \"daddr_geoip\": {},\n  \"saddr\": \"5.6.7.8\",\n  \"sport\": 60684,\n  \"saddr_geoip\": {},\n  \"direction\": \"in\",\n  \"image_name\": \"/usr/sbin/nginx\",\n  \"pid\": 24946,\n  \"username\": \"user\",\n  \"event_id\": 3,\n  \"is_ipv6\": false,\n  \"initiated\": false,\n  \"timestamp\": \"2025-07-21T13:01:32.131423Z\",\n  \"@event_create_date\": \"2025-07-21T13:01:32.131423Z\",\n  \"@timestamp\": \"2025-07-21T13:01:33.167059+00:00\",\n  \"tenant\": \"dummy-tenant-id\",\n  \"agent\": {\n    \"agentid\": \"00000000-0000-0000-0000-000000000003\",\n    \"hostname\": \"test-host\",\n    \"domain\": null,\n    \"domainname\": null,\n    \"dnsdomainname\": null,\n    \"ostype\": \"linux\",\n    \"osversion\": \"x.y.z\",\n    \"distroid\": \"generic-linux\",\n    \"osproducttype\": \"Generic Linux 7\",\n    \"version\": \"x.y.z\",\n    \"additional_info\": {},\n    \"ipaddress\": null,\n    \"producttype\": null\n  }\n}\n"
+  },
+  "expected": {
+    "message": "{\n  \"log_type\": \"network\",\n  \"process_unique_id\": \"00000000-0000-0000-0000-000000000001\",\n  \"groups\": [\n    {\n      \"id\": \"00000000-0000-0000-0000-000000000002\",\n      \"name\": \"SERVERS\"\n    }\n  ],\n  \"conn_type\": 0,\n  \"daddr\": \"1.2.3.4\",\n  \"dport\": 443,\n  \"daddr_geoip\": {},\n  \"saddr\": \"5.6.7.8\",\n  \"sport\": 60684,\n  \"saddr_geoip\": {},\n  \"direction\": \"in\",\n  \"image_name\": \"/usr/sbin/nginx\",\n  \"pid\": 24946,\n  \"username\": \"user\",\n  \"event_id\": 3,\n  \"is_ipv6\": false,\n  \"initiated\": false,\n  \"timestamp\": \"2025-07-21T13:01:32.131423Z\",\n  \"@event_create_date\": \"2025-07-21T13:01:32.131423Z\",\n  \"@timestamp\": \"2025-07-21T13:01:33.167059+00:00\",\n  \"tenant\": \"dummy-tenant-id\",\n  \"agent\": {\n    \"agentid\": \"00000000-0000-0000-0000-000000000003\",\n    \"hostname\": \"test-host\",\n    \"domain\": null,\n    \"domainname\": null,\n    \"dnsdomainname\": null,\n    \"ostype\": \"linux\",\n    \"osversion\": \"x.y.z\",\n    \"distroid\": \"generic-linux\",\n    \"osproducttype\": \"Generic Linux 7\",\n    \"version\": \"x.y.z\",\n    \"additional_info\": {},\n    \"ipaddress\": null,\n    \"producttype\": null\n  }\n}\n",
+    "event": {
+      "category": [
+        "network"
+      ],
+      "dataset": "network",
+      "type": [
+        "connection"
+      ]
+    },
+    "@timestamp": "2025-07-21T13:01:32.131423Z",
+    "agent": {
+      "id": "00000000-0000-0000-0000-000000000003",
+      "name": "harfanglab"
+    },
+    "destination": {
+      "address": "1.2.3.4",
+      "ip": "1.2.3.4",
+      "port": 443
+    },
+    "harfanglab": {
+      "groups": [
+        "{\"id\":\"00000000-0000-0000-0000-000000000002\",\"name\":\"SERVERS\"}"
+      ]
+    },
+    "host": {
+      "hostname": "test-host",
+      "name": "test-host",
+      "os": {
+        "full": "Generic Linux 7",
+        "type": "linux",
+        "version": "x.y.z"
+      }
+    },
+    "log": {
+      "hostname": "test-host"
+    },
+    "network": {
+      "direction": "inbound"
+    },
+    "organization": {
+      "id": "dummy-tenant-id"
+    },
+    "process": {
+      "executable": "/usr/sbin/nginx",
+      "pid": 24946
+    },
+    "related": {
+      "hosts": [
+        "test-host"
+      ],
+      "ip": [
+        "1.2.3.4",
+        "5.6.7.8"
+      ],
+      "user": [
+        "user"
+      ]
+    },
+    "source": {
+      "address": "5.6.7.8",
+      "ip": "5.6.7.8",
+      "port": 60684
+    },
+    "user": {
+      "name": "user",
+      "roles": "SERVERS"
+    }
+  }
+}

--- a/HarfangLab/harfanglab/tests/network5.json
+++ b/HarfangLab/harfanglab/tests/network5.json
@@ -1,0 +1,74 @@
+{
+  "input": {
+    "message": "{\n  \"log_type\": \"network\",\n  \"process_unique_id\": \"00000000-0000-0000-0000-000000000001\",\n  \"groups\": [\n    {\n      \"id\": \"00000000-0000-0000-0000-000000000002\",\n      \"name\": \"SERVERS\"\n    }\n  ],\n  \"conn_type\": 0,\n  \"daddr\": \"127.0.0.1\",\n  \"dport\": 8080,\n  \"daddr_geoip\": {},\n  \"saddr\": \"127.0.0.1\",\n  \"sport\": 42364,\n  \"saddr_geoip\": {},\n  \"direction\": \"in\",\n  \"image_name\": \"/opt/app/java/bin/java\",\n  \"pid\": 39910,\n  \"username\": \"user\",\n  \"event_id\": 3,\n  \"is_ipv6\": false,\n  \"initiated\": false,\n  \"timestamp\": \"2025-07-21T13:01:31.267161Z\",\n  \"@event_create_date\": \"2025-07-21T13:01:31.267161Z\",\n  \"@timestamp\": \"2025-07-21T13:01:33.166683+00:00\",\n  \"tenant\": \"dummy-tenant-id\",\n  \"agent\": {\n    \"agentid\": \"00000000-0000-0000-0000-000000000003\",\n    \"hostname\": \"test-host\",\n    \"domain\": null,\n    \"domainname\": null,\n    \"dnsdomainname\": null,\n    \"ostype\": \"linux\",\n    \"osversion\": \"x.y.z\",\n    \"distroid\": \"generic-linux\",\n    \"osproducttype\": \"Generic Linux 7\",\n    \"version\": \"x.y.z\",\n    \"additional_info\": {},\n    \"ipaddress\": null,\n    \"producttype\": null\n  }\n}"
+  },
+  "expected": {
+    "message": "{\n  \"log_type\": \"network\",\n  \"process_unique_id\": \"00000000-0000-0000-0000-000000000001\",\n  \"groups\": [\n    {\n      \"id\": \"00000000-0000-0000-0000-000000000002\",\n      \"name\": \"SERVERS\"\n    }\n  ],\n  \"conn_type\": 0,\n  \"daddr\": \"127.0.0.1\",\n  \"dport\": 8080,\n  \"daddr_geoip\": {},\n  \"saddr\": \"127.0.0.1\",\n  \"sport\": 42364,\n  \"saddr_geoip\": {},\n  \"direction\": \"in\",\n  \"image_name\": \"/opt/app/java/bin/java\",\n  \"pid\": 39910,\n  \"username\": \"user\",\n  \"event_id\": 3,\n  \"is_ipv6\": false,\n  \"initiated\": false,\n  \"timestamp\": \"2025-07-21T13:01:31.267161Z\",\n  \"@event_create_date\": \"2025-07-21T13:01:31.267161Z\",\n  \"@timestamp\": \"2025-07-21T13:01:33.166683+00:00\",\n  \"tenant\": \"dummy-tenant-id\",\n  \"agent\": {\n    \"agentid\": \"00000000-0000-0000-0000-000000000003\",\n    \"hostname\": \"test-host\",\n    \"domain\": null,\n    \"domainname\": null,\n    \"dnsdomainname\": null,\n    \"ostype\": \"linux\",\n    \"osversion\": \"x.y.z\",\n    \"distroid\": \"generic-linux\",\n    \"osproducttype\": \"Generic Linux 7\",\n    \"version\": \"x.y.z\",\n    \"additional_info\": {},\n    \"ipaddress\": null,\n    \"producttype\": null\n  }\n}",
+    "event": {
+      "category": [
+        "network"
+      ],
+      "dataset": "network",
+      "type": [
+        "connection"
+      ]
+    },
+    "@timestamp": "2025-07-21T13:01:31.267161Z",
+    "agent": {
+      "id": "00000000-0000-0000-0000-000000000003",
+      "name": "harfanglab"
+    },
+    "destination": {
+      "address": "127.0.0.1",
+      "ip": "127.0.0.1",
+      "port": 8080
+    },
+    "harfanglab": {
+      "groups": [
+        "{\"id\":\"00000000-0000-0000-0000-000000000002\",\"name\":\"SERVERS\"}"
+      ]
+    },
+    "host": {
+      "hostname": "test-host",
+      "name": "test-host",
+      "os": {
+        "full": "Generic Linux 7",
+        "type": "linux",
+        "version": "x.y.z"
+      }
+    },
+    "log": {
+      "hostname": "test-host"
+    },
+    "network": {
+      "direction": "inbound"
+    },
+    "organization": {
+      "id": "dummy-tenant-id"
+    },
+    "process": {
+      "executable": "/opt/app/java/bin/java",
+      "pid": 39910
+    },
+    "related": {
+      "hosts": [
+        "test-host"
+      ],
+      "ip": [
+        "127.0.0.1"
+      ],
+      "user": [
+        "user"
+      ]
+    },
+    "source": {
+      "address": "127.0.0.1",
+      "ip": "127.0.0.1",
+      "port": 42364
+    },
+    "user": {
+      "name": "user",
+      "roles": "SERVERS"
+    }
+  }
+}

--- a/HarfangLab/harfanglab/tests/network6.json
+++ b/HarfangLab/harfanglab/tests/network6.json
@@ -1,0 +1,74 @@
+{
+  "input": {
+    "message": "{\n  \"log_type\": \"network\",\n  \"process_unique_id\": \"00000000-0000-0000-0000-000000000001\",\n  \"groups\": [\n    {\n      \"id\": \"00000000-0000-0000-0000-000000000002\",\n      \"name\": \"SERVERS\"\n    }\n  ],\n  \"conn_type\": 0,\n  \"daddr\": \"1.2.3.4\",\n  \"dport\": 443,\n  \"daddr_geoip\": {},\n  \"saddr\": \"1.2.3.4\",\n  \"sport\": 44269,\n  \"saddr_geoip\": {},\n  \"direction\": \"in\",\n  \"image_name\": \"/usr/sbin/nginx\",\n  \"pid\": 24946,\n  \"username\": \"user\",\n  \"event_id\": 3,\n  \"is_ipv6\": false,\n  \"initiated\": false,\n  \"timestamp\": \"2025-07-21T13:01:31.184421Z\",\n  \"@event_create_date\": \"2025-07-21T13:01:31.184421Z\",\n  \"@timestamp\": \"2025-07-21T13:01:33.165890+00:00\",\n  \"tenant\": \"dummy-tenant-id\",\n  \"agent\": {\n    \"agentid\": \"00000000-0000-0000-0000-000000000003\",\n    \"hostname\": \"test-host\",\n    \"domain\": null,\n    \"domainname\": null,\n    \"dnsdomainname\": null,\n    \"ostype\": \"linux\",\n    \"osversion\": \"x.y.z\",\n    \"distroid\": \"generic-linux\",\n    \"osproducttype\": \"Generic Linux 7\",\n    \"version\": \"x.y.z\",\n    \"additional_info\": {},\n    \"ipaddress\": null,\n    \"producttype\": null\n  }\n}"
+  },
+  "expected": {
+    "message": "{\n  \"log_type\": \"network\",\n  \"process_unique_id\": \"00000000-0000-0000-0000-000000000001\",\n  \"groups\": [\n    {\n      \"id\": \"00000000-0000-0000-0000-000000000002\",\n      \"name\": \"SERVERS\"\n    }\n  ],\n  \"conn_type\": 0,\n  \"daddr\": \"1.2.3.4\",\n  \"dport\": 443,\n  \"daddr_geoip\": {},\n  \"saddr\": \"1.2.3.4\",\n  \"sport\": 44269,\n  \"saddr_geoip\": {},\n  \"direction\": \"in\",\n  \"image_name\": \"/usr/sbin/nginx\",\n  \"pid\": 24946,\n  \"username\": \"user\",\n  \"event_id\": 3,\n  \"is_ipv6\": false,\n  \"initiated\": false,\n  \"timestamp\": \"2025-07-21T13:01:31.184421Z\",\n  \"@event_create_date\": \"2025-07-21T13:01:31.184421Z\",\n  \"@timestamp\": \"2025-07-21T13:01:33.165890+00:00\",\n  \"tenant\": \"dummy-tenant-id\",\n  \"agent\": {\n    \"agentid\": \"00000000-0000-0000-0000-000000000003\",\n    \"hostname\": \"test-host\",\n    \"domain\": null,\n    \"domainname\": null,\n    \"dnsdomainname\": null,\n    \"ostype\": \"linux\",\n    \"osversion\": \"x.y.z\",\n    \"distroid\": \"generic-linux\",\n    \"osproducttype\": \"Generic Linux 7\",\n    \"version\": \"x.y.z\",\n    \"additional_info\": {},\n    \"ipaddress\": null,\n    \"producttype\": null\n  }\n}",
+    "event": {
+      "category": [
+        "network"
+      ],
+      "dataset": "network",
+      "type": [
+        "connection"
+      ]
+    },
+    "@timestamp": "2025-07-21T13:01:31.184421Z",
+    "agent": {
+      "id": "00000000-0000-0000-0000-000000000003",
+      "name": "harfanglab"
+    },
+    "destination": {
+      "address": "1.2.3.4",
+      "ip": "1.2.3.4",
+      "port": 443
+    },
+    "harfanglab": {
+      "groups": [
+        "{\"id\":\"00000000-0000-0000-0000-000000000002\",\"name\":\"SERVERS\"}"
+      ]
+    },
+    "host": {
+      "hostname": "test-host",
+      "name": "test-host",
+      "os": {
+        "full": "Generic Linux 7",
+        "type": "linux",
+        "version": "x.y.z"
+      }
+    },
+    "log": {
+      "hostname": "test-host"
+    },
+    "network": {
+      "direction": "inbound"
+    },
+    "organization": {
+      "id": "dummy-tenant-id"
+    },
+    "process": {
+      "executable": "/usr/sbin/nginx",
+      "pid": 24946
+    },
+    "related": {
+      "hosts": [
+        "test-host"
+      ],
+      "ip": [
+        "1.2.3.4"
+      ],
+      "user": [
+        "user"
+      ]
+    },
+    "source": {
+      "address": "1.2.3.4",
+      "ip": "1.2.3.4",
+      "port": 44269
+    },
+    "user": {
+      "name": "user",
+      "roles": "SERVERS"
+    }
+  }
+}


### PR DESCRIPTION
Related to [768](https://github.com/SekoiaLab/integration/issues/768)

## Summary by Sourcery

Add missing smart descriptions metadata for the HarfangLab integration and include new network test fixtures to cover network levels 3 through 6.

Enhancements:
- Introduce smart-descriptions.json for HarfangLab to enable contextual event descriptions.

Tests:
- Add network3.json, network4.json, network5.json, and network6.json fixtures to extend network-level test coverage.