### PR TITLE
Fix: Apply linter

### DIFF
--- a/Cisco/cisco-esa/_meta/fields.yml
+++ b/Cisco/cisco-esa/_meta/fields.yml
@@ -31,14 +31,15 @@ cisco.esa.email.message_size:
   name: cisco.esa.email.message_size
   type: keyword
 
-cisco.esa.friendly.from:
-  description: This field is the friendly header that is displayed in most email clients before the user email address
-  name: cisco.esa.friendly.from
-  type: keyword
-
 cisco.esa.event.action_details:
   description: This field contains the details about the action of the event
   name: cisco.esa.event.action_details
+  type: keyword
+
+cisco.esa.friendly.from:
+  description: This field is the friendly header that is displayed in most email clients
+    before the user email address
+  name: cisco.esa.friendly.from
   type: keyword
 
 cisco.esa.helo.domain:
@@ -91,20 +92,20 @@ cisco.esa.protection.dlp.verdict:
   name: cisco.esa.protection.dlp.verdict
   type: keyword
 
+cisco.esa.protection.graymail.verdict:
+  description: This field indicates the verdict assigned to a message by the ESA's
+    graymail protection mechanism. A verdict can be either NOT EVALUATED (indicating
+    that the message has not been processed) POSITIVE (indicating that the message
+    is considered as a graymail such as Marketing Email, Social Network Email, Bulk
+    Email... ) or NEGATIVE (indicating that the message is not considered as a graymail)
+  name: cisco.esa.protection.graymail.verdict
+  type: keyword
+
 cisco.esa.protection.spam.verdict:
   description: This field indicates the verdict assigned to a message by the ESA's
     spam protection mechanism. A verdict can be either spam (indicating that the message
     is likely unwanted or malicious) or not spam (indicating that the message is legitimate).
   name: cisco.esa.protection.spam.verdict
-  type: keyword
-
-cisco.esa.protection.graymail.verdict:
-  description: This field indicates the verdict assigned to a message by the ESA's
-    graymail protection mechanism. A verdict can be either NOT EVALUATED (indicating
-    that the message has not been processed) POSITIVE (indicating that the message is
-    considered as a graymail such as Marketing Email, Social Network Email, Bulk Email... )
-    or NEGATIVE (indicating that the message is not considered as a graymail)
-  name: cisco.esa.protection.graymail.verdict
   type: keyword
 
 cisco.esa.sender_group:

--- a/Cisco/cisco-esa/tests/test_attachments_details.json
+++ b/Cisco/cisco-esa/tests/test_attachments_details.json
@@ -30,6 +30,9 @@
         "email": {
           "message_size": "340614"
         },
+        "friendly": {
+          "from": "\"John Doe\" <john.doe@example.org>"
+        },
         "helo": {
           "domain": "smtp.smtpout.example.org",
           "ip": "5.6.7.8"
@@ -44,10 +47,10 @@
           "antivirus": {
             "verdict": "NOT_EVALUATED"
           },
-          "spam": {
+          "graymail": {
             "verdict": "NEGATIVE"
           },
-          "graymail": {
+          "spam": {
             "verdict": "NEGATIVE"
           }
         },
@@ -56,9 +59,6 @@
           "domain": {
             "age": "30 days (or greater)"
           }
-        },
-        "friendly": {
-          "from": "\"John Doe\" <john.doe@example.org>"
         },
         "url": [
           "http://schemas.microsoft.com/office/2004/12/omml",

--- a/Cisco/cisco-esa/tests/test_ingest_log1.json
+++ b/Cisco/cisco-esa/tests/test_ingest_log1.json
@@ -21,6 +21,9 @@
         "delivery": {
           "connection_id": "925893"
         },
+        "friendly": {
+          "from": "senderexample@example.com"
+        },
         "helo": {
           "domain": "mail.example.com",
           "ip": "1.2.3.4"
@@ -35,11 +38,11 @@
           "dlp": {
             "verdict": "NOT_EVALUATED"
           },
-          "spam": {
-            "verdict": "NEGATIVE"
-          },
           "graymail": {
             "verdict": "NOT_EVALUATED"
+          },
+          "spam": {
+            "verdict": "NEGATIVE"
           }
         },
         "sender_group": "UNKNOWNLIST",
@@ -47,9 +50,6 @@
           "domain": {
             "age": "9 years 6 months 21 days"
           }
-        },
-        "friendly": {
-          "from": "senderexample@example.com"
         }
       }
     },

