### PR TITLE
Adding parsing process.command_line for KBD_INPUT

### DIFF
--- a/Wallix/wallix-bastion/ingest/parser.yml
+++ b/Wallix/wallix-bastion/ingest/parser.yml
@@ -108,6 +108,10 @@ stages:
           process.command_line: "{{ parsed_event.message.command_line }}"
         filter: '{{parsed_event.message.get("type") in ["NEW_PROCESS", "COMPLETED_PROCESS"]}}'
 
+      - set:
+          process.command_line: "{{ parsed_event.message.data }}"
+        filter: '{{parsed_event.message.get("type") == "KBD_INPUT"}}'
+
   set_auditd:
     actions:
       - set:


### PR DESCRIPTION
Bonjour,

Suite à la demande support suivante : https://support.sekoia.io/hc/fr/requests/6760.

Nous souhaiterions avancer sur le sujet.

Un log exemple : 5c074dcd-1f4e-4a35-b19c-8510c0c54acb à 26/08/2025 10:10:56.

## Summary by Sourcery

Enhancements:
- Extract process.command_line from parsed_event.message.data for KBD_INPUT events.