### PR TITLE
BeyondTrust PRA - parse hash

### DIFF
--- a/BeyondTrust/beyondtrust-pra-sessions/ingest/parser.yml
+++ b/BeyondTrust/beyondtrust-pra-sessions/ingest/parser.yml
@@ -84,6 +84,7 @@ stages:
           url.original: "{{parsed_event.message.data.download_url or parsed_event.message.data.view_url}}"
           file.path: "{{parsed_event.message.data.path}}"
           file.name: "{{parsed_event.message.data.filename}}"
+          file.hash.sha256: "{{parsed_event.message.data.sha256}}"
           registry.key: "{{parsed_event.message.data.key_name}}"
           registry.value: "{{parsed_event.message.data.value_name}}"
 

--- a/BeyondTrust/beyondtrust-pra-sessions/tests/test_file_transfer_complete.json
+++ b/BeyondTrust/beyondtrust-pra-sessions/tests/test_file_transfer_complete.json
@@ -1,0 +1,56 @@
+{
+  "input": {
+    "message": "{\"timestamp\": \"1753112754\", \"event_type\": \"File Transfer Complete\", \"performed_by\": {\"type\": \"customer\", \"name\": \"JOHNDOE\"}, \"data\": {\"filename\": \"C:\\\\tps_report.rtf\", \"sha256\": \"9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08\"}, \"destination\": {\"type\": \"representative\", \"name\": \"Jane Doe\"}, \"session_id\": \"098f6bcd4621d373cade4e832627b4f6\", \"jump_group\": {\"name\": \"EXAMPLE\", \"type\": \"shared\"}}"
+  },
+  "expected": {
+    "message": "{\"timestamp\": \"1753112754\", \"event_type\": \"File Transfer Complete\", \"performed_by\": {\"type\": \"customer\", \"name\": \"JOHNDOE\"}, \"data\": {\"filename\": \"C:\\\\tps_report.rtf\", \"sha256\": \"9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08\"}, \"destination\": {\"type\": \"representative\", \"name\": \"Jane Doe\"}, \"session_id\": \"098f6bcd4621d373cade4e832627b4f6\", \"jump_group\": {\"name\": \"EXAMPLE\", \"type\": \"shared\"}}",
+    "event": {
+      "category": [
+        "session"
+      ],
+      "code": "File Transfer Complete",
+      "dataset": "session",
+      "type": [
+        "info"
+      ]
+    },
+    "@timestamp": "2025-07-21T15:45:54Z",
+    "beyondtrust": {
+      "pra": {
+        "destination_name": "Jane Doe",
+        "destination_type": "representative",
+        "jump_group": {
+          "type": "shared"
+        },
+        "performed_by": {
+          "type": "customer"
+        },
+        "session_id": "098f6bcd4621d373cade4e832627b4f6"
+      }
+    },
+    "file": {
+      "hash": {
+        "sha256": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+      },
+      "name": "C:\\tps_report.rtf"
+    },
+    "group": {
+      "name": "EXAMPLE"
+    },
+    "observer": {
+      "product": "Privileged Remote Access",
+      "vendor": "BeyondTrust"
+    },
+    "related": {
+      "hash": [
+        "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+      ],
+      "user": [
+        "JOHNDOE"
+      ]
+    },
+    "user": {
+      "name": "JOHNDOE"
+    }
+  }
+}


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/794

## Summary by Sourcery

Add SHA256 hash parsing for file transfers and include a corresponding test fixture

Enhancements:
- Extract and populate file.hash.sha256 from incoming event data in the BeyondTrust PRA parser

Tests:
- Add test fixture for file transfer completion including SHA256 field