### PR TITLE
Apache: change the way to represent the date in action.properties.timestamp

### DIFF
--- a/Apache/apache/ingest/parser.yml
+++ b/Apache/apache/ingest/parser.yml
@@ -58,8 +58,15 @@ stages:
           action.properties.ruleline: "{{grok.event.ruleline}}"
           action.properties.rulerev: "{{grok.event.rulerev}}"
           action.properties.ruleseverity: "{{grok.event.ruleseverity}}"
-          action.properties.timestamp: "{{grok.event.timestamp or grok.event.error_timestamp}}"
           action.properties.uniqueid: "{{grok.event.uniqueid}}"
+
+      - set:
+          action.properties.timestamp: "{{parse_date.timestamp}}"
+        filter: "{{parse_date.timestamp != null}}"
+
+      - set:
+          action.properties.timestamp: "{{grok.event.error_timestamp|to_rfc3339}}"
+        filter: "{{grok.event.error_timestamp != null}}"
 
   finalizer:
     actions:

--- a/Apache/apache/tests/access_combined.json
+++ b/Apache/apache/tests/access_combined.json
@@ -17,7 +17,7 @@
       "name": "GET",
       "outcome": "success",
       "properties": {
-        "timestamp": "10/Oct/2000:13:55:36 -0700"
+        "timestamp": "2000-10-10T20:55:36.000000Z"
       }
     },
     "http": {

--- a/Apache/apache/tests/access_combined_2.json
+++ b/Apache/apache/tests/access_combined_2.json
@@ -17,7 +17,7 @@
       "name": "GET",
       "outcome": "success",
       "properties": {
-        "timestamp": "15/Jan/2024:14:30:25 +0100"
+        "timestamp": "2024-01-15T13:30:25.000000Z"
       }
     },
     "http": {

--- a/Apache/apache/tests/access_extended.json
+++ b/Apache/apache/tests/access_extended.json
@@ -23,7 +23,7 @@
       "name": "GET",
       "outcome": "success",
       "properties": {
-        "timestamp": "31/Jul/2024:16:41:52 +0200"
+        "timestamp": "2024-07-31T14:41:52.000000Z"
       }
     },
     "destination": {

--- a/Apache/apache/tests/access_failure_1.json
+++ b/Apache/apache/tests/access_failure_1.json
@@ -23,7 +23,7 @@
       "name": "GET",
       "outcome": "failure",
       "properties": {
-        "timestamp": "01/Oct/2024:10:22:11 +0200"
+        "timestamp": "2024-10-01T08:22:11.000000Z"
       }
     },
     "http": {

--- a/Apache/apache/tests/access_failure_2.json
+++ b/Apache/apache/tests/access_failure_2.json
@@ -23,7 +23,7 @@
       "name": "GET",
       "outcome": "failure",
       "properties": {
-        "timestamp": "14/Dec/2023:14:19:32 +0100"
+        "timestamp": "2023-12-14T13:19:32.000000Z"
       }
     },
     "http": {

--- a/Apache/apache/tests/access_redirect.json
+++ b/Apache/apache/tests/access_redirect.json
@@ -23,7 +23,7 @@
       "name": "GET",
       "outcome": "redirect",
       "properties": {
-        "timestamp": "01/Oct/2024:10:22:01 +0200"
+        "timestamp": "2024-10-01T08:22:01.000000Z"
       }
     },
     "http": {

--- a/Apache/apache/tests/access_robot.json
+++ b/Apache/apache/tests/access_robot.json
@@ -1,0 +1,65 @@
+{
+  "input": {
+    "message": "192.0.2.1 - - [14/Dec/2023:14:19:32 +0100] \"GET /robots.txt.exe HTTP/1.1\" 404 7363 \"-\" \"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.6045.159 Safari/537.36\"",
+    "sekoiaio": {
+      "intake": {
+        "dialect": "Apache HTTP Server",
+        "dialect_uuid": "6c2a44e3-a86a-4d98-97a6-d575ffcb29f7"
+      }
+    }
+  },
+  "expected": {
+    "message": "192.0.2.1 - - [14/Dec/2023:14:19:32 +0100] \"GET /robots.txt.exe HTTP/1.1\" 404 7363 \"-\" \"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.6045.159 Safari/537.36\"",
+    "event": {
+      "category": [
+        "web"
+      ],
+      "outcome": "failure",
+      "type": [
+        "access"
+      ]
+    },
+    "action": {
+      "name": "GET",
+      "outcome": "failure",
+      "properties": {
+        "timestamp": "2023-12-14T13:19:32.000000Z"
+      }
+    },
+    "http": {
+      "request": {
+        "method": "GET"
+      },
+      "response": {
+        "bytes": 7363,
+        "status_code": 404
+      },
+      "version": "1.1"
+    },
+    "related": {
+      "ip": [
+        "192.0.2.1"
+      ]
+    },
+    "source": {
+      "address": "192.0.2.1",
+      "ip": "192.0.2.1"
+    },
+    "url": {
+      "original": "/robots.txt.exe",
+      "path": "/robots.txt.exe"
+    },
+    "user_agent": {
+      "device": {
+        "name": "Other"
+      },
+      "name": "Chrome",
+      "original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.6045.159 Safari/537.36",
+      "os": {
+        "name": "Windows",
+        "version": "10"
+      },
+      "version": "119.0.6045"
+    }
+  }
+}

--- a/Apache/apache/tests/access_success.json
+++ b/Apache/apache/tests/access_success.json
@@ -23,7 +23,7 @@
       "name": "POST",
       "outcome": "success",
       "properties": {
-        "timestamp": "01/Oct/2024:08:22:45 +0000"
+        "timestamp": "2024-10-01T08:22:45.000000Z"
       }
     },
     "http": {

--- a/Apache/apache/tests/access_success_02.json
+++ b/Apache/apache/tests/access_success_02.json
@@ -23,7 +23,7 @@
       "name": "GET",
       "outcome": "success",
       "properties": {
-        "timestamp": "04/Aug/2025:09:52:56 +0200"
+        "timestamp": "2025-08-04T07:52:56.000000Z"
       }
     },
     "http": {

--- a/Apache/apache/tests/common_log_format.json
+++ b/Apache/apache/tests/common_log_format.json
@@ -17,7 +17,7 @@
       "name": "GET",
       "outcome": "success",
       "properties": {
-        "timestamp": "10/Oct/2000:13:55:36 -0700"
+        "timestamp": "2000-10-10T20:55:36.000000Z"
       }
     },
     "http": {

--- a/Apache/apache/tests/error.json
+++ b/Apache/apache/tests/error.json
@@ -18,7 +18,7 @@
       "outcome": "failure",
       "outcome_reason": "client denied by server configuration: /export/home/live/ap/htdocs/test",
       "properties": {
-        "timestamp": "Wed Oct 11 14:32:52 2000"
+        "timestamp": "2000-10-11T14:32:52.000000Z"
       }
     },
     "related": {

--- a/Apache/apache/tests/error_2.json
+++ b/Apache/apache/tests/error_2.json
@@ -18,7 +18,7 @@
       "outcome": "failure",
       "outcome_reason": "/usr/local/apache2/htdocs/favicon.ico",
       "properties": {
-        "timestamp": "Fri Sep 09 10:42:29.902022 2011"
+        "timestamp": "2011-09-09T10:42:29.902022Z"
       }
     },
     "process": {

--- a/Apache/apache/tests/error_module.json
+++ b/Apache/apache/tests/error_module.json
@@ -29,7 +29,7 @@
         "ruleid": "960015",
         "ruleline": "36",
         "ruleseverity": "CRITICAL",
-        "timestamp": "Mon Apr 15 15:44:09.056862 2024",
+        "timestamp": "2024-04-15T15:44:09.056862Z",
         "uniqueid": "111111111111111111111111111"
       },
       "type": "warning"

