### PR TITLE
Fix: Fortigate Cfgpath (763)

### DIFF
--- a/Fortinet/fortigate/_meta/fields.yml
+++ b/Fortinet/fortigate/_meta/fields.yml
@@ -43,6 +43,11 @@ fortinet.fortigate.cfgattr:
   name: fortinet.fortigate.cfgattr
   type: keyword
 
+fortinet.fortigate.cfgpath:
+  description: Configuration path
+  name: fortinet.fortigate.cfgpath
+  type: keyword
+
 fortinet.fortigate.cfgtid:
   description: Transaction ID of the configuration
   name: fortinet.fortigate.cfgtid

--- a/Fortinet/fortigate/ingest/parser.yml
+++ b/Fortinet/fortigate/ingest/parser.yml
@@ -217,6 +217,7 @@ stages:
           fortinet.fortigate.vpntype: "{{parsed_event.message.vpntype}}"
           fortinet.fortigate.cfgtid: "{{parsed_event.message.cfgtid or parsed_event.message.FTNTFGTcfgtid or parsed_event.message.FortinetFortiGatecfgtid}}"
           fortinet.fortigate.cfgattr: "{{parsed_event.message.cfgattr or parsed_event.message.FTNTFGTcfgattr or parsed_event.message.FortinetFortiGatecfgattr}}"
+          fortinet.fortigate.cfgpath: "{{parsed_event.message.cfgpath or parsed_event.message.FTNTFGTcfgpath or parsed_event.message.FortinetFortiGatecfgpath}}"
           fortinet.fortigate.event.type: "{{parsed_event.message.type}}"
           fortinet.fortigate.event.severity: "{{parsed_event.message.severity or parsed_event.message.FTNTFGTseverity}}"
           fortinet.fortigate.security_profile: "{{parsed_event.message.profile}}"

