### PR TITLE
Infoblox DDI - parse hostname

### DIFF
--- a/Infoblox/ddi/ingest/parser.yml
+++ b/Infoblox/ddi/ingest/parser.yml
@@ -128,6 +128,8 @@ stages:
           destination.ip: "{{parse_event.message.destination_ip}}"
           destination.port: "{{parse_event.message.destination_port}}"
 
+          host.name: "{{parse_event.message.infoblox_nios_log_dhcp_client_hostname}}"
+
           observer.ingress.interface.name: "{{parse_event.message.observer_ingress_interface_name}}"
 
           infoblox.dhcp.interface_ip: "{{parse_event.message.infoblox_nios_log_dhcp_interface_ip}}"

--- a/Infoblox/ddi/tests/query_log_dhcp_4.json
+++ b/Infoblox/ddi/tests/query_log_dhcp_4.json
@@ -12,6 +12,9 @@
       "header_flags": [],
       "type": "query"
     },
+    "host": {
+      "name": "VDPSCE080019"
+    },
     "infoblox": {
       "dhcp": {
         "trans_id": "823c1fa3"

--- a/Infoblox/ddi/tests/query_log_dhcp_7.json
+++ b/Infoblox/ddi/tests/query_log_dhcp_7.json
@@ -11,6 +11,9 @@
       "header_flags": [],
       "type": "query"
     },
+    "host": {
+      "name": "P70955"
+    },
     "observer": {
       "ingress": {
         "interface": {

--- a/Infoblox/ddi/tests/query_log_dhcp_9.json
+++ b/Infoblox/ddi/tests/query_log_dhcp_9.json
@@ -18,6 +18,9 @@
       "header_flags": [],
       "type": "query"
     },
+    "host": {
+      "name": "ABCDEFGHI"
+    },
     "infoblox": {
       "dhcp": {
         "trans_id": "1234abcd"


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/929

## Summary by Sourcery

Add support for extracting the DHCP client hostname from Infoblox DDI logs by mapping the client hostname to host.name and update corresponding tests.

New Features:
- Map infoblox_nios_log_dhcp_client_hostname to host.name in the parser.

Tests:
- Update DHCP log test fixtures to include the client hostname field.