### PR TITLE
McAfee Web Gateway: URL enhancements

### DIFF
--- a/SkyhighSecurity/skyhigh_secure_web_gateway/ingest/parser.yml
+++ b/SkyhighSecurity/skyhigh_secure_web_gateway/ingest/parser.yml
@@ -97,8 +97,11 @@ stages:
       - set:
           url.original: "{{parse_kv.message.requested_path}}"
           url.full: "{{parse_kv.message.uri_scheme}}://{{parse_kv.message.requested_host}}{{parse_kv.message.requested_path}}"
+          url.domain: "{{parse_kv.message.requested_host}}"
         filter: "{{parse_kv.message.requested_path != null and parse_kv.message.uri_scheme != null and parse_kv.message.requested_host!= null and parse_kv.message.requested_path != null}}"
-
+      - set:
+          url.extension: "{{parse_kv.message.requested_path.split('?')[0].split('.')[-1]}}"
+        filter: "{{parse_kv.message.requested_path != null and '.' in parse_kv.message.requested_path.split('?')[0]}}"
       - set:
           user_agent.original: "{{parse_kv.message.user_agent or parse_kv.message.user_agent_product}}"
         filter: '{{parse_kv.message.user_agent != null and parse_kv.message.user_agent != "-" and parse_kv.message.user_agent != ""}}'

