### PR TITLE
O365 - fix attachments parsing

### DIFF
--- a/Office 365/o365/ingest/parser.yml
+++ b/Office 365/o365/ingest/parser.yml
@@ -401,7 +401,7 @@ stages:
               {%- if json_event.message.AffectedItems != None -%}
                 {%- for email in json_event.message.AffectedItems -%}
                   {%- for file in email.Attachments.split("; ") -%}
-                    {"file":{ "name": "{{ file.split(" (")[0] }}", "size": "{{ file.split(" (")[1].strip('b)') }}" }},
+                    {"file":{ "name": "{{ file.rsplit(" (", 1)[0] }}", "size": "{{ file.rsplit(" (", 1)[1].strip('b)') }}" }},
                   {%- endfor -%}
                 {%- endfor -%}
               {%- endif -%}

--- a/Office 365/o365/tests/exchange_item_group_3.json
+++ b/Office 365/o365/tests/exchange_item_group_3.json
@@ -1,0 +1,103 @@
+{
+  "input": {
+    "message": "{\"AppAccessContext\": {\"APIId\": \"\"}, \"CreationTime\": \"2025-09-16T14:46:55\", \"Id\": \"135ddd32-fee4-4f54-8606-7f203190b25f\", \"Operation\": \"SoftDelete\", \"OrganizationId\": \"5cd23ff0-2911-44d3-ab09-72f29cdaa023\", \"RecordType\": 3, \"ResultStatus\": \"Succeeded\", \"UserKey\": \"11111111111111\", \"UserType\": 0, \"Version\": 1, \"Workload\": \"Exchange\", \"ClientIP\": \"1.2.3.4\", \"UserId\": \"john.doe@example.com\", \"ActorInfoString\": \"OUTLOOK.EXE/16.0.10417.20051\", \"ClientIPAddress\": \"1.2.3.4\", \"ClientInfoString\": \"Client=MSExchangeRPC\", \"ClientProcessName\": \"OUTLOOK.EXE\", \"ClientRequestId\": \"{D10D3A8A-BCFF-481B-B609-2AE0B1DE9B14}\", \"ClientVersion\": \"16.0.10417.20051\", \"ExternalAccess\": false, \"InternalLogonType\": 0, \"LogonType\": 0, \"LogonUserSid\": \"S-1-5-21-1111111111-2222222222-3333333333-4444444\", \"MailboxGuid\": \"9f63ab44-248d-43a2-8565-63589e5232db\", \"MailboxOwnerSid\": \"S-1-5-21-1111111111-2222222222-3333333333-4444444\", \"MailboxOwnerUPN\": \"john.doe@example.com\", \"OrganizationName\": \"example.onmicrosoft.com\", \"OriginatingServer\": \"MYSERVER (15.20.4200.000)\\r\\n\", \"SessionId\": \"70d4272c-db05-4e17-90a6-5c475bab04b7\", \"AffectedItems\": [{\"Attachments\": \"tps (report) 1.docx (1024b); image001.jpg (2048b); image002.jpg (4096b); image003.jpg (8192b)\", \"Id\": \"ABCDEF0123456\", \"InternetMessageId\": \"<message.id.test@0123456789.userabc.prod.outlook.com>\", \"ParentFolder\": {\"Id\": \"908eca3617c16126164465a986b6a2610f84efdcf91c46dc37a34f68954e2a3c\", \"Path\": \"\\\\Test\"}, \"Subject\": \"Report\"}], \"CrossMailboxOperation\": false, \"Folder\": {\"Id\": \"908eca3617c16126164465a986b6a2610f84efdcf91c46dc37a34f68954e2a3c\", \"Path\": \"\\\\Test\"}, \"AssociatedAdminUnits\": [\"4aef334f-5097-4b40-9286-d7b2efcd57bf\"]}"
+  },
+  "expected": {
+    "message": "{\"AppAccessContext\": {\"APIId\": \"\"}, \"CreationTime\": \"2025-09-16T14:46:55\", \"Id\": \"135ddd32-fee4-4f54-8606-7f203190b25f\", \"Operation\": \"SoftDelete\", \"OrganizationId\": \"5cd23ff0-2911-44d3-ab09-72f29cdaa023\", \"RecordType\": 3, \"ResultStatus\": \"Succeeded\", \"UserKey\": \"11111111111111\", \"UserType\": 0, \"Version\": 1, \"Workload\": \"Exchange\", \"ClientIP\": \"1.2.3.4\", \"UserId\": \"john.doe@example.com\", \"ActorInfoString\": \"OUTLOOK.EXE/16.0.10417.20051\", \"ClientIPAddress\": \"1.2.3.4\", \"ClientInfoString\": \"Client=MSExchangeRPC\", \"ClientProcessName\": \"OUTLOOK.EXE\", \"ClientRequestId\": \"{D10D3A8A-BCFF-481B-B609-2AE0B1DE9B14}\", \"ClientVersion\": \"16.0.10417.20051\", \"ExternalAccess\": false, \"InternalLogonType\": 0, \"LogonType\": 0, \"LogonUserSid\": \"S-1-5-21-1111111111-2222222222-3333333333-4444444\", \"MailboxGuid\": \"9f63ab44-248d-43a2-8565-63589e5232db\", \"MailboxOwnerSid\": \"S-1-5-21-1111111111-2222222222-3333333333-4444444\", \"MailboxOwnerUPN\": \"john.doe@example.com\", \"OrganizationName\": \"example.onmicrosoft.com\", \"OriginatingServer\": \"MYSERVER (15.20.4200.000)\\r\\n\", \"SessionId\": \"70d4272c-db05-4e17-90a6-5c475bab04b7\", \"AffectedItems\": [{\"Attachments\": \"tps (report) 1.docx (1024b); image001.jpg (2048b); image002.jpg (4096b); image003.jpg (8192b)\", \"Id\": \"ABCDEF0123456\", \"InternetMessageId\": \"<message.id.test@0123456789.userabc.prod.outlook.com>\", \"ParentFolder\": {\"Id\": \"908eca3617c16126164465a986b6a2610f84efdcf91c46dc37a34f68954e2a3c\", \"Path\": \"\\\\Test\"}, \"Subject\": \"Report\"}], \"CrossMailboxOperation\": false, \"Folder\": {\"Id\": \"908eca3617c16126164465a986b6a2610f84efdcf91c46dc37a34f68954e2a3c\", \"Path\": \"\\\\Test\"}, \"AssociatedAdminUnits\": [\"4aef334f-5097-4b40-9286-d7b2efcd57bf\"]}",
+    "event": {
+      "action": "SoftDelete",
+      "category": [
+        "email"
+      ],
+      "code": "3",
+      "outcome": "success",
+      "type": [
+        "info"
+      ]
+    },
+    "@timestamp": "2025-09-16T14:46:55Z",
+    "action": {
+      "id": 3,
+      "name": "SoftDelete",
+      "outcome": "success",
+      "target": "user"
+    },
+    "email": {
+      "attachments": [
+        {
+          "file": {
+            "name": "tps (report) 1.docx",
+            "size": 1024
+          }
+        },
+        {
+          "file": {
+            "name": "image001.jpg",
+            "size": 2048
+          }
+        },
+        {
+          "file": {
+            "name": "image002.jpg",
+            "size": 4096
+          }
+        },
+        {
+          "file": {
+            "name": "image003.jpg",
+            "size": 8192
+          }
+        }
+      ]
+    },
+    "office365": {
+      "context": {
+        "aad_session_id": "70d4272c-db05-4e17-90a6-5c475bab04b7"
+      },
+      "exchange": {
+        "client_version": "16.0.10417.20051",
+        "email": {
+          "paths": [
+            "\\Test"
+          ],
+          "subjects": [
+            "Report"
+          ]
+        }
+      },
+      "record_id": "135ddd32-fee4-4f54-8606-7f203190b25f",
+      "record_type": 3,
+      "result_status": "Succeeded",
+      "user_type": {
+        "code": 0,
+        "name": "Regular"
+      }
+    },
+    "organization": {
+      "id": "5cd23ff0-2911-44d3-ab09-72f29cdaa023"
+    },
+    "process": {
+      "name": "OUTLOOK.EXE"
+    },
+    "related": {
+      "ip": [
+        "1.2.3.4"
+      ],
+      "user": [
+        "john.doe@example.com"
+      ]
+    },
+    "service": {
+      "name": "Exchange"
+    },
+    "source": {
+      "address": "1.2.3.4",
+      "ip": "1.2.3.4"
+    },
+    "user": {
+      "email": "john.doe@example.com",
+      "id": "11111111111111",
+      "name": "john.doe@example.com"
+    }
+  }
+}


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/923

## Summary by Sourcery

Fix attachments parsing in the Office 365 ingest pipeline by splitting on the last delimiter and add a test fixture to cover the change.

Bug Fixes:
- Use rsplit instead of split to correctly extract file name and size from email attachments in the Office 365 parser.

Tests:
- Add new Exchange item group 3 JSON test data to validate attachments parsing.