### PR TITLE
Broadcom: fix format identifier

### DIFF
--- a/Broadcom/siteminder/_meta/manifest.yml
+++ b/Broadcom/siteminder/_meta/manifest.yml
@@ -1,5 +1,5 @@
 automation_module_uuid: b58b7f4d-4384-4e30-ad46-cba0c36cdb5e
-uuid: 6a740c4b-468b-45b4-9982-3903abf9fc54
+uuid: 2bfa5c39-bc73-48cf-afbd-7fd0eccf1d59
 name: Broadcom Siteminder [BETA]
 slug: broadcom-siteminder
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the uuid field in the Broadcom Siteminder manifest