### PR TITLE
New fields for Azure AD/Entra ID integration

### DIFF
--- a/Azure/azure-ad/_meta/fields.yml
+++ b/Azure/azure-ad/_meta/fields.yml
@@ -25,11 +25,6 @@ azuread.authenticationDetails:
   name: azuread.authenticationDetails
   type: array
 
-azuread.authenticationProtocol:
-  description: ''
-  name: azuread.authenticationProtocol
-  type: keyword
-
 azuread.authenticationRequirement:
   description: ''
   name: azuread.authenticationRequirement
@@ -88,11 +83,6 @@ azuread.homeTenantId:
 azuread.identity:
   description: ''
   name: azuread.identity
-  type: keyword
-
-azuread.incomingTokenType:
-  description: ''
-  name: azuread.incomingTokenType
   type: keyword
 
 azuread.isTenantRestricted:
@@ -180,6 +170,11 @@ azuread.properties.id:
   name: azuread.properties.id
   type: keyword
 
+azuread.properties.incomingTokenType:
+  description: ''
+  name: azuread.properties.incomingTokenType
+  type: keyword
+
 azuread.properties.network_location.network_names:
   description: ''
   name: azuread.properties.network_location.network_names
@@ -190,6 +185,11 @@ azuread.properties.network_location.network_type:
   name: azuread.properties.network_location.network_type
   type: keyword
 
+azuread.properties.oauth_scope_info:
+  description: ''
+  name: azuread.properties.oauth_scope_info
+  type: keyword
+
 azuread.properties.original_transfer_method:
   description: ''
   name: azuread.properties.original_transfer_method
@@ -198,6 +198,11 @@ azuread.properties.original_transfer_method:
 azuread.properties.requestId:
   description: ''
   name: azuread.properties.requestId
+  type: keyword
+
+azuread.properties.resourceId:
+  description: ''
+  name: azuread.properties.resourceId
   type: keyword
 
 azuread.properties.riskDetail:
@@ -295,9 +300,24 @@ azuread.properties.targetUserPrincipalName:
   name: azuread.properties.targetUserPrincipalName
   type: keyword
 
+azuread.properties.tokenIssuerType:
+  description: ''
+  name: azuread.properties.tokenIssuerType
+  type: keyword
+
+azuread.properties.uniqueTokenIdentifier:
+  description: ''
+  name: azuread.properties.uniqueTokenIdentifier
+  type: keyword
+
 azuread.properties.userPrincipalObjectID:
   description: ''
   name: azuread.properties.userPrincipalObjectID
+  type: keyword
+
+azuread.properties.userType:
+  description: ''
+  name: azuread.properties.userType
   type: keyword
 
 azuread.resourceId:
@@ -328,19 +348,4 @@ azuread.ssoExtensionVersion:
 azuread.tenantId:
   description: ''
   name: azuread.tenantId
-  type: keyword
-
-azuread.tokenIssuerType:
-  description: ''
-  name: azuread.tokenIssuerType
-  type: keyword
-
-azuread.uniqueTokenIdentifier:
-  description: ''
-  name: azuread.uniqueTokenIdentifier
-  type: keyword
-
-azuread.userType:
-  description: ''
-  name: azuread.userType
   type: keyword

--- a/Azure/azure-ad/ingest/parser.yml
+++ b/Azure/azure-ad/ingest/parser.yml
@@ -78,9 +78,14 @@ stages:
           azuread.properties.deviceDetail.isManaged: "{{parsed_event.message.properties.deviceDetail.isManaged}}"
           azuread.properties.deviceDetail.trustType: "{{parsed_event.message.properties.deviceDetail.trustType}}"
           azuread.properties.original_transfer_method: "{{parsed_event.message.properties.originalTransferMethod}}"
-          azuread.properties.session_id: "{{parsed_event.message.properties.sessionId}}"
+          azuread.properties.session_id: "{{parsed_event.message.properties.sessionId or parsed_event.message.properties.C_Sid}}"
           azuread.properties.userPrincipalObjectID: "{{parsed_event.message.properties.UserPrincipalObjectID}}"
           azuread.properties.authenticationRequirement: "{{parsed_event.message.properties.authenticationRequirement}}"
