### PR TITLE
Office365: don't extract the machine name, from AIR events, into host.name

### DIFF
--- a/Office 365/o365/_meta/fields.yml
+++ b/Office 365/o365/_meta/fields.yml
@@ -413,6 +413,11 @@ office365.logon_error:
   name: office365.logon_error
   type: keyword
 
+office365.machine_name:
+  description: Machine name
+  name: office365.machine_name
+  type: keyword
+
 office365.ofph:
   description: ''
   name: office365.ofph

--- a/Office 365/o365/ingest/parser.yml
+++ b/Office 365/o365/ingest/parser.yml
@@ -809,7 +809,7 @@ stages:
           office365.investigation.alert.source_type: "{{parse_data.ParsedData.SourceAlertType}}"
           event.start: "{{json_event.message.StartTimeUtc}}"
           event.end: "{{json_event.message.EndTimeUtc}}"
-          host.name: "{{parse_data.ParsedData.MachineName}}"
+          office365.machine_name: "{{parse_data.ParsedData.MachineName}}"
           log.level: "{{parse_data.ParsedData.Severity}}"
           rule.name: "{{parse_data.ParsedData.AlertDisplayName}}"
 

--- a/Office 365/o365/tests/automated_investigation_and_response.json
+++ b/Office 365/o365/tests/automated_investigation_and_response.json
@@ -19,9 +19,6 @@
       "outcome": "success",
       "target": "user"
     },
-    "host": {
-      "name": "machine_name_value"
-    },
     "log": {
       "level": "severity_value"
     },
@@ -47,6 +44,7 @@
         "status": "Remediated",
         "type": "ZappedUrlInvestigation"
       },
+      "machine_name": "machine_name_value",
       "record_id": "60eaf0aa-edc3-4f8d-8275-bc82d9500e59",
       "record_type": 64,
       "user_type": {

--- a/Office 365/o365/tests/automated_investigation_and_response_1.json
+++ b/Office 365/o365/tests/automated_investigation_and_response_1.json
@@ -41,9 +41,6 @@
         ]
       }
     },
-    "host": {
-      "name": "MachineNameTest"
-    },
     "log": {
       "level": "Informational"
     },
@@ -146,6 +143,7 @@
         ],
         "type": "ZappedUrlInvestigation"
       },
+      "machine_name": "MachineNameTest",
       "record_id": "c3ebef20-fb63-4d14-b3c1-7bfb5937903a",
       "record_type": 64,
       "user_type": {

--- a/Office 365/o365/tests/automated_investigation_and_response_2.json
+++ b/Office 365/o365/tests/automated_investigation_and_response_2.json
@@ -32,9 +32,6 @@
         ]
       }
     },
-    "host": {
-      "name": "PC01"
-    },
     "log": {
       "level": "High"
     },
@@ -70,6 +67,7 @@
         "status": "Pending Action",
         "type": "UrlVerdictChangeInvestigation"
       },
+      "machine_name": "PC01",
       "record_id": "11111111-1111-1111-1111-111111111111",
       "record_type": 64,
       "user_type": {

--- a/Office 365/o365/tests/automated_investigation_and_response_with_additional_fields.json
+++ b/Office 365/o365/tests/automated_investigation_and_response_with_additional_fields.json
@@ -33,9 +33,6 @@
         ]
       }
     },
-    "host": {
-      "name": "machine_name_value"
-    },
     "log": {
       "level": "severity_value"
     },
@@ -88,6 +85,7 @@
         ],
         "type": "ZappedUrlInvestigation"
       },
+      "machine_name": "machine_name_value",
       "record_id": "60eaf0aa-edc3-4f8d-8275-bc82d9500e59",
       "record_type": 64,
       "user_type": {

--- a/Office 365/o365/tests/automated_investigation_and_response_with_additional_fields_1.json
+++ b/Office 365/o365/tests/automated_investigation_and_response_with_additional_fields_1.json
@@ -31,9 +31,6 @@
         ]
       }
     },
-    "host": {
-      "name": "MACHINE01"
-    },
     "log": {
       "level": "Informational"
     },
@@ -121,6 +118,7 @@
         ],
         "type": "ZappedUrlInvestigation"
       },
+      "machine_name": "MACHINE01",
       "record_id": "1234ab56-7890-1234-c5de-678fabcd9012",
       "record_type": 64,
       "user_type": {

--- a/Office 365/o365/tests/automated_investigation_and_response_with_attachment.json
+++ b/Office 365/o365/tests/automated_investigation_and_response_with_attachment.json
@@ -41,9 +41,6 @@
         ]
       }
     },
-    "host": {
-      "name": "DBAEUR03BG405"
-    },
     "log": {
       "level": "Informational"
     },
@@ -107,6 +104,7 @@
         "status": "Investigation Started",
         "type": "ZappedFileInvestigation"
       },
+      "machine_name": "DBAEUR03BG405",
       "record_id": "d32b02fd-f97e-47a1-9407-f5cb2dcca772",
       "record_type": 64,
       "user_type": {


### PR DESCRIPTION
Use an custom field instead

## Summary by Sourcery

Stop extracting MachineName into host.name for automated investigation and response events by introducing a dedicated office365.machine_name field and updating mappings and tests accordingly.

Enhancements:
- Add office365.machine_name custom field definition
- Map AIR event MachineName to office365.machine_name instead of host.name in the parser

Tests:
- Adjust automated investigation and response test fixtures to expect the new office365.machine_name field