### PR TITLE
Broadcom: add automation module to siteminder

### DIFF
--- a/Broadcom/siteminder/_meta/manifest.yml
+++ b/Broadcom/siteminder/_meta/manifest.yml
@@ -1,3 +1,4 @@
+automation_module_uuid: b58b7f4d-4384-4e30-ad46-cba0c36cdb5e
 uuid: 6a740c4b-468b-45b4-9982-3903abf9fc54
 name: Broadcom Siteminder [BETA]
 slug: broadcom-siteminder


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Include automation_module_uuid field in manifest.yml