### PR TITLE
update office 365 parser

### DIFF
--- a/Office 365/o365/_meta/smart-descriptions.json
+++ b/Office 365/o365/_meta/smart-descriptions.json
@@ -55,7 +55,7 @@
     ]
   },
   {
-    "value": "Cloud App Security alert: {office365.alert.alert_name} - {event.reason}",
+    "value": "Cloud App Security alert: {office365.alert.display_name} - {event.reason}",
     "conditions": [
       {
         "field": "event.code",
@@ -66,7 +66,7 @@
         "value": "Cloud App Security"
       },
       {
-        "field": "office365.alert.alert_name"
+        "field": "office365.alert.display_name"
       },
       {
         "field": "event.reason"

--- a/Office 365/o365/ingest/parser.yml
+++ b/Office 365/o365/ingest/parser.yml
@@ -1010,7 +1010,7 @@ stages:
           event.url: "{{parse_data.ParsedData.alk}}"
           rule.reference: "{{parse_data.ParsedData.plk}}"
           rule.category: "{{parse_data.ParsedData.mat}}"
-          office365.alert.alert_name: "{{parse_data.ParsedData.an}}"
+          office365.alert.display_name: "{{parse_data.ParsedData.an}}"
         filter: "{{json_event.message.Source == 'Cloud App Security'}}"
 
       - set:

--- a/Office 365/o365/tests/mass_download.json
+++ b/Office 365/o365/tests/mass_download.json
@@ -29,7 +29,6 @@
     },
     "office365": {
       "alert": {
-        "alert_name": "Mass download by a single user",
         "category": "ThreatManagement",
         "display_name": "Mass download by a single user",
         "id": "c299a0a0-14da-428a-b08d-481d562298cb",

--- a/Office 365/o365/tests/test_cloud_app_security_alert.json
+++ b/Office 365/o365/tests/test_cloud_app_security_alert.json
@@ -35,7 +35,6 @@
     },
     "office365": {
       "alert": {
-        "alert_name": "Quarantine File",
         "category": "DataLossPrevention",
         "display_name": "Quarantine File",
         "id": "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeee0002",


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/1014

## Summary by Sourcery

Support parsing additional Cloud App Security alert fields in the Office 365 parser and add a corresponding test

New Features:
- Map Cloud App Security parsed data to event.start, event.end, event.reason, event.url, rule.reference, rule.category, and office365.alert.alert_name

Enhancements:
- Add office365.alert.alert_name field definition in metadata

Tests:
- Introduce a test case for Cloud App Security alert parsing