### PR TITLE
Netskope Transaction events - parse http referrer

### DIFF
--- a/Netskope/netskope-transaction/ingest/parser.yml
+++ b/Netskope/netskope-transaction/ingest/parser.yml
@@ -314,3 +314,7 @@ stages:
       - set:
           netskope.events.category_id: "{{ parse_event.message.get('x-category-id') }}"
         filter: "{{parse_event.message.get('x-category-id') != '-'}}"
+
+      - set:
+          http.request.referrer: "{{ parse_event.message.get('cs-referer') }}"
+        filter: "{{ parse_event.message.get('cs-referer') != '-' }}"

--- a/Netskope/netskope-transaction/tests/test_4.json
+++ b/Netskope/netskope-transaction/tests/test_4.json
@@ -28,7 +28,8 @@
     "http": {
       "request": {
         "method": "POST",
-        "mime_type": "text/xml"
+        "mime_type": "text/xml",
+        "referrer": "https://www.bing.com/AS/API/WindowsCortanaPane/V2/Init"
       },
       "response": {
         "status_code": 204


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/786

## Summary by Sourcery

Parse and map HTTP referrer in Netskope transaction events when available

Enhancements:
- Extract the HTTP referrer from the 'cs-referer' header into the http.request.referrer field

Tests:
- Update test_4.json to include and validate the new http.request.referrer mapping