### PR TITLE
CrowdStrikeFalcon: add back DetectId in the crowdstrike.detect_id field

### DIFF
--- a/CrowdStrike/crowdstrike_falcon/ingest/parser.yml
+++ b/CrowdStrike/crowdstrike_falcon/ingest/parser.yml
@@ -116,7 +116,7 @@ stages:
           process.command_line: "{{parsed_event.message.event.CommandLine}}"
           process.name: "{{parsed_event.message.event.FileName}}"
           process.working_directory: "{{parsed_event.message.event.FilePath}}"
-          crowdstrike.detect_id: "{{parsed_event.message.event.AggregateId}}"
+          crowdstrike.detect_id: "{{parsed_event.message.event.DetectId or parsed_event.message.event.AggregateId}}"
           crowdstrike.composite_id: "{{parsed_event.message.event.CompositeId}}"
           threat.indicator.name: "{{parsed_event.message.event.IOCValue}}"
           threat.technique.name: "{{parsed_event.message.event.Technique or parsed_event.message.event.Techniques}}"

--- a/CrowdStrike/crowdstrike_falcon/tests/detection_summary_event1.json
+++ b/CrowdStrike/crowdstrike_falcon/tests/detection_summary_event1.json
@@ -17,6 +17,7 @@
     "@timestamp": "2023-05-01T08:33:20Z",
     "crowdstrike": {
       "detect_description": "This file meets the Adware/PUP Anti-malware ML algorithms high-confidence threshold.",
+      "detect_id": "ldt:c9794942866f:26628996",
       "event_type": "DetectionSummaryEvent",
       "severity_name": "Low"
     },

--- a/CrowdStrike/crowdstrike_falcon/tests/detection_summary_event2.json
+++ b/CrowdStrike/crowdstrike_falcon/tests/detection_summary_event2.json
@@ -23,6 +23,7 @@
     "@timestamp": "2025-03-25T08:47:39Z",
     "crowdstrike": {
       "detect_description": "A domain matched a Custom Intelligence Indicator (Custom IOC) with high severity.",
+      "detect_id": "ldt:1234567890abcdef1234567890abcdef:1111111111111111111",
       "event_type": "DetectionSummaryEvent",
       "host_groups": [
         "33333333333333333333333333333333",


### PR DESCRIPTION
## Summary by Sourcery

Reintroduce detection ID field mapping from the DetectId event property with fallback to AggregateId and update related test fixtures

Enhancements:
- Support crowdstrike.detect_id from parsed_event.message.event.DetectId with AggregateId fallback

Tests:
- Update detection_summary_event fixtures to include the DetectId field mapping