--- a/Cisco/cisco-esa/tests/test_ingest_log2.json
+++ b/Cisco/cisco-esa/tests/test_ingest_log2.json
@@ -30,6 +30,9 @@
         "event": {
           "action_details": "5.1.0 - Unknown address error"
         },
+        "friendly": {
+          "from": "no-reply@example.org"
+        },
         "helo": {
           "domain": "mail.example.orgm",
           "ip": "10.0.0.0"
@@ -47,10 +50,10 @@
           "dlp": {
             "verdict": "NOT_EVALUATED"
           },
-          "spam": {
+          "graymail": {
             "verdict": "NEGATIVE"
           },
-          "graymail": {
+          "spam": {
             "verdict": "NEGATIVE"
           }
         },
@@ -59,9 +62,6 @@
           "domain": {
             "age": "9 years 3 months 14 days"
           }
-        },
-        "friendly": {
-          "from": "no-reply@example.org"
         },
         "url": [
           "http://mandrill.appc.cisco.com/track/open.php?u=30372747&id=d57275a6c9df40418a90fd977e3bf506",

--- a/Cisco/cisco-esa/tests/test_ingest_log3.json
+++ b/Cisco/cisco-esa/tests/test_ingest_log3.json
@@ -19,6 +19,9 @@
         "email": {
           "message_size": "3762"
         },
+        "friendly": {
+          "from": "no-reply@example.org"
+        },
         "helo": {
           "domain": "mail.example.org",
           "ip": "10.0.0.0"
@@ -33,18 +36,14 @@
           "antivirus": {
             "verdict": "NOT_EVALUATED"
           },
-          "spam": {
+          "graymail": {
             "verdict": "NOT_EVALUATED"
           },
-          "graymail": {
+          "spam": {
             "verdict": "NOT_EVALUATED"
           }
         },
-        "sender_group": "RELAYLIST",
-        "friendly":
-          {
-            "from": "no-reply@example.org"
-          }
+        "sender_group": "RELAYLIST"
       }
     },
     "email": {
@@ -58,9 +57,6 @@
           }
         }
       ],