--- a/SkyhighSecurity/skyhigh_secure_web_gateway/tests/skyhigh_swg.json
+++ b/SkyhighSecurity/skyhigh_secure_web_gateway/tests/skyhigh_swg.json
@@ -85,6 +85,7 @@
       }
     },
     "url": {
+      "domain": "ping-edge.smartscreen.microsoft.com",
       "full": "https://ping-edge.smartscreen.microsoft.com/",
       "original": "/",
       "path": "/",

--- a/SkyhighSecurity/skyhigh_secure_web_gateway/tests/skyhigh_swg_1.json
+++ b/SkyhighSecurity/skyhigh_secure_web_gateway/tests/skyhigh_swg_1.json
@@ -91,6 +91,7 @@
       }
     },
     "url": {
+      "domain": "wetransfer.com",
       "full": "https://wetransfer.com/api/v4/transfers/azerty123/finalize",
       "original": "/api/v4/transfers/azerty123/finalize",
       "path": "/api/v4/transfers/azerty123/finalize",

--- a/SkyhighSecurity/skyhigh_secure_web_gateway/tests/skyhigh_swg_2.json
+++ b/SkyhighSecurity/skyhigh_secure_web_gateway/tests/skyhigh_swg_2.json
@@ -1,0 +1,113 @@
+{
+  "input": {
+    "message": "user_id=-1 username=johndoe source_ip=1.2.3.4 http_action=GET server_to_client_bytes=6877 client_to_server_bytes=90 requested_host=domain.requested.host.com requested_path=/scripts/publishers/65e74c523defca0008346b3f/file.js?name=test&team=integration result=OBSERVED virus= request_timestamp_epoch=1753717241 request_timestamp=2025-07-28 15:40:41 uri_scheme=https category=Content Server media_type=text/plain application_type= reputation=Minimal Risk last_rule=Allow http_status_code=200 client_ip=5.6.7.8 location= block_reason= user_agent_product=Edge user_agent_version=137.0.0.0 user_agent_comment=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36 Edg/137.0.0.0 process_name=msedge.exe destination_ip=10.20.30.40 destination_port=443 pop_country_code=FR referer=https://referer.com/ ssl_scanned=t av_scanned_up=t av_scanned_down=t rbi=f dlp=f client_system_name=client123-sys456 filename=file.js pop_egress_ip=50.60.70.80 pop_ingress_ip=11.22.33.44 proxy_port=8081",
+    "sekoiaio": {
+      "intake": {
+        "dialect": "Skyhigh Secure Web Gateway / McAfee Web Gateway",
+        "dialect_uuid": "40bac399-2d8e-40e3-af3b-f73a622c9687"
+      }
+    }
+  },
+  "expected": {
+    "message": "user_id=-1 username=johndoe source_ip=1.2.3.4 http_action=GET server_to_client_bytes=6877 client_to_server_bytes=90 requested_host=domain.requested.host.com requested_path=/scripts/publishers/65e74c523defca0008346b3f/file.js?name=test&team=integration result=OBSERVED virus= request_timestamp_epoch=1753717241 request_timestamp=2025-07-28 15:40:41 uri_scheme=https category=Content Server media_type=text/plain application_type= reputation=Minimal Risk last_rule=Allow http_status_code=200 client_ip=5.6.7.8 location= block_reason= user_agent_product=Edge user_agent_version=137.0.0.0 user_agent_comment=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36 Edg/137.0.0.0 process_name=msedge.exe destination_ip=10.20.30.40 destination_port=443 pop_country_code=FR referer=https://referer.com/ ssl_scanned=t av_scanned_up=t av_scanned_down=t rbi=f dlp=f client_system_name=client123-sys456 filename=file.js pop_egress_ip=50.60.70.80 pop_ingress_ip=11.22.33.44 proxy_port=8081",
+    "event": {
+      "action": "allowed",
+      "category": [
+        "network"
+      ],
+      "type": [
+        "access",
+        "allowed",
+        "connection"
+      ]
+    },
+    "@timestamp": "2025-07-28T15:40:41Z",
+    "destination": {
+      "address": "domain.requested.host.com",
+      "bytes": 6877,
+      "domain": "domain.requested.host.com",
+      "ip": "10.20.30.40",
+      "port": 443,
+      "registered_domain": "host.com",
+      "subdomain": "domain.requested",
+      "top_level_domain": "com"
+    },
+    "file": {
+      "name": "file.js"
+    },
+    "host": {
+      "name": "client123-sys456"
+    },
+    "http": {
+      "request": {
+        "method": "GET",
+        "mime_type": "text/plain"
+      },
+      "response": {
+        "mime_type": "text/plain",
+        "status_code": 200
+      }
+    },
+    "network": {
+      "direction": "egress"
+    },
+    "observer": {
+      "product": "McAfee Web Gateway",
+      "type": "proxy",
+      "vendor": "McAfee Corp."
+    },
+    "process": {
+      "name": "msedge.exe"
+    },
+    "related": {
+      "hosts": [
+        "domain.requested.host.com"
+      ],
+      "ip": [
+        "1.2.3.4",
+        "10.20.30.40",
+        "5.6.7.8"
+      ],
+      "user": [
+        "johndoe"
+      ]
+    },
+    "rule": {
+      "category": "Content Server",
+      "name": "Allow"
+    },
+    "skyhighsecurity": {
+      "av_scanned_down": "true",
+      "av_scanned_up": "true",
+      "dlp": "false",
+      "proxy_port": 8081,
+      "rbi": "false",
+      "referer": "https://referer.com/",
+      "reputation": "Minimal Risk",
+      "ssl_scanned": "true",
+      "user_agent_comment": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36 Edg/137.0.0.0",
+      "user_agent_version": "137.0.0.0"
+    },
+    "source": {
+      "address": "5.6.7.8",
+      "bytes": 90,
+      "ip": "5.6.7.8",
+      "nat": {
+        "ip": "1.2.3.4"
+      }
+    },
+    "url": {
+      "domain": "domain.requested.host.com",
+      "extension": "js",
+      "full": "https://domain.requested.host.com/scripts/publishers/65e74c523defca0008346b3f/file.js?name=test&team=integration",
+      "original": "/scripts/publishers/65e74c523defca0008346b3f/file.js?name=test&team=integration",
+      "path": "/scripts/publishers/65e74c523defca0008346b3f/file.js?name=test&team=integration",
+      "port": 443,
+      "query": "name=test&team=integration",
+      "scheme": "https"
+    },
+    "user": {
+      "name": "johndoe"
+    }
+  }
+}

--- a/SkyhighSecurity/skyhigh_secure_web_gateway/tests/skyhigh_swg_block.json
+++ b/SkyhighSecurity/skyhigh_secure_web_gateway/tests/skyhigh_swg_block.json
@@ -82,6 +82,8 @@
       }
     },
     "url": {
+      "domain": "ctldl.windowsupdate.com",
+      "extension": "cab",
       "full": "http://ctldl.windowsupdate.com/msdownload/update/v3/static/trustedr/en/pinrulesstl.cab",
       "original": "/msdownload/update/v3/static/trustedr/en/pinrulesstl.cab",
       "path": "/msdownload/update/v3/static/trustedr/en/pinrulesstl.cab",


### PR DESCRIPTION
Enhancement related to [this issue](https://github.com/SekoiaLab/integration/issues/798)

`url.subdomain` is not defined due to the structure of [Ingest](https://github.com/SekoiaLab/platform/blob/develop/services/ingest/ingest/common/helpers/ecs.py#L586). There is in our events a `url.original` fields, but it is not the one in which `url.domain` can be found (and the next step of the code being an `elif`, the `url.domain` field is not treated here). Some suggestions to fix it :

- Taking only `url.domain.split('.')[:-2]` in order to not have the registered domain nor the top level domain (but according to ECS specification concerning [top level domain](https://www.elastic.co/docs/reference/ecs/ecs-url#field-url-top-level-domain), it is probably not really suitable and might generate errors)
- Not extract this field for this kind of events
- See with engineering for a fix on `finalize_event_fields_url` in Ingest