### PR TITLE
adding parsing for Authentication type and unique token identifier

### DIFF
--- a/Office 365/o365/_meta/fields.yml
+++ b/Office 365/o365/_meta/fields.yml
@@ -29,6 +29,11 @@ action.target:
   name: action.target
   type: keyword
 
+azuread.properties.uniqueTokenIdentifier:
+  description: ''
+  name: azuread.properties.uniqueTokenIdentifier
+  type: keyword
+
 office365.alert.category:
   description: ''
   name: office365.alert.category
@@ -135,6 +140,11 @@ office365.context.aad_session_id:
 office365.context.api_id:
   description: The identifier of the API pathway
   name: office365.context.api_id
+  type: keyword
+
+office365.context.authentication_type:
+  description: ''
+  name: office365.context.authentication_type
   type: keyword
 
 office365.context.client.id:

--- a/Office 365/o365/ingest/parser.yml
+++ b/Office 365/o365/ingest/parser.yml
@@ -143,6 +143,7 @@ stages:
           office365.audit.object_id: "{{json_event.message.ObjectId}}"
           office365.virus_info: "{{json_event.message.VirusInfo}}"
           office365.virus_vendor: "{{json_event.message.VirusVendor}}"
+          office365.context.authentication_type: "{{json_event.message.AuthenticationType}}"
       - set:
           office365.operation.properties: >
             {
@@ -186,6 +187,7 @@ stages:
           office365.context.client.id: "{{json_event.message.AppAccessContext.ClientAppId}}"
           office365.context.client.name: "{{json_event.message.AppAccessContext.ClientAppName}}"
           office365.context.correlation.id: "{{json_event.message.AppAccessContext.CorrelationId}}"
+          azuread.properties.uniqueTokenIdentifier: "{{json_event.message.AppAccessContext.UniqueTokenId}}"
         filter: '{{json_event.message.get("AppAccessContext") != None}}'
 
       - translate:

--- a/Office 365/o365/tests/browser_log.json
+++ b/Office 365/o365/tests/browser_log.json
@@ -16,12 +16,18 @@
       "outcome": "success",
       "target": "user"
     },
