### PR TITLE
ThinkstCanary - remove country_iso_code and fix timezone field

### DIFF
--- a/ThinkstCanary/thinkst-canary/ingest/parser.yml
+++ b/ThinkstCanary/thinkst-canary/ingest/parser.yml
@@ -75,8 +75,7 @@ stages:
           user_agent.original: "{{parsed_event.message.USERAGENT or parsed_event.message.get('headers', {}).get('User-Agent')}}"
           source.geo.city_name: "{{parsed_event.message.geoip.city}}"
           source.geo.continent_code: "{{parsed_event.message.geoip.continent_code}}"
-          source.geo.country_iso_code: "{{parsed_event.message.geoip.city}}"
-          source.geo.timezone: "{{parsed_event.message.geoip.country_code}}"
+          source.geo.timezone: "{{parsed_event.message.geoip.timezone.id}}"
 
       - set:
           user.name: "{{parsed_event.message.USERNAME or parsed_event.message.user or parsed_event.message.USER}}"

--- a/ThinkstCanary/thinkst-canary/tests/test_dns_canary_token.json
+++ b/ThinkstCanary/thinkst-canary/tests/test_dns_canary_token.json
@@ -44,8 +44,7 @@
       "geo": {
         "city_name": "Paris",
         "continent_code": "EU",
-        "country_iso_code": "Paris",
-        "timezone": "FR"
+        "timezone": "Europe/Paris"
       },
       "ip": "1.2.3.4",
       "port": 40296

--- a/ThinkstCanary/thinkst-canary/tests/test_http_canary_token.json
+++ b/ThinkstCanary/thinkst-canary/tests/test_http_canary_token.json
@@ -37,8 +37,7 @@
       "geo": {
         "city_name": "Emerainville",
         "continent_code": "EU",
-        "country_iso_code": "Emerainville",
-        "timezone": "FR"
+        "timezone": "Europe/Paris"
       },
       "ip": "1.2.3.4",
       "port": 0


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/821

1. Remove country_iso_code according to https://github.com/SekoiaLab/integration/issues/822
2. Fix timezone field

## Summary by Sourcery

Remove obsolete country_iso_code mapping and correct timezone extraction in ThinkstCanary parser

Bug Fixes:
- Fix source.geo.timezone to use geoip.timezone.id instead of country_code

Enhancements:
- Drop the source.geo.country_iso_code field mapping

Tests:
- Update test fixtures to reflect removal of country_iso_code and timezone mapping fix