+          azuread.properties.uniqueTokenIdentifier: "{{parsed_event.message.properties.uniqueTokenIdentifier or parsed_event.message.properties.signInActivityId}}"
+          azuread.properties.userType: "{{parsed_event.message.properties.userType}}"
+          azuread.properties.tokenIssuerType: "{{parsed_event.message.properties.tokenIssuerType}}"
+          azuread.properties.incomingTokenType: "{{parsed_event.message.properties.incomingTokenType}}"
+          azuread.properties.resourceId: "{{parsed_event.message.properties.resourceId}}"
 
       - set:
           azuread.properties.network_location.network_type: "{{(parsed_event.message.properties.networkLocationDetails | first).networkType}}"
@@ -102,6 +107,12 @@ stages:
           parsed_event.message.category: event.category
         fallback: ["iam"]
 
+      - set:
+          azuread.properties.oauth_scope_info: >
+            {%- for item in parsed_event.message.properties.authenticationProcessingDetails -%}
+              {%- if item.key == 'Oauth Scope Info' -%}{{ item.value }}{%- endif -%}
+            {%- endfor -%}
+
   read_message_properties_location_geoCoordinates:
     actions:
       - set:
@@ -120,7 +131,7 @@ stages:
           service.name: '{{ parsed_event.message.resourceDisplayName or "Azure Active Directory"}}'
           action.name: "{{parsed_event.message.operationName}}"
           event.action: "{{parsed_event.message.operationName}}"
-          user.id: "{{ parsed_event.message.userId}}"
+          user.id: "{{ parsed_event.message.userId or parsed_event.message.properties.userId}}"
           user.name: "{{ parsed_event.message.userPrincipalName}}"
           user_agent.original: "{{ parsed_event.message.userAgent}}"
           log.level: "{{parsed_event.message.Level}}"
@@ -200,10 +211,8 @@ stages:
           azuread.detectedDateTime: "{{parsed_event.message.detectedDateTime}}"
           azuread.lastUpdatedDateTime: "{{parsed_event.message.lastUpdatedDateTime}}"
           azuread.additionalInfo: "{{parsed_event.message.additionalInfo}}"
-          azuread.tokenIssuerType: "{{parsed_event.message.tokenIssuerType}}"
           azuread.resourceTenantId: "{{parsed_event.message.resourceTenantId}}"
           azuread.homeTenantId: "{{parsed_event.message.homeTenantId}}"
-          azuread.userType: "{{parsed_event.message.userType}}"
           azuread.crossTenantAccessType: "{{parsed_event.message.crossTenantAccessType}}"
           azuread.authenticationRequirementPolicies: "{{parsed_event.message.authenticationRequirementPolicies}}"
           azuread.authenticationRequirement: "{{parsed_event.message.authenticationRequirement}}"
@@ -213,9 +222,6 @@ stages:
           azuread.autonomousSystemNumber: "{{parsed_event.message.autonomousSystemNumber}}"
           azuread.privateLinkDetails: "{{parsed_event.message.privateLinkDetails}}"
           azuread.ssoExtensionVersion: "{{parsed_event.message.ssoExtensionVersion}}"
-          azuread.uniqueTokenIdentifier: "{{parsed_event.message.uniqueTokenIdentifier}}"
-          azuread.incomingTokenType: "{{parsed_event.message.incomingTokenType}}"
-          azuread.authenticationProtocol: "{{parsed_event.message.authenticationProtocol}}"
 
       - set:
           action.target: "user"

--- a/Azure/azure-ad/tests/empty_geolocalisation.json
+++ b/Azure/azure-ad/tests/empty_geolocalisation.json
@@ -46,6 +46,28 @@
         "conditionalAccessStatus": "notApplied",
         "correlationId": "7ee10819-f631-4ab1-8edb-4efb7286baba",
         "id": "b2fdcc8f-954d-4d88-a035-58daefab4f00",