--- a/Fortinet/fortigate/tests/editpolicy.json
+++ b/Fortinet/fortigate/tests/editpolicy.json
@@ -29,6 +29,7 @@
     "fortinet": {
       "fortigate": {
         "cfgattr": "service[svc-win->svc-repo-linux-port]",
+        "cfgpath": "firewall.policy",
         "cfgtid": "111111111",
         "event": {
           "type": "event"

--- a/Fortinet/fortigate/tests/event_add_admin.json
+++ b/Fortinet/fortigate/tests/event_add_admin.json
@@ -26,6 +26,7 @@
     "fortinet": {
       "fortigate": {
         "cfgattr": "password[*]accprofile[super_admin]vdom[root]",
+        "cfgpath": "system.admin",
         "cfgtid": "1234567890",
         "event": {
           "type": "event"

--- a/Fortinet/fortigate/tests/system_event_3.json
+++ b/Fortinet/fortigate/tests/system_event_3.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "message": "time=12:35:04 devname=\"DEVNAME01\" devid=\"FGT123456ABCDEF\" eventtime=1748601303656994360 tz=\"+0200\" logid=\"0123456789\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Attribute configured\" user=\"admin\" ui=\"jsconsole(1.2.3.4)\" action=\"Edit\" cfgtid=987654321 cfgpath=\"system.settings\" cfgattr=\"gui-sslvpn[disable->enable]\" msg=\"Edit system.settings \"",
+    "message": "time=12:35:04 devname=\"TESTDEVNAME\" devid=\"TESTDEVID\" eventtime=1748601303656994360 tz=\"+0200\" logid=\"0100044546\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Attribute configured\" user=\"admin\" ui=\"jsconsole(1.2.3.4)\" action=\"Edit\" cfgtid=153616384 cfgpath=\"system.settings\" cfgattr=\"gui-sslvpn[disable->enable]\" msg=\"Edit system.settings \"",
     "sekoiaio": {
       "intake": {
         "dialect": "Fortinet FortiGate",
@@ -9,11 +9,11 @@
     }
   },
   "expected": {
-    "message": "time=12:35:04 devname=\"DEVNAME01\" devid=\"FGT123456ABCDEF\" eventtime=1748601303656994360 tz=\"+0200\" logid=\"0123456789\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Attribute configured\" user=\"admin\" ui=\"jsconsole(1.2.3.4)\" action=\"Edit\" cfgtid=987654321 cfgpath=\"system.settings\" cfgattr=\"gui-sslvpn[disable->enable]\" msg=\"Edit system.settings \"",
+    "message": "time=12:35:04 devname=\"TESTDEVNAME\" devid=\"TESTDEVID\" eventtime=1748601303656994360 tz=\"+0200\" logid=\"0100044546\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Attribute configured\" user=\"admin\" ui=\"jsconsole(1.2.3.4)\" action=\"Edit\" cfgtid=153616384 cfgpath=\"system.settings\" cfgattr=\"gui-sslvpn[disable->enable]\" msg=\"Edit system.settings \"",
     "event": {
       "action": "Edit",
       "category": "event",
-      "code": "0123456789",
+      "code": "0100044546",
       "dataset": "event:system",
       "outcome": "success",
       "reason": "Edit system.settings",
@@ -30,7 +30,7 @@
       "fortigate": {
         "cfgattr": "gui-sslvpn[disable->enable]",
         "cfgpath": "system.settings",
-        "cfgtid": "987654321",
+        "cfgtid": "153616384",
         "event": {
           "type": "event"
         },
@@ -39,16 +39,16 @@
     },
     "log": {
       "description": "Attribute configured",
-      "hostname": "DEVNAME01",
+      "hostname": "TESTDEVNAME",
       "level": "information"
     },
     "observer": {
-      "hostname": "DEVNAME01",
-      "serial_number": "FGT123456ABCDEF"
+      "hostname": "TESTDEVNAME",
+      "serial_number": "TESTDEVID"
     },
     "related": {
       "hosts": [
-        "DEVNAME01"
+        "TESTDEVNAME"
       ],
       "ip": [
         "1.2.3.4"

--- a/Fortinet/fortigate/tests/test_event_source_ip_1.json
+++ b/Fortinet/fortigate/tests/test_event_source_ip_1.json
@@ -29,6 +29,7 @@
     "fortinet": {
       "fortigate": {
         "cfgattr": "name[vpn_remote_0]srcintf[TestTest]dstintf[internal]action[accept]srcaddr[TestTest]dstaddr[TestTest]schedule[always]service[ALL]comments[VPN: TestTest (Created by VPN wizard)]",
+        "cfgpath": "firewall.policy",
         "cfgtid": "1231232131",
         "event": {
           "type": "event"

--- a/Fortinet/fortigate/tests/test_event_source_ip_2.json
+++ b/Fortinet/fortigate/tests/test_event_source_ip_2.json
@@ -29,6 +29,7 @@
     "fortinet": {
       "fortigate": {
         "cfgattr": "name[vpn_TestTest_remote_0]srcintf[TestTest]dstintf[internal]action[accept]srcaddr[TestTest_remote]dstaddr[TestTest_local]schedule[always]service[ALL]comments[VPN: TestTest (Created by VPN wizard)]",
+        "cfgpath": "firewall.policy",
         "cfgtid": "1111111",
         "event": {
           "type": "event"

--- a/Fortinet/fortigate/tests/test_event_source_ip_3.json
+++ b/Fortinet/fortigate/tests/test_event_source_ip_3.json
@@ -29,6 +29,7 @@
     "fortinet": {
       "fortigate": {
         "cfgattr": "uuid[0000000000-48a2-51ee-9a4e-d49ca8f62bfb]srcintf[Z_INTERCO]dstintf[Z_APP]action[accept]srcaddr[Nw-3.3.3.3-AdministrateursDN]dstaddr[Host-2.2.2.2-VIP_PROD]schedule[always]service[HTTPS PING]utm-status[enable]ssl-ssh-profile[certificate-inspection]ips-sensor[Sensor_Web]logtraffic[all]",
+        "cfgpath": "firewall.policy",
         "cfgtid": "111111111",
         "event": {
           "type": "event"

--- a/Fortinet/fortigate/tests/test_event_source_ip_4.json
+++ b/Fortinet/fortigate/tests/test_event_source_ip_4.json
@@ -28,6 +28,7 @@
     "fortinet": {
       "fortigate": {
         "cfgattr": "uuid[00000000-8f03-51ec-de75-17ef43f88c98]subnet[2.1.1.1 255.255.255.255]",
+        "cfgpath": "firewall.address",
         "cfgtid": "1623130112",
         "event": {
           "type": "event"

--- a/Fortinet/fortigate/tests/test_event_source_ip_5.json
+++ b/Fortinet/fortigate/tests/test_event_source_ip_5.json
@@ -28,6 +28,7 @@
     "fortinet": {
       "fortigate": {
         "cfgattr": "server[1.2.1.1->1.2.2.2]",
+        "cfgpath": "log.syslogd.setting",
         "cfgtid": "613613570",
         "event": {
           "type": "event"

--- a/Fortinet/fortigate/tests/test_event_source_ip_6.json
+++ b/Fortinet/fortigate/tests/test_event_source_ip_6.json
@@ -29,6 +29,7 @@
     "fortinet": {
       "fortigate": {
         "cfgattr": "ips-sensor[g-default->default]application-list[g-default->default]",
+        "cfgpath": "firewall.policy",
         "cfgtid": "146604040",
         "event": {
           "type": "event"

--- a/Fortinet/fortigate/tests/test_event_source_ip_7.json
+++ b/Fortinet/fortigate/tests/test_event_source_ip_7.json
@@ -28,6 +28,7 @@
     "fortinet": {
       "fortigate": {
         "cfgattr": "server[1.2.1.1->1.2.2.2]",
+        "cfgpath": "log.syslogd.setting",
         "cfgtid": "17898414",
         "event": {
           "type": "event"


### PR DESCRIPTION
Relates to [763](https://github.com/SekoiaLab/integration/issues/763)

## Summary by Sourcery

Add support for the fortinet.fortigate.cfgpath field by defining it in fields.yml, mapping it in the parser, and updating tests accordingly.

New Features:
- Introduce the fortinet.fortigate.cfgpath keyword field to capture configuration paths

Enhancements:
- Map cfgpath values from incoming FortiGate messages to the new cfgpath field in parser.yml

Tests:
- Update existing JSON fixtures to cover cfgpath scenarios and add a new system_event_3.json test