### PR TITLE
Netskope - fix event.outcome

### DIFF
--- a/Netskope/netskope_events/ingest/parser.yml
+++ b/Netskope/netskope_events/ingest/parser.yml
@@ -248,16 +248,26 @@ stages:
       - set:
           event.category: ["authentication"]
         filter: '{{"Login" in parsed_event.message.audit_log_event or "Logout" in parsed_event.message.audit_log_event}}'
+
       - translate:
         dictionary:
           "Login Successful": ["start"]
           "Login Failed": ["info"]
           "Logout Successful": ["end"]
-
         mapping:
           parsed_event.message.audit_log_event: event.type
         fallback: ["info"]
         filter: '{{"Login" in parsed_event.message.audit_log_event or "Logout" in parsed_event.message.audit_log_event}}'
+
+      - translate:
+        dictionary:
+          "Login Successful": "success"
+          "Login Failed": "failure"
+          "Logout Successful": "success"
+        mapping:
+          parsed_event.message.audit_log_event: event.outcome
+        filter: '{{"Login" in parsed_event.message.audit_log_event or "Logout" in parsed_event.message.audit_log_event}}'
+
       - set:
           event.category: ["iam"]
           event.type: ["change"]

--- a/Netskope/netskope_events/tests/test_audit_log_login_failed.json
+++ b/Netskope/netskope_events/tests/test_audit_log_login_failed.json
@@ -10,6 +10,7 @@
       ],
       "dataset": "admin_audit_logs",
       "kind": "event",
+      "outcome": "failure",
       "reason": "Login Failed",
       "type": [
         "info"

--- a/Netskope/netskope_events/tests/test_audit_log_login_successful.json
+++ b/Netskope/netskope_events/tests/test_audit_log_login_successful.json
@@ -10,6 +10,7 @@
       ],
       "dataset": "admin_audit_logs",
       "kind": "event",
+      "outcome": "success",
       "reason": "Login Successful",
       "type": [
         "start"

--- a/Netskope/netskope_events/tests/test_audit_log_logout_successful.json
+++ b/Netskope/netskope_events/tests/test_audit_log_logout_successful.json
@@ -10,6 +10,7 @@
       ],
       "dataset": "admin_audit_logs",
       "kind": "event",
+      "outcome": "success",
       "reason": "Logout Successful",
       "type": [
         "end"


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/594

## Summary by Sourcery

Add mapping for event.outcome in the Netskope event parser based on audit log messages and update corresponding tests

Bug Fixes:
- Populate event.outcome as 'success' or 'failure' for login and logout audit events in the parser

Tests:
- Update JSON tests for login and logout events to assert the new event.outcome field