### PR TITLE
OpenLDAP - fix event.outcome

### DIFF
--- a/OpenLDAP/openldap/ingest/parser.yml
+++ b/OpenLDAP/openldap/ingest/parser.yml
@@ -87,6 +87,7 @@ stages:
       - set:
           event.category: ["authentication"]
           event.type: ["end"]
+          event.outcome: "success"
         filter: "{{pre_parsing.pre_message.action_type in ['UNBIND']}}"
 
       - set:

--- a/OpenLDAP/openldap/tests/test_miscellaneous_5.json
+++ b/OpenLDAP/openldap/tests/test_miscellaneous_5.json
@@ -9,6 +9,7 @@
       "category": [
         "authentication"
       ],
+      "outcome": "success",
       "type": [
         "end"
       ]


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/596

In OpenLDAP a BIND event doesn't represent finished action, we actually get result later with RESULT log (and RESULT log isn't dedicated to BIND events only, so we cannot mark every RESULT as a finished auth events)

```
conn=2804 op=3 BIND anonymous mech=implicit ssf=0
conn=2804 op=3 BIND dn="" method=128
conn=2804 op=3 RESULT tag=97 err=0 text=
```

Thus, I don't believe we can add `event.outcome` for BIND events.