+        "incomingTokenType": "none",
+        "oauth_scope_info": [
+          "AuditLog.Create",
+          "Chat.Read",
+          "DataLossPreventionPolicy.Evaluate",
+          "Directory.Read.All",
+          "EduRoster.ReadBasic",
+          "Files.ReadWrite.All",
+          "Group.ReadWrite.All",
+          "InformationProtectionPolicy.Read",
+          "Notes.Create",
+          "OnlineMeetings.Read",
+          "OnlineMeetings.ReadWrite",
+          "People.Read",
+          "SensitiveInfoType.Detect",
+          "SensitiveInfoType.Read.All",
+          "SensitivityLabel.Evaluate",
+          "User.Invite.All",
+          "User.Read",
+          "User.ReadBasic.All"
+        ],
+        "resourceId": "00000002-0000-0ff1-ce00-000000000000",
         "riskDetail": "none",
         "riskEventTypes": [],
         "riskEventTypes_v2": [],
@@ -54,7 +76,10 @@
         "riskState": "none",
         "status": {
           "errorCode": "0"
-        }
+        },
+        "tokenIssuerType": "AzureAD",
+        "uniqueTokenIdentifier": "11111111111111111111111111",
+        "userType": "Member"
       },
       "resourceId": "/tenants/e6eb2b5c-ad71-4c33-9856-1ed49b85bfe2/providers/Microsoft.aadiam",
       "tenantId": "e6eb2b5c-ad71-4c33-9856-1ed49b85bfe2"

--- a/Azure/azure-ad/tests/graph_activity.json
+++ b/Azure/azure-ad/tests/graph_activity.json
@@ -31,6 +31,7 @@
           "openid",
           "profile"
         ],
+        "uniqueTokenIdentifier": "JgW9XEOQM0WNakyHMghCAA",
         "userPrincipalObjectID": "TEST_USER_ID"
       },
       "resourceId": "/TENANTS/TEST_TENANT_ID/PROVIDERS/MICROSOFT.AADIAM",
@@ -67,6 +68,9 @@
       "scheme": "https",
       "subdomain": "graph",
       "top_level_domain": "com"
+    },
+    "user": {
+      "id": "TEST_USER_ID"
     },
     "user_agent": {
       "device": {

--- a/Azure/azure-ad/tests/graph_activity_1.json
+++ b/Azure/azure-ad/tests/graph_activity_1.json
@@ -31,6 +31,7 @@
           "openid",
           "profile"
         ],
+        "uniqueTokenIdentifier": "activityId",
         "userPrincipalObjectID": "testUserId"
       },
       "resourceId": "/TENANTS/testTenantId/PROVIDERS/MICROSOFT.AADIAM",
@@ -67,6 +68,9 @@
       "scheme": "https",
       "subdomain": "graph",
       "top_level_domain": "com"
+    },
+    "user": {
+      "id": "testUserId"
     },
     "user_agent": {
       "device": {

--- a/Azure/azure-ad/tests/graph_activity_2.json
+++ b/Azure/azure-ad/tests/graph_activity_2.json
@@ -54,6 +54,8 @@
           "openid",
           "profile"
         ],
+        "session_id": "008df009-2a78-3a93-bd91-b826cab98083",
+        "uniqueTokenIdentifier": "nCIzipjKBXc87y9rpX8dAA",
         "userPrincipalObjectID": "2f5b9bf9-c5a2-4682-af6f-ab7fe9f9497f"
       },
       "resourceId": "/TENANTS/8e6ebb74-d7b1-4f81-a7ab-71746fe6f9ef/PROVIDERS/MICROSOFT.AADIAM",
@@ -90,6 +92,9 @@
       "scheme": "https",
       "subdomain": "graph",
       "top_level_domain": "com"
