### PR TITLE
Fix: Microsoft Defender Additional Fields (747)

### DIFF
--- a/Microsoft/microsoft-365-defender/_meta/fields.yml
+++ b/Microsoft/microsoft-365-defender/_meta/fields.yml
@@ -332,6 +332,11 @@ action.properties.OnboardingStatus:
   name: action.properties.OnboardingStatus
   type: keyword
 
+action.properties.OperationName:
+  description: ''
+  name: action.properties.OperationName
+  type: keyword
+
 action.properties.OrgLevelAction:
   description: Action taken on the email in response to matches to a policy defined
     at the organizational level
@@ -543,6 +548,21 @@ action.properties.UserLevelAction:
 action.properties.UserLevelPolicy:
   description: End-user mailbox policy that triggered the action taken on the email
   name: action.properties.UserLevelPolicy
+  type: keyword
+
+action.properties.office365.RiskEventType:
+  description: ''
+  name: action.properties.office365.RiskEventType
+  type: keyword
+
+action.properties.office365.UserDisplayName:
+  description: ''
+  name: action.properties.office365.UserDisplayName
+  type: keyword
+
+action.properties.user.risk.static_state:
+  description: ''
+  name: action.properties.user.risk.static_state
   type: keyword
 
 email.direction:

--- a/Microsoft/microsoft-365-defender/ingest/parser.yml
+++ b/Microsoft/microsoft-365-defender/ingest/parser.yml
@@ -704,4 +704,4 @@ stages:
 
       - set:
           user_agent.original: '{{json_event.message.AdditionalInfo | selectattr("Key", "equalto", "userAgent") | map(attribute="Value") | first}}'
-        filter: '{{json_event.message.AdditionalInfo | length > 0}}'
+        filter: "{{json_event.message.AdditionalInfo | length > 0}}"

--- a/Microsoft/microsoft-365-defender/ingest/parser.yml
+++ b/Microsoft/microsoft-365-defender/ingest/parser.yml
@@ -8,6 +8,13 @@ pipeline:
     external:
       name: date.parse
       properties:
+        input_field: "{{json_event.message.DetectedDateTime}}"
+        output_field: datetime
+    filter: '{{json_event.message.get("DetectedDateTime") != None}}'
+  - name: parsed_date
+    external:
+      name: date.parse
+      properties:
         input_field: "{{json_event.message.properties.Timestamp}}"
         output_field: datetime
     filter: '{{json_event.message.properties.get("Timestamp") != None}}'
@@ -104,6 +111,8 @@ pipeline:
     filter: '{{json_event.message.get("category") == "AdvancedHunting-IdentityQueryEvents"}}'
   - name: set_url_click_events
     filter: '{{json_event.message.get("category") == "AdvancedHunting-UrlClickEvents"}}'
+  - name: set_signin_fields
+    filter: '{{json_event.message.get("Activity") == "signin"}}'
 
 stages:
   set_common_fields:
@@ -672,3 +681,27 @@ stages:
           event.dataset: "identity_info"
           event.category: ["iam"]
           event.type: ["user"]
+
+  set_signin_fields:
+    actions:
+      - set:
+          source.ip: "{{json_event.message.IpAddress}}"
+          client.geo.city_name: "{{json_event.message.Location.city}}"
+          client.geo.continent_code: "{{json_event.message.Location.countryOrRegion}}"
+          action.properties.OperationName: "{{json_event.message.OperationName}}"
+          action.properties.office365.RiskEventType: "{{json_event.message.RiskEventType}}"
+          action.properties.office365.UserDisplayName: "{{json_event.message.UserDisplayName}}"
+          action.properties.user.risk.static_state: "{{json_event.message.RiskState}}"
+          user.risk.static_level: "{{json_event.message.RiskLevel}}"
+
+      - set:
+          user.email: "{{json_event.message.UserPrincipalName}}"
+        filter: '{{"@" in json_event.message.get("UserPrincipalName", "")}}'
+
+      - set:
+          user.name: "{{json_event.message.UserPrincipalName}}"
+        filter: '{{"@" not in json_event.message.get("UserPrincipalName", "")}}'
+
+      - set:
+          user_agent.original: '{{json_event.message.AdditionalInfo | selectattr("Key", "equalto", "userAgent") | map(attribute="Value") | first}}'
+        filter: '{{json_event.message.AdditionalInfo | length > 0}}'

