### PR TITLE
Utils: add support for arrays as condition value

### DIFF
--- a/utils/show_smart_descriptions.py
+++ b/utils/show_smart_descriptions.py
@@ -43,7 +43,10 @@ class SmartDescriptionManager(IntakeTestManager):
 
                 if condition_value is not None:
                     if isinstance(parsed[condition_field], list):
-                        condition_value_set = set(item.strip() for item in condition_value.split(","))
+                        if isinstance(condition_value, list):
+                            condition_value_set = set(condition_value)
+                        else:
+                            condition_value_set = set(item.strip() for item in condition_value.split(","))
 
                         if len(parsed[condition_field]) == 0 or set(parsed[condition_field]) != condition_value_set:
                             all_conditions_are_met = False


### PR DESCRIPTION
After a little discussion with the Frontend team, the smart-description engine supports condition's values as array.