### PR TITLE
Crowdstrike telemetry: fix on url.domain

### DIFF
--- a/CrowdStrike/crowdstrike-telemetry/ingest/parser.yml
+++ b/CrowdStrike/crowdstrike-telemetry/ingest/parser.yml
@@ -223,10 +223,10 @@ stages:
           "observer.egress.interface.alias": "{{parsed_event.message.InterfaceAlias}}"
       - set:
           url.domain: "{{parsed_event.message.OriginatingURL.split('/')[0]}}"
-        filter: "{{parsed_event.message.OriginatingURL != None and not parsed_event.message.OriginatingURL.startswith('http')}}"
+        filter: "{{parsed_event.message.OriginatingURL != None and '://' not in parsed_event.message.OriginatingURL }}"
       - set:
           url.domain: "{{parsed_event.message.OriginatingURL.split('/')[2]}}"
-        filter: "{{parsed_event.message.OriginatingURL != None and parsed_event.message.OriginatingURL.startswith('http')}}"
+        filter: "{{parsed_event.message.OriginatingURL != None and '://' in parsed_event.message.OriginatingURL }}"
       - set:
           "observer.ip": >
             [

--- a/CrowdStrike/crowdstrike-telemetry/tests/telemetry_event_41.json
+++ b/CrowdStrike/crowdstrike-telemetry/tests/telemetry_event_41.json
@@ -1,0 +1,80 @@
+{
+  "input": {
+    "message": "{\"LocalAddressIP4\":\"1.2.3.4\",\"event_simpleName\":\"NetworkConnectIP6\",\"ContextTimeStamp\":\"1758983740.810\",\"LocalAddressIP6\":\"1111:2222:3333:4444:5555:6666:7777:8888\",\"RemoteAddressIP6\":\"1111:2222:3333:4444:0:0:0:0\",\"ConfigStateHash\":\"536970106\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"12168621487068014576\",\"RemotePort\":\"443\",\"OriginatingURL\":\"wss://test.region.database.app/.ws\",\"aip\":\"1111:2222:3333:4444:5555:6666:7777:8888\",\"ConfigBuild\":\"1007.32.20250701.1\",\"event_platform\":\"iOS\",\"LocalPort\":\"60716\",\"name\":\"NetworkConnectIP6IOSV3\",\"ComputerName\":\"PC01\",\"id\":\"11111111-2222-3333-4444-555555555555\",\"Protocol\":\"6\",\"aid\":\"11111111111111111111111111111111\",\"ConnectionDirection\":\"0\",\"timestamp\":\"1758983752537\",\"cid\":\"22222222222222222222222222222222\"}",
+    "sekoiaio": {
+      "intake": {
+        "dialect": "Crowdstrike Falcon Telemetry",
+        "dialect_uuid": "10999b99-9a8d-4b92-9fbd-01e3fac01cd5"
+      }
+    }
+  },
+  "expected": {
+    "message": "{\"LocalAddressIP4\":\"1.2.3.4\",\"event_simpleName\":\"NetworkConnectIP6\",\"ContextTimeStamp\":\"1758983740.810\",\"LocalAddressIP6\":\"1111:2222:3333:4444:5555:6666:7777:8888\",\"RemoteAddressIP6\":\"1111:2222:3333:4444:0:0:0:0\",\"ConfigStateHash\":\"536970106\",\"ConnectionFlags\":\"0\",\"ContextProcessId\":\"12168621487068014576\",\"RemotePort\":\"443\",\"OriginatingURL\":\"wss://test.region.database.app/.ws\",\"aip\":\"1111:2222:3333:4444:5555:6666:7777:8888\",\"ConfigBuild\":\"1007.32.20250701.1\",\"event_platform\":\"iOS\",\"LocalPort\":\"60716\",\"name\":\"NetworkConnectIP6IOSV3\",\"ComputerName\":\"PC01\",\"id\":\"11111111-2222-3333-4444-555555555555\",\"Protocol\":\"6\",\"aid\":\"11111111111111111111111111111111\",\"ConnectionDirection\":\"0\",\"timestamp\":\"1758983752537\",\"cid\":\"22222222222222222222222222222222\"}",
+    "event": {
+      "action": "NetworkConnectIP6",
+      "category": [
+        "process"
+      ],
+      "type": [
+        "info"
+      ]
+    },
+    "@timestamp": "2025-09-27T14:35:52.537000Z",
+    "agent": {
+      "id": "11111111111111111111111111111111"
+    },
+    "crowdstrike": {
+      "customer_id": "22222222222222222222222222222222"
+    },
+    "destination": {
+      "address": "1111:2222:3333:4444::",
+      "ip": "1111:2222:3333:4444::",
+      "nat": {
+        "port": 443
+      }
+    },
+    "host": {
+      "ip": [
+        "1111:2222:3333:4444:5555:6666:7777:8888"
+      ],
+      "name": "PC01",
+      "os": {
+        "platform": "ios",
+        "type": "ios"
+      }
+    },
+    "network": {
+      "iana_number": "6"
+    },
+    "observer": {
+      "ip": [
+        "1.2.3.4"
+      ]
+    },
+    "related": {
+      "hosts": [
+        "test.region.database.app"
+      ],
+      "ip": [
+        "1.2.3.4",
+        "1111:2222:3333:4444:5555:6666:7777:8888",
+        "1111:2222:3333:4444::"
+      ]
+    },
+    "source": {
+      "address": "1.2.3.4",
+      "ip": "1.2.3.4",
+      "nat": {
+        "ip": "1111:2222:3333:4444:5555:6666:7777:8888",
+        "port": 60716
+      }
+    },
+    "url": {
+      "domain": "test.region.database.app",
+      "full": "wss://test.region.database.app/.ws",
+      "registered_domain": "database.app",
+      "subdomain": "test.region",
+      "top_level_domain": "app"
+    }
+  }
+}


### PR DESCRIPTION
Fix related to [this issue](https://github.com/SekoiaLab/integration/issues/950)

## Summary by Sourcery

Fix URL domain extraction logic by checking for '://' in OriginatingURL to properly distinguish HTTP and non-HTTP URLs, and add a test case to validate the change.

Bug Fixes:
- Use presence of '://' instead of HTTP prefix to distinguish URLs when setting url.domain in parser

Tests:
- Add telemetry_event_41.json test case for URL domain parsing