+    "azuread": {
+      "properties": {
+        "uniqueTokenIdentifier": "xxxxxxx"
+      }
+    },
     "office365": {
       "audit": {
         "object_id": "https://domain.com/subdomain/xxxxxx"
       },
       "context": {
         "aad_session_id": "xxxxxxx",
+        "authentication_type": "FormsCookieAuth",
         "correlation": {
           "id": "xxxxxxx"
         }

--- a/Office 365/o365/tests/exchange_item_group_4.json
+++ b/Office 365/o365/tests/exchange_item_group_4.json
@@ -22,6 +22,11 @@
       "outcome": "success",
       "target": "user"
     },
+    "azuread": {
+      "properties": {
+        "uniqueTokenIdentifier": "0000000000000000000000"
+      }
+    },
     "email": {
       "attachments": [
         {

--- a/Office 365/o365/tests/exchange_item_group_5.json
+++ b/Office 365/o365/tests/exchange_item_group_5.json
@@ -22,6 +22,11 @@
       "outcome": "success",
       "target": "user"
     },
+    "azuread": {
+      "properties": {
+        "uniqueTokenIdentifier": "0000000000000000000000"
+      }
+    },
     "email": {
       "attachments": [
         {

--- a/Office 365/o365/tests/exchange_item_group_6.json
+++ b/Office 365/o365/tests/exchange_item_group_6.json
@@ -22,6 +22,11 @@
       "outcome": "success",
       "target": "user"
     },
+    "azuread": {
+      "properties": {
+        "uniqueTokenIdentifier": "0000000000000000000000"
+      }
+    },
     "email": {
       "attachments": [
         {

--- a/Office 365/o365/tests/external_user.json
+++ b/Office 365/o365/tests/external_user.json
@@ -42,6 +42,7 @@
         "object_id": "https://example.com/1.zip"
       },
       "context": {
+        "authentication_type": "OAuth",
         "client": {
           "name": "MeTA"
         },

--- a/Office 365/o365/tests/file_malware_detected.json
+++ b/Office 365/o365/tests/file_malware_detected.json
@@ -41,6 +41,7 @@
         "object_id": "https://example.com/files/AdobePhotoshop20-cs_CZ_x64.zip"
       },
       "context": {
+        "authentication_type": "OAuth",
         "client": {
           "id": "f482d5ab-3acd-4c27-9721-30b09a03a648",
           "name": "f482d5ab-3acd-4c27-9721-30b09a03a648"

--- a/Office 365/o365/tests/file_size.json
+++ b/Office 365/o365/tests/file_size.json
@@ -43,6 +43,7 @@
       },
       "context": {
         "aad_session_id": "xxxx-xxx-xxx-xxx",
+        "authentication_type": "OAuth",
         "client": {
           "name": "WebExcel"
         },

--- a/Office 365/o365/tests/file_sync_download_full.json
+++ b/Office 365/o365/tests/file_sync_download_full.json
@@ -30,6 +30,11 @@
       ],
       "target": "user"
     },
+    "azuread": {
+      "properties": {
+        "uniqueTokenIdentifier": "0000000000000000000000"
+      }
+    },
     "file": {
       "directory": "public/assets/website",
       "extension": "png",

--- a/Office 365/o365/tests/managed_sync.json
+++ b/Office 365/o365/tests/managed_sync.json
@@ -22,6 +22,11 @@
       "outcome": "success",
       "target": "user"
     },
+    "azuread": {
+      "properties": {
+        "uniqueTokenIdentifier": "2222222222222222222222"
+      }
+    },
     "office365": {
       "audit": {
         "event_source": "SharePoint",
@@ -31,6 +36,7 @@
       },
       "context": {
         "aad_session_id": "fbe7d318-3d7f-4645-9e03-caa46e2a8f01",
+        "authentication_type": "FormsCookieAuth",
         "correlation": {
           "id": "5f24aa82-f874-44d1-b6df-857cd9e1decf"
         }

--- a/Office 365/o365/tests/source_log.json
+++ b/Office 365/o365/tests/source_log.json
@@ -30,6 +30,11 @@
       ],
       "target": "user"
     },
+    "azuread": {
+      "properties": {
+        "uniqueTokenIdentifier": "xxxxxx"
+      }
+    },
     "file": {
       "directory": "Documents partages/xxxxx.xlsx",
       "extension": "xlsx",
@@ -42,6 +47,7 @@
       },
       "context": {
         "aad_session_id": "xxxxxx",
+        "authentication_type": "FormsCookieAuth",
         "correlation": {
           "id": "xxxxxx"
         }

--- a/Office 365/o365/tests/targetusername.json
+++ b/Office 365/o365/tests/targetusername.json
@@ -36,6 +36,11 @@
       ],
       "target": "user"
     },
+    "azuread": {
+      "properties": {
+        "uniqueTokenIdentifier": "xxxxxx"
+      }
+    },
     "file": {
       "directory": "Documents/filename.pdf",
       "extension": "pdf",
@@ -48,6 +53,7 @@
       },
       "context": {
         "aad_session_id": "000-000-000-000",
+        "authentication_type": "OAuth",
         "client": {
           "id": "000-000-000-000",
           "name": "Microsoft Teams"

--- a/Office 365/o365/tests/teams_with_foreign_tenant_users.json
+++ b/Office 365/o365/tests/teams_with_foreign_tenant_users.json
@@ -28,6 +28,11 @@
       "outcome": "success",
       "target": "network-traffic"
     },
+    "azuread": {
+      "properties": {
+        "uniqueTokenIdentifier": "mYyWp_-UrEa4Z_pZM7FlAA"
+      }
+    },
     "office365": {
       "record_id": "4e3612b5-9cf5-4c6d-8213-2ba12af15334",
       "record_type": 25,


### PR DESCRIPTION
Be aware that I use `azuread.properties.uniqueTokenIdentifier` even though this is a O365 intake. The value is identical accross both intakes when the same token is used and I wanted to simplify pivots.

## Summary by Sourcery

Add support for parsing and indexing the new AuthenticationType and UniqueTokenIdentifier properties in Office 365 event data

Enhancements:
- Add office365.context.authentication_type and azuread.properties.uniqueTokenIdentifier fields to the schema
- Extract AuthenticationType and UniqueTokenId from incoming events in the parser

Tests:
- Update JSON test fixtures to include and validate the new authentication_type and uniqueTokenIdentifier fields