+    },
+    "user": {
+      "id": "2f5b9bf9-c5a2-4682-af6f-ab7fe9f9497f"
     },
     "user_agent": {
       "device": {

--- a/Azure/azure-ad/tests/sign-in_activity.json
+++ b/Azure/azure-ad/tests/sign-in_activity.json
@@ -47,12 +47,14 @@
         "conditionalAccessStatus": "failure",
         "correlationId": "e68960e2-8996-448c-ba7a-e54eeb8ff2ed",
         "id": "22253f56-6fc4-45f2-b148-d7fe15504900",
+        "incomingTokenType": "none",
         "network_location": {
           "network_names": [
             "IP corp"
           ],
           "network_type": "trustedNamedLocation"
         },
+        "resourceId": "5f09333a-842c-47da-a157-57da27fcbca5",
         "riskDetail": "none",
         "riskEventTypes": [],
         "riskEventTypes_v2": [],
@@ -62,7 +64,10 @@
         "status": {
           "errorCode": "50158",
           "failureReason": "External security challenge was not satisfied."
-        }
+        },
+        "tokenIssuerType": "AzureAD",
+        "uniqueTokenIdentifier": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "userType": "Member"
       },
       "resourceId": "/tenants/34314e6e-4023-4e4b-a15e-143f63244e2b/providers/Microsoft.aadiam",
       "tenantId": "34314e6e-4023-4e4b-a15e-143f63244e2b"

--- a/Azure/azure-ad/tests/sign-in_activity2.json
+++ b/Azure/azure-ad/tests/sign-in_activity2.json
@@ -46,12 +46,14 @@
         "conditionalAccessStatus": "success",
         "correlationId": "467c1340-0762-40d2-b6fb-339235633ebb",
         "id": "8795994f-0bb8-46d7-8797-8c9c385d5900",
+        "incomingTokenType": "none",
         "network_location": {
           "network_names": [
             "IP network"
           ],
           "network_type": "trustedNamedLocation"
         },
+        "resourceId": "00000002-0000-0000-c000-000000000000",
         "riskDetail": "none",
         "riskEventTypes": [],
         "riskEventTypes_v2": [],
@@ -61,7 +63,10 @@
         "status": {
           "additionalDetails": "MFA requirement satisfied by claim in the token",
           "errorCode": "0"
-        }
+        },
+        "tokenIssuerType": "AzureAD",
+        "uniqueTokenIdentifier": "ODc5NTk5NGYtMGJiOC00NmQ3LTg3OTctOGM5YzM4NWQ1OTAw",
+        "userType": "Member"
       },
       "resourceId": "/tenants/34314e6e-4023-4e4b-a15e-143f63244e2b/providers/Microsoft.aadiam",
       "tenantId": "34314e6e-4023-4e4b-a15e-143f63244e2b"

--- a/Azure/azure-ad/tests/sign-in_activity3.json
+++ b/Azure/azure-ad/tests/sign-in_activity3.json
@@ -55,12 +55,14 @@
         "conditionalAccessStatus": "notApplied",
         "correlationId": "93f63260-ad9a-4087-b7e0-d9010cb919dd",
         "id": "93f63260-ad9a-4087-b7e0-d9010cb919dd",
+        "incomingTokenType": "none",
         "network_location": {
           "network_names": [
             "Fra"
           ],
           "network_type": "namedNetwork"
         },
+        "resourceId": "93f63260-ad9a-4087-b7e0-d9010cb919dd",
         "riskDetail": "none",
         "riskEventTypes": [],
         "riskEventTypes_v2": [],
@@ -70,7 +72,10 @@
         "status": {
           "additionalDetails": "MFA completed in Azure AD",
           "errorCode": "0"
-        }
+        },
+        "tokenIssuerType": "AzureAD",
+        "uniqueTokenIdentifier": "5555555555555555555555",
+        "userType": "Member"
       },
       "resourceId": "/tenants/93f63260-ad9a-4087-b7e0-d9010cb919dd/providers/Microsoft.aadiam",
       "tenantId": "93f63260-ad9a-4087-b7e0-d9010cb919dd"

