### PR TITLE
OFFICE 365 - add email parsing 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 __pycache__
 .DS_Store
 .vscode/*
+.devcontainer/*

--- a/Office 365/o365/ingest/parser.yml
+++ b/Office 365/o365/ingest/parser.yml
@@ -67,6 +67,8 @@ pipeline:
     filter: "{{json_event.message.RecordType == 20}}"
   - name: parse_threat_intelligence_url
     filter: "{{json_event.message.RecordType == 41}}"
+  - name: parse_office_email
+    filter: "{{json_event.message.RecordType == 43}}"
 
 stages:
   set_common_fields:
@@ -1044,3 +1046,12 @@ stages:
     actions:
       - set:
           url.original: "{{json_event.message.Url}}"
+
+  parse_office_email:
+    actions:
+      - set:
+          email.sender.address: "{{json_event.message.Sender}}"
+          email.subject: "{{json_event.message.ItemName}}"
+      - set:
+          email.to.address: "{{json_event.message.Receivers}}"
+        filter: '{{json_event.message.get("Receivers", []) != []}}'

--- a/Office 365/o365/tests/email_reported2.json
+++ b/Office 365/o365/tests/email_reported2.json
@@ -1,0 +1,75 @@
+{
+  "input": {
+    "message": "{\"CreationTime\":\"2025-08-13T14:02:32\",\"Id\":\"id-1\",\"Operation\":\"MipLabel\",\"OrganizationId\":\"org-1\",\"RecordType\":43,\"UserKey\":\"userkey-1\",\"UserType\":0,\"Version\":1,\"Workload\":\"Exchange\",\"ObjectId\":\"objectid-1\",\"UserId\":\"user-1@example.com\",\"ApplicationMode\":\"Standard\",\"ItemName\":\"subject-1\",\"LabelAction\":\"None\",\"LabelAppliedDateTime\":\"2025-06-25T12:40:11\",\"LabelId\":\"labelid-1\",\"LabelName\":\"Internal\",\"Receivers\":[\"user-2@example.com\",\"user-3@example.com\",\"user-4@example.com\",\"user-5@example.com\",\"user-6@example.com\",\"user-7@example.com\",\"user-8@example.com\",\"user-9@example.com\",\"user-10@example.com\",\"user-11@example.com\",\"user-12@example.com\",\"user-13@example.com\",\"user-14@example.com\",\"user-15@example.com\",\"user-16@example.com\",\"user-17@example.com\",\"user-18@example.com\",\"user-19@example.com\",\"user-20@example.com\"],\"Sender\":\"user-1@example.com\"}\n"
+  },
+  "expected": {
+    "message": "{\"CreationTime\":\"2025-08-13T14:02:32\",\"Id\":\"id-1\",\"Operation\":\"MipLabel\",\"OrganizationId\":\"org-1\",\"RecordType\":43,\"UserKey\":\"userkey-1\",\"UserType\":0,\"Version\":1,\"Workload\":\"Exchange\",\"ObjectId\":\"objectid-1\",\"UserId\":\"user-1@example.com\",\"ApplicationMode\":\"Standard\",\"ItemName\":\"subject-1\",\"LabelAction\":\"None\",\"LabelAppliedDateTime\":\"2025-06-25T12:40:11\",\"LabelId\":\"labelid-1\",\"LabelName\":\"Internal\",\"Receivers\":[\"user-2@example.com\",\"user-3@example.com\",\"user-4@example.com\",\"user-5@example.com\",\"user-6@example.com\",\"user-7@example.com\",\"user-8@example.com\",\"user-9@example.com\",\"user-10@example.com\",\"user-11@example.com\",\"user-12@example.com\",\"user-13@example.com\",\"user-14@example.com\",\"user-15@example.com\",\"user-16@example.com\",\"user-17@example.com\",\"user-18@example.com\",\"user-19@example.com\",\"user-20@example.com\"],\"Sender\":\"user-1@example.com\"}\n",
+    "event": {
+      "action": "MipLabel",
+      "code": "43",
+      "outcome": "success"
+    },
+    "@timestamp": "2025-08-13T14:02:32Z",
+    "action": {
+      "id": 43,
+      "name": "MipLabel",
+      "outcome": "success",
+      "target": "user"
+    },
+    "email": {
+      "sender": {
+        "address": "user-1@example.com"
+      },
+      "subject": "subject-1",
+      "to": {
+        "address": [
+          "user-10@example.com",
+          "user-11@example.com",
+          "user-12@example.com",
+          "user-13@example.com",
+          "user-14@example.com",
+          "user-15@example.com",
+          "user-16@example.com",
+          "user-17@example.com",
+          "user-18@example.com",
+          "user-19@example.com",
+          "user-20@example.com",
+          "user-2@example.com",
+          "user-3@example.com",
+          "user-4@example.com",
+          "user-5@example.com",
+          "user-6@example.com",
+          "user-7@example.com",
+          "user-8@example.com",
+          "user-9@example.com"
+        ]
+      }
+    },
+    "office365": {
+      "audit": {
+        "object_id": "objectid-1"
+      },
+      "record_type": 43,
+      "user_type": {
+        "code": 0,
+        "name": "Regular"
+      }
+    },
+    "organization": {
+      "id": "org-1"
+    },
+    "related": {
+      "user": [
+        "user-1@example.com"
+      ]
+    },
+    "service": {
+      "name": "Exchange"
+    },
+    "user": {
+      "email": "user-1@example.com",
+      "id": "userkey-1",
+      "name": "user-1@example.com"
+    }
+  }
+}


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/833

## Summary by Sourcery

Add support for parsing Office 365 email events by introducing a new parser stage and mapping relevant ECS email fields, and include a corresponding test fixture.

New Features:
- Introduce parse_office_email stage to handle Office 365 email events (RecordType 43)

Enhancements:
- Map Sender, ItemName, and Receivers fields to ECS email.sender.address, email.subject, and email.to.address respectively

Tests:
- Add email_reported2.json fixture for testing email parsing