### PR TITLE
VMWare vCenter - parse command line without header

### DIFF
--- a/VMWare/vmware-vcenter/ingest/parser.yml
+++ b/VMWare/vmware-vcenter/ingest/parser.yml
@@ -26,7 +26,7 @@ pipeline:
           OTHERS_EVENTS_TYPE_6: 'Event \[%{INT:id}\] \[1-1\] \[%{TIMESTAMP_ISO8601:timestamp}\] \[%{DATA:event_code}\] \[%{DATA:log_level}\] \[%{DATA}\] \[%{DATA}\] \[%{INT}\] \[A ticket for %{USERNAME:username} of type %{DATA} on %{IP:ip_address} in %{DATA} has been acquired\]'
           OTHERS_EVENTS_TYPE_7: 'Event \[%{INT:id}\] \[1-1\] \[%{TIMESTAMP_ISO8601:timestamp}\] \[%{DATA:event_code}\] \[%{DATA:log_level}\] \[%{USERNAME_WITH_DOMAIN}?\] \[%{HOSTNAME:hostname}?\] \[%{INT}] \[(?P<reason>%{DATA} from %{IP:source_ip} %{GREEDYDATA})\]'
           OTHERS_EVENTS_TYPE_7_1: 'Event \[%{INT:id}\] \[1-1\] \[%{TIMESTAMP_ISO8601:timestamp}\] \[%{DATA:event_code}\] \[%{DATA:log_level}\] \[%{USERNAME_WITH_DOMAIN}?\] \[%{HOSTNAME:hostname}?\] \[%{INT}] \[%{GREEDYDATA:reason}\]'
-          OTHERS_EVENTS_TYPE_8: '%{TIMESTAMP_ISO8601:timestamp} %{DATA}\s+%{DATA}\s+%{DATA}\s+%{DATA}\s+%{DATA}\s+%{DATA}\s+: PWD=%{DATA:pwd} ; USER=%{DATA:proc_username} ; COMMAND=%{DATA:command_line}'
+          OTHERS_EVENTS_TYPE_8: '(%{TIMESTAMP_ISO8601:timestamp} %{DATA}\s+%{DATA}\s+%{DATA}\s+%{DATA}\s+%{DATA}\s+)?%{DATA}\s+: PWD=%{DATA:pwd} ; USER=%{DATA:proc_username} ; COMMAND=%{DATA:command_line}'
           OTHERS_EVENTS_TYPE_9: 'Event \[%{INT:id}\] \[%{DATA}\] \[%{TIMESTAMP_ISO8601:timestamp}\] \[%{DATA:event_code}\] \[%{DATA:log_level}\] \[%{USERNAME_WITH_DOMAIN}?\] \[%{HOSTNAME:hostname}?\] \[%{INT}] \[Reconfigured %{DATA:vm_name} on %{IPORHOST:ip_address} in %{DATA}\.'
           USERNAME_WITH_DOMAIN: '%{SINGLE_QUOTE}?(%{DATA:user_domain}\\)?%{DATA:username}(@(%{IP:ip_address}|%{DATA:user_domain}))?%{SINGLE_QUOTE}?'
           SINGLE_QUOTE: "'"

--- a/VMWare/vmware-vcenter/tests/command_line_without_header.json
+++ b/VMWare/vmware-vcenter/tests/command_line_without_header.json
@@ -1,0 +1,27 @@
+{
+  "input": {
+    "message": "observability : PWD=/ ; USER=root ; COMMAND=/usr/lib/vmware-observability/scripts/createDBRole.sh"
+  },
+  "expected": {
+    "message": "observability : PWD=/ ; USER=root ; COMMAND=/usr/lib/vmware-observability/scripts/createDBRole.sh",
+    "event": {
+      "category": [
+        "process"
+      ],
+      "type": [
+        "info"
+      ]
+    },
+    "observer": {
+      "product": "VCenter",
+      "vendor": "VMWare"
+    },
+    "process": {
+      "command_line": "/usr/lib/vmware-observability/scripts/createDBRole.sh",
+      "user": {
+        "name": "root"
+      },
+      "working_directory": "/"
+    }
+  }
+}


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/954

## Summary by Sourcery

Allow parsing of command line events without a timestamp header by making the header optional in the regex and add a test for this scenario

Bug Fixes:
- Make the OTHERS_EVENTS_TYPE_8 pattern optional for timestamp and preceding fields to parse command line events without a header

Tests:
- Add a test case for parsing command line events without a header