--- a/Azure/azure-ad/tests/sign-in_activity4.json
+++ b/Azure/azure-ad/tests/sign-in_activity4.json
@@ -41,7 +41,9 @@
           "trustType": "Azure AD joined"
         },
         "id": "e14254f4-4288-4c00-8689-80823c4f4cb5",
+        "incomingTokenType": "primaryRefreshToken",
         "original_transfer_method": "none",
+        "resourceId": "11d70870-823f-4450-828a-aba3cf69af8d",
         "riskDetail": "none",
         "riskEventTypes": [],
         "riskEventTypes_v2": [],
@@ -50,7 +52,10 @@
         "riskState": "none",
         "status": {
           "errorCode": "0"
-        }
+        },
+        "tokenIssuerType": "AzureAD",
+        "uniqueTokenIdentifier": "aaaaaaaaaaaaaaaaaaaaaa",
+        "userType": "Member"
       },
       "resourceId": "/tenants/34314e6e-4023-4e4b-a15e-143f63244e2b/providers/Microsoft.aadiam",
       "tenantId": "34314e6e-4023-4e4b-a15e-143f63244e2b"

--- a/Azure/azure-ad/tests/sign-in_activity5.json
+++ b/Azure/azure-ad/tests/sign-in_activity5.json
@@ -55,6 +55,7 @@
         "conditionalAccessStatus": "success",
         "correlationId": "15d9ac10-2532-4b45-81b4-93f8ce58524e",
         "id": "f34698ee-3f03-4bcd-b846-d418728d9c7e",
+        "incomingTokenType": "none",
         "network_location": {
           "network_names": [
             "Acme_Public_IPs (FR)"
@@ -62,6 +63,7 @@
           "network_type": "trustedNamedLocation"
         },
         "original_transfer_method": "none",
+        "resourceId": "5ba6ebdb-f8f0-4aa1-a23b-7fa9ed3db50c",
         "riskDetail": "none",
         "riskEventTypes": [],
         "riskEventTypes_v2": [],
@@ -72,7 +74,10 @@
         "status": {
           "additionalDetails": "MFA completed in Azure AD",
           "errorCode": "0"
-        }
+        },
+        "tokenIssuerType": "AzureAD",
+        "uniqueTokenIdentifier": "aEQ2qLOsqkS86zz3OHIeAA",
+        "userType": "Member"
       },
       "resourceId": "/tenants/20cab87f-7ec5-4f28-8701-dca407137de5/providers/Microsoft.aadiam",
       "tenantId": "20cab87f-7ec5-4f28-8701-dca407137de5"

--- a/Azure/azure-ad/tests/sign-in_activity6.json
+++ b/Azure/azure-ad/tests/sign-in_activity6.json
@@ -40,13 +40,18 @@
           "trustType": "Hybrid Azure AD joined"
         },
         "id": "7ce11419-2ac8-4a62-84d5-205677a23771",
+        "incomingTokenType": "primaryRefreshToken",
         "network_location": {
           "network_names": [
             "Company-Zscaler TDF-Trusted Proxy IPs"
           ],
           "network_type": "trustedNamedLocation"
         },
+        "oauth_scope_info": [
+          "user_impersonation"
+        ],
         "original_transfer_method": "none",
+        "resourceId": "78103d10-b6d6-4b8e-8e5d-606361f22d9e",
         "riskDetail": "none",
         "riskEventTypes": [],
         "riskEventTypes_v2": [],
@@ -57,7 +62,10 @@
         "status": {
           "additionalDetails": "MFA requirement satisfied by claim in the token",
           "errorCode": "0"
-        }
+        },
+        "tokenIssuerType": "AzureAD",
+        "uniqueTokenIdentifier": "URB3vEvKUUuClWlFhN4gAA",
+        "userType": "Member"
       },
       "resourceId": "/tenants/abcdfegc-9b3d-4c44-95e7-714e319b60f6/providers/Microsoft.aadiam",
       "resultSignature": "SUCCESS",

--- a/Azure/azure-ad/tests/user_risk_detection.json
+++ b/Azure/azure-ad/tests/user_risk_detection.json
@@ -36,7 +36,9 @@
         "riskEventType": "unfamiliarFeatures",
         "riskLevel": "low",
         "riskState": "dismissed",