--- a/Microsoft/microsoft-365-defender/tests/test_additional_fields_error2.json
+++ b/Microsoft/microsoft-365-defender/tests/test_additional_fields_error2.json
@@ -1,0 +1,67 @@
+{
+  "input": {
+    "message": "{\"Activity\":\"signin\",\"ActivityDateTime\":\"2025-06-23T10:15:32.9490000Z\",\"AdditionalInfo\":[{\"Key\":\"riskReasons\",\"Value\":[\"UnfamiliarASN\",\"UnfamiliarBrowser\",\"UnfamiliarDevice\",\"UnfamiliarIP\",\"UnfamiliarLocation\",\"UnfamiliarEASId\",\"UnfamiliarTenantIPsubnet\"]},{\"Key\":\"userAgent\",\"Value\":\"Mozilla/5.0 (Linux; Android 15; SM-S936B Build/AP3A.240905.015.A2; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/137.0.7151.115 Mobile Safari/537.36 PKeyAuth/1.0\"},{\"Key\":\"alertUrl\",\"Value\":null},{\"Key\":\"mitreTechniques\",\"Value\":\"T1078.004\"}],\"CorrelationId\":\"f6a04952-3411-410a-94ca-eeecefb75fb3\",\"DetectedDateTime\":\"2025-06-23T10:15:32.9490000Z\",\"DetectionTimingType\":\"realtime\",\"Id\":\"1705c714f9d67fab1502feb5e4548dd7d5be04af8dbc026841043720e79d2c3c\",\"IpAddress\":\"1.2.3.4\",\"LastUpdatedDateTime\":\"2025-06-23T10:17:18.8570000Z\",\"Location\":{\"city\":\"Salzburg\",\"state\":\"Salzburg\",\"countryOrRegion\":\"AT\",\"geoCoordinates\":{\"altitude\":0,\"latitude\":47.8005,\"longitude\":13.04441}},\"RequestId\":\"31a4e7c9-e037-49e6-81c5-c089d8470100\",\"RiskDetail\":\"none\",\"RiskEventType\":\"unfamiliarFeatures\",\"RiskLevel\":\"low\",\"RiskState\":\"atRisk\",\"Source\":\"IdentityProtection\",\"TokenIssuerType\":\"AzureAD\",\"UserDisplayName\":\"TestUser, TestUserName\",\"UserId\":\"514fc9b2-d7c2-43b8-b152-6edadda3d7c7\",\"UserPrincipalName\":\"TestUserName.TestUser@ttt.test\",\"OperationName\":\"User Risk Detection\",\"TimeGenerated\":\"2025-06-23T10:17:18.0000000Z\",\"_ItemId\":\"6bc9bf40-501b-11f0-8ee4-000d3ae79fd9\",\"TenantId\":\"9cdd8200-1a5c-4a8d-8184-ea570caf432c\",\"_Internal_WorkspaceResourceId\":\"/subscriptions/9a7137fe-7913-45bd-ad6d-28f2d54c70f8/resourcegroups/rg-log_analytics/providers/microsoft.operationalinsights/workspaces/azureadloganalytics\",\"Type\":\"AADUserRiskEvents\"}",
+    "sekoiaio": {
+      "intake": {
+        "dialect": "Microsoft 365 Defender",
+        "dialect_uuid": "05e6f36d-cee0-4f06-b575-9e43af779f9f"
+      }
+    }
+  },
+  "expected": {
+    "message": "{\"Activity\":\"signin\",\"ActivityDateTime\":\"2025-06-23T10:15:32.9490000Z\",\"AdditionalInfo\":[{\"Key\":\"riskReasons\",\"Value\":[\"UnfamiliarASN\",\"UnfamiliarBrowser\",\"UnfamiliarDevice\",\"UnfamiliarIP\",\"UnfamiliarLocation\",\"UnfamiliarEASId\",\"UnfamiliarTenantIPsubnet\"]},{\"Key\":\"userAgent\",\"Value\":\"Mozilla/5.0 (Linux; Android 15; SM-S936B Build/AP3A.240905.015.A2; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/137.0.7151.115 Mobile Safari/537.36 PKeyAuth/1.0\"},{\"Key\":\"alertUrl\",\"Value\":null},{\"Key\":\"mitreTechniques\",\"Value\":\"T1078.004\"}],\"CorrelationId\":\"f6a04952-3411-410a-94ca-eeecefb75fb3\",\"DetectedDateTime\":\"2025-06-23T10:15:32.9490000Z\",\"DetectionTimingType\":\"realtime\",\"Id\":\"1705c714f9d67fab1502feb5e4548dd7d5be04af8dbc026841043720e79d2c3c\",\"IpAddress\":\"1.2.3.4\",\"LastUpdatedDateTime\":\"2025-06-23T10:17:18.8570000Z\",\"Location\":{\"city\":\"Salzburg\",\"state\":\"Salzburg\",\"countryOrRegion\":\"AT\",\"geoCoordinates\":{\"altitude\":0,\"latitude\":47.8005,\"longitude\":13.04441}},\"RequestId\":\"31a4e7c9-e037-49e6-81c5-c089d8470100\",\"RiskDetail\":\"none\",\"RiskEventType\":\"unfamiliarFeatures\",\"RiskLevel\":\"low\",\"RiskState\":\"atRisk\",\"Source\":\"IdentityProtection\",\"TokenIssuerType\":\"AzureAD\",\"UserDisplayName\":\"TestUser, TestUserName\",\"UserId\":\"514fc9b2-d7c2-43b8-b152-6edadda3d7c7\",\"UserPrincipalName\":\"TestUserName.TestUser@ttt.test\",\"OperationName\":\"User Risk Detection\",\"TimeGenerated\":\"2025-06-23T10:17:18.0000000Z\",\"_ItemId\":\"6bc9bf40-501b-11f0-8ee4-000d3ae79fd9\",\"TenantId\":\"9cdd8200-1a5c-4a8d-8184-ea570caf432c\",\"_Internal_WorkspaceResourceId\":\"/subscriptions/9a7137fe-7913-45bd-ad6d-28f2d54c70f8/resourcegroups/rg-log_analytics/providers/microsoft.operationalinsights/workspaces/azureadloganalytics\",\"Type\":\"AADUserRiskEvents\"}",
+    "event": {
+      "type": [
+        "info"
+      ]
+    },
+    "@timestamp": "2025-06-23T10:15:32.949000Z",
+    "action": {
+      "properties": {
+        "OperationName": "User Risk Detection",
+        "office365": {
+          "RiskEventType": "unfamiliarFeatures",
+          "UserDisplayName": "TestUser, TestUserName"
+        },
+        "user": {
+          "risk": {
+            "static_state": "atRisk"
+          }
+        }
+      }
+    },
+    "client": {
+      "geo": {
+        "city_name": "Salzburg",
+        "continent_code": "AT"
+      }
+    },
+    "related": {
+      "ip": [
+        "1.2.3.4"
+      ]
+    },
+    "source": {
+      "address": "1.2.3.4",
+      "ip": "1.2.3.4"
+    },
+    "user": {
+      "email": "TestUserName.TestUser@ttt.test",
+      "risk": {
+        "static_level": "low"
+      }
+    },
+    "user_agent": {
+      "device": {
+        "name": "Samsung SM-S936B"
+      },
+      "name": "Chrome Mobile WebView",
+      "original": "Mozilla/5.0 (Linux; Android 15; SM-S936B Build/AP3A.240905.015.A2; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/137.0.7151.115 Mobile Safari/537.36 PKeyAuth/1.0",
+      "os": {
+        "name": "Android",
+        "version": "15"
+      },
+      "version": "137.0.7151"
+    }
+  }
+}


### PR DESCRIPTION
Closes [747](https://github.com/SekoiaLab/integration/issues/747)

## Summary by Sourcery

Extend the Microsoft Defender integration to parse DetectedDateTime and enrich signin events with additional fields, update ECS metadata for new properties, and add validation tests

New Features:
- Add conditional parsing of DetectedDateTime into the datetime field
- Introduce a set_signin_fields stage to extract IP, geo data, risk attributes, user identifiers, and user agent for signin activities
- Add metadata definitions for action.properties.OperationName, action.properties.office365.RiskEventType, action.properties.office365.UserDisplayName, and action.properties.user.risk.static_state
- Include a new test file to validate the additional fields mapping