### PR TITLE
Nozomi vantage : Add some smart description for alerts

### DIFF
--- a/Nozomi/nozomi-vantage/_meta/smart-descriptions.json
+++ b/Nozomi/nozomi-vantage/_meta/smart-descriptions.json
@@ -1,5 +1,32 @@
 [
   {
+    "value": "Alert triggered from {source.ip}:{source.port} to {destination.ip}:{destination.port} with severity {event.severity}: {event.reason}",
+    "conditions": [
+      {
+        "field": "source.ip"
+      },
+      {
+        "field": "source.port"
+      },
+      {
+        "field": "destination.ip"
+      },
+      {
+        "field": "destination.port"
+      },
+      {
+        "field": "event.severity"
+      },
+      {
+        "field": "event.reason"
+      },
+      {
+        "field": "event.kind",
+        "value": "alert"
+      }
+    ]
+  },
+  {
     "value": "Alert triggered from {source.ip}:{source.port} to {destination.ip}:{destination.port} with severity {event.severity}: {event.action}",
     "conditions": [
       {
@@ -17,6 +44,108 @@
       {
         "field": "event.severity"
       },
+      {
+        "field": "event.action"
+      },
+      {
+        "field": "event.kind",
+        "value": "alert"
+      }
+    ]
+  },
+  {
+    "value": "Alert triggered from {source.ip} to {destination.ip} with severity {event.severity}: {event.reason}",
+    "conditions": [
+      {
+        "field": "source.ip"
+      },
+      {
+        "field": "destination.ip"
+      },
+      {
+        "field": "event.severity"
+      },
+      {
+        "field": "event.reason"
+      },
+      {
+        "field": "event.kind",
+        "value": "alert"
+      }
+    ]
+  },
+  {
+    "value": "Alert triggered from {source.ip} to {destination.ip} with severity {event.severity}: {event.action}",
+    "conditions": [
+      {
+        "field": "source.ip"
+      },
+      {
+        "field": "destination.ip"
+      },
+      {
+        "field": "event.severity"
+      },
+      {
+        "field": "event.action"
+      },
+      {
+        "field": "event.kind",
+        "value": "alert"
+      }
+    ]
+  },
+  {
+    "value": "Alert triggered from {source.ip} to {destination.ip}: {event.reason}",
+    "conditions": [
+      {
+        "field": "source.ip"
+      },
+      {
+        "field": "destination.ip"
+      },
+      {
+        "field": "event.reason"
+      },
+      {
+        "field": "event.kind",
+        "value": "alert"
+      }
+    ]
+  },
+  {
+    "value": "Alert triggered from {source.ip} to {destination.ip}: {event.action}",
+    "conditions": [
+      {
+        "field": "source.ip"
+      },
+      {
+        "field": "destination.ip"
+      },
+      {
+        "field": "event.action"
+      },
+      {
+        "field": "event.kind",
+        "value": "alert"
+      }
+    ]
+  },
+  {
+    "value": "Alert triggered : {event.reason}",
+    "conditions": [
+      {
+        "field": "event.reason"
+      },
+      {
+        "field": "event.kind",
+        "value": "alert"
+      }
+    ]
+  },
+  {
+    "value": "Alert triggered : {event.action}",
+    "conditions": [
       {
         "field": "event.action"
       },


### PR DESCRIPTION
Summary of this PR :
- Enhance alert descriptions to include the event.reason value.
- The ticket also proposed adding several fields, but they’re already provided by the parser.
Related issue: https://github.com/SekoiaLab/integration/issues/867