### PR TITLE
Nozomi CMC: add module uuid

### DIFF
--- a/Nozomi/nozomi-cmc/_meta/manifest.yml
+++ b/Nozomi/nozomi-cmc/_meta/manifest.yml
@@ -1,4 +1,5 @@
 uuid: baf03007-4fbc-427e-a966-fa50cbe77856
+automation_module_uuid: fca9d3d3-a252-467b-8735-0fd0ff17e07f
 name: Nozomi CMC [BETA]
 slug: nozomi-cmc
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Add automation_module_uuid field to the Nozomi CMC manifest