--- a/Apache/apache/tests/needs_striping.json
+++ b/Apache/apache/tests/needs_striping.json
@@ -18,7 +18,7 @@
       "outcome": "success",
       "outcome_reason": "Connection to child 114 established (server app.corp.com:443)",
       "properties": {
-        "timestamp": "Thu Feb 29 11:47:27.072780 2024"
+        "timestamp": "2024-02-29T11:47:27.072780Z"
       }
     },
     "process": {

--- a/Apache/apache/tests/process_id.json
+++ b/Apache/apache/tests/process_id.json
@@ -18,7 +18,7 @@
       "outcome": "success",
       "outcome_reason": "SSL input filter read failed.",
       "properties": {
-        "timestamp": "Thu Feb 29 14:23:43.643358 2024"
+        "timestamp": "2024-02-29T14:23:43.643358Z"
       }
     },
     "process": {


### PR DESCRIPTION
A proposal to change the representation of date in action.properties.timestamp

## Summary by Sourcery

Standardize timestamp representation in the Apache ingest parser by using the parse_date filter and converting error timestamps to RFC3339.

Enhancements:
- Use parse_date.timestamp for action.properties.timestamp when available.
- Fallback to converting grok.event.error_timestamp to RFC3339 for action.properties.timestamp.

Tests:
- Update test fixtures to expect the new timestamp formats across various scenarios.