-        "source": "IdentityProtection"
+        "source": "IdentityProtection",
+        "tokenIssuerType": "AzureAD",
+        "userType": "member"
       },
       "resourceId": "/tenants/2d0c1986-ef7b-4bbf-8428-3c837471e7ad/providers/microsoft.aadiam",
       "tenantId": "2d0c1986-ef7b-4bbf-8428-3c837471e7ad"
@@ -67,7 +69,8 @@
     },
     "user": {
       "email": "foo.bar@corp.eu",
-      "full_name": "bar foo"
+      "full_name": "bar foo",
+      "id": "4c64c30a-7a60-4211-bef1-5e4279854e85"
     },
     "user_agent": {
       "device": {

--- a/Azure/azure-ad/tests/user_risk_detection_2.json
+++ b/Azure/azure-ad/tests/user_risk_detection_2.json
@@ -51,7 +51,9 @@
           "UnfamiliarTenantIPsubnet"
         ],
         "riskState": "atRisk",
-        "source": "IdentityProtection"
+        "source": "IdentityProtection",
+        "tokenIssuerType": "AzureAD",
+        "userType": "member"
       },
       "resourceId": "/tenants/2d0c1986-ef7b-4bbf-8428-3c837471e7ad/providers/microsoft.aadiam",
       "tenantId": "2d0c1986-ef7b-4bbf-8428-3c837471e7ad"
@@ -80,7 +82,8 @@
     },
     "user": {
       "email": "foo.bar@corp.eu",
-      "full_name": "bar foo"
+      "full_name": "bar foo",
+      "id": "4c64c30a-7a60-4211-bef1-5e4279854e85"
     },
     "user_agent": {
       "device": {

--- a/Azure/azure-ad/tests/user_risk_detection_3.json
+++ b/Azure/azure-ad/tests/user_risk_detection_3.json
@@ -50,7 +50,9 @@
           "UnfamiliarTenantIPsubnet"
         ],
         "riskState": "dismissed",
-        "source": "IdentityProtection"
+        "source": "IdentityProtection",
+        "tokenIssuerType": "AzureAD",
+        "userType": "member"
       },
       "resourceId": "/tenants/1ed21da3-c6d6-41a5-8764-ebec8ba8a020/providers/microsoft.aadiam",
       "tenantId": "1ed21da3-c6d6-41a5-8764-ebec8ba8a020"
@@ -81,7 +83,8 @@
     },
     "user": {
       "email": "DOE@company.com",
-      "full_name": "DOE John"
+      "full_name": "DOE John",
+      "id": "d6e4b382-39a3-4988-9db3-85156bcdadfd"
     },
     "user_agent": {
       "device": {


### PR DESCRIPTION
## Summary by Sourcery

Add and migrate several token and identity fields into the azuread.properties namespace, update parser mappings to populate them, and refresh test fixtures.

Enhancements:
- Introduce new azuread.properties fields: incomingTokenType, oauth_scope_info, resourceId, tokenIssuerType, uniqueTokenIdentifier, userType
- Update ingest/parser.yml to map new properties from event payloads and add fallbacks for session_id and user.id
- Add logic to extract OAuth scope info from authenticationProcessingDetails
- Refresh existing test fixtures and add a new graph_activity_2.json test

## Summary by Sourcery

Add and migrate additional token and identity fields into azuread.properties namespace, enhance parser mappings to populate them including OAuth scope extraction, and refresh tests

New Features:
- Introduce new azuread.properties fields for token and identity metadata (incomingTokenType, oauth_scope_info, resourceId, tokenIssuerType, uniqueTokenIdentifier, userType)

Enhancements:
- Update parser mappings to populate new properties with fallbacks for session_id and user.id
- Add logic in parser to extract OAuth scope information from authenticationProcessingDetails

Tests:
- Refresh existing Azure AD test fixtures and add a new graph_activity_2.json test file