-      "reply_to": {
-          "address": "no-reply@example.org"
-        },
       "from": {
         "address": [
           "no-reply@example.org"
@@ -68,6 +64,9 @@
       },
       "local_id": "11111111",
       "message_id": "11111111.2222222222222222222.JavaMail.ccccccccccc@dddddddddddddddd",
+      "reply_to": {
+        "address": "no-reply@example.org"
+      },
       "subject": "'\\=?UTF-8?Q?Nice to Meet you?\\='",
       "to": {
         "address": [

--- a/Cisco/cisco-esa/tests/test_ingest_log4.json
+++ b/Cisco/cisco-esa/tests/test_ingest_log4.json
@@ -19,6 +19,9 @@
         "email": {
           "message_size": "111066"
         },
+        "friendly": {
+          "from": "JOHN DOE <john.doe@example.com>"
+        },
         "helo": {
           "domain": "mail.example.org",
           "ip": "10.0.0.0"
@@ -33,17 +36,14 @@
           "antivirus": {
             "verdict": "NOT_EVALUATED"
           },
-          "spam": {
+          "graymail": {
             "verdict": "NOT_EVALUATED"
           },
-          "graymail": {
+          "spam": {
             "verdict": "NOT_EVALUATED"
           }
         },
-        "sender_group": "RELAYLISTTELEDEP",
-        "friendly": {
-          "from": "JOHN DOE <john.doe@example.com>"
-        }
+        "sender_group": "RELAYLISTTELEDEP"
       }
     },
     "email": {

--- a/Cisco/cisco-esa/tests/test_ingest_log5.json
+++ b/Cisco/cisco-esa/tests/test_ingest_log5.json
@@ -27,6 +27,9 @@
         "email": {
           "message_size": "1197675"
         },
+        "friendly": {
+          "from": "John Doe <john.doe@example.org>"
+        },
         "helo": {
           "domain": "mail.example.org",
           "ip": "10.0.0.0"
@@ -41,10 +44,10 @@
           "antivirus": {
             "verdict": "NOT_EVALUATED"
           },
-          "spam": {
+          "graymail": {
             "verdict": "NEGATIVE"
           },
-          "graymail": {
+          "spam": {
             "verdict": "NEGATIVE"
           }
         },
@@ -53,9 +56,6 @@
           "domain": {
             "age": "30 days (or greater)"
           }
-        },
-        "friendly": {
-          "from": "John Doe <john.doe@example.org>"
         },
         "url": [
           "https://facebook.com/u/john.doe",

--- a/Cisco/cisco-esa/tests/test_ingest_log6.json
+++ b/Cisco/cisco-esa/tests/test_ingest_log6.json
@@ -30,6 +30,9 @@
         "email": {
           "message_size": "73748"
         },
+        "friendly": {
+          "from": "John Doe <john.doe@example.org>"
+        },
         "helo": {
           "domain": "mail.example.org",
           "ip": "10.0.0.0"
@@ -44,10 +47,10 @@
           "antivirus": {
             "verdict": "NOT_EVALUATED"
           },
-          "spam": {
+          "graymail": {
             "verdict": "NEGATIVE"
           },
-          "graymail": {
+          "spam": {
             "verdict": "NEGATIVE"
           }
         },
@@ -55,9 +58,6 @@
           "domain": {
             "age": "30 days (or greater)"
           }
-        },
-        "friendly": {
-          "from": "John Doe <john.doe@example.org>"
         }
       }
     },

--- a/Cisco/cisco-esa/tests/test_ingest_log7.json
+++ b/Cisco/cisco-esa/tests/test_ingest_log7.json
@@ -30,6 +30,9 @@
         "event": {
           "action_details": "Message held temporarily in Delay Quarantine"
         },
+        "friendly": {
+          "from": "John Doe <john.doe@example.org>"
+        },
         "helo": {
           "domain": "mail.example.org",
           "ip": "10.0.0.0"
@@ -44,11 +47,11 @@
           "antivirus": {
             "verdict": "NOT_EVALUATED"
           },
-          "spam": {
-            "verdict": "BULK_MAIL"
-          },
           "graymail": {
             "verdict": "POSITIVE"
+          },
+          "spam": {
+            "verdict": "BULK_MAIL"
           }
         },
         "sender_group": "UNKNOWNLIST",
@@ -56,9 +59,6 @@
           "domain": {
             "age": "30 days (or greater)"
           }
-        },
-        "friendly": {
-          "from": "John Doe <john.doe@example.org>"
         }
       }
     },

--- a/Cisco/cisco-esa/tests/test_ingest_log9.json
+++ b/Cisco/cisco-esa/tests/test_ingest_log9.json
@@ -30,6 +30,9 @@
         "email": {
           "message_size": "418081"
         },
+        "friendly": {
+          "from": "Marc Dupont <m.dupont@corp.fr>"
+        },
         "helo": {
           "domain": "example.org",
           "ip": "192.168.10.244"
@@ -44,11 +47,11 @@
           "dlp": {
             "verdict": "NOT EVALUATED"
           },
-          "spam": {
-            "verdict": "NOT_EVALUATED"
-          },
           "graymail": {
             "verdict": "NEGATIVE"
+          },
+          "spam": {
+            "verdict": "NOT_EVALUATED"
           }
         },
         "sender_group": "SUSPECTLIST",
@@ -56,9 +59,6 @@
           "domain": {
             "age": "30 days (or greater)"
           }
-        },
-        "friendly" : {
-          "from": "Marc Dupont <m.dupont@corp.fr>"
         }
       }
     },

--- a/Cisco/cisco-esa/tests/test_tls.json
+++ b/Cisco/cisco-esa/tests/test_tls.json
@@ -36,10 +36,10 @@
           "dlp": {
             "verdict": "NOT_EVALUATED"
           },
-          "spam": {
+          "graymail": {
             "verdict": "NOT_EVALUATED"
           },
-          "graymail": {
+          "spam": {
             "verdict": "NOT_EVALUATED"
           }
         }

--- a/Trellix/trellix-epo-on-prem/tests/epo_event_35102.json
+++ b/Trellix/trellix-epo-on-prem/tests/epo_event_35102.json
@@ -59,7 +59,9 @@
         "Syst\u00e8me"
       ]
     },
-    "rule": {"id": "330"},
+    "rule": {
+      "id": "330"
+    },
     "source": {
       "user": {
         "domain": "System"


### PR DESCRIPTION
## Summary by Sourcery

Apply linter formatting to Cisco ESA field definitions and test fixtures

Enhancements:
- Wrap long descriptions and adjust ordering of the friendly.from and graymail verdict fields in fields.yml
- Remove duplicate cisco.esa.protection.graymail.verdict entry and relocate it under the correct section

Tests:
- Reformat JSON test fixtures for Cisco ESA and Trellix EPO to comply with linter rules