### PR TITLE
F5 Big-Ip - parse referrer from CEF events

### DIFF
--- a/F5 Networks/f5-big-ip/ingest/parser.yml
+++ b/F5 Networks/f5-big-ip/ingest/parser.yml
@@ -307,6 +307,7 @@ stages:
 
           http.response.status_code: "{{parse_cef_event.message.response_code or parse_cef_event.message.http_code}}"
           http.request.method: "{{parse_cef_event.message.requestMethod}}"
+          http.request.referrer: "{{parse_cef_full_request.message.Referer}}"
 
       - set:
           rule.name: "{{parse_cef_event.message.acl_rule_name}}"

--- a/F5 Networks/f5-big-ip/tests/test_asm1.json
+++ b/F5 Networks/f5-big-ip/tests/test_asm1.json
@@ -46,7 +46,8 @@
     },
     "http": {
       "request": {
-        "method": "GET"
+        "method": "GET",
+        "referrer": "https://5.6.7.8/"
       },
       "response": {
         "status_code": 0

--- a/F5 Networks/f5-big-ip/tests/test_asm2.json
+++ b/F5 Networks/f5-big-ip/tests/test_asm2.json
@@ -41,7 +41,8 @@
     },
     "http": {
       "request": {
-        "method": "GET"
+        "method": "GET",
+        "referrer": "https://HOST_NAME/REFERER_PATH"
       },
       "response": {
         "status_code": 200

--- a/F5 Networks/f5-big-ip/tests/test_successful_request.json
+++ b/F5 Networks/f5-big-ip/tests/test_successful_request.json
@@ -40,7 +40,8 @@
     },
     "http": {
       "request": {
-        "method": "GET"
+        "method": "GET",
+        "referrer": "https://chronograf.example.org/sources/1/chronograf/data-explorer?query\\=SELECT%20mean%28%22db28482.AP001_10%25%22%29%20AS%20%22mean_db28482.AP001_10%25%22%2C%20mean%28%22MNPZ_FCC_Feed_D86_T10Pct%22%29%20AS%20%22mean_MNPZ_FCC_Feed_D86_T10Pct%22%20FROM%20%22db1000000%22.%22autogen%22.%22centralized_data%22%20WHERE%20time%20%3E%20%3AdashboardTime%3A%20AND%20time%20%3C%20%3AupperDashboardTime%3A%20GROUP%20BY%20time%28%3Ainterval%3A%29%20FILL%28null%29"
       },
       "response": {
         "status_code": 200


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/785

## Summary by Sourcery

Add HTTP referrer extraction to the F5 Big-IP CEF parser and update tests accordingly

New Features:
- Map the CEF Referer field to http.request.referrer in the parser

Tests:
- Include Referer in test fixtures and validate referrer mapping