### PR TITLE
CI: find comments to update them

### DIFF
--- a/.github/workflows/copilot-pr-review.yml
+++ b/.github/workflows/copilot-pr-review.yml
@@ -289,6 +289,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Find Comment
+        if: github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize'
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
         id: find-comment
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,6 +113,7 @@ jobs:
           EOF
 
       - name: Find Comment
+        if: steps.checks.outcome == 'failure' && github.event_name == 'pull_request'
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
         id: find-comment
         with:


### PR DESCRIPTION
Fix https://github.com/SEKOIA-IO/intake-formats/pull/2009 that the purpose was to update existing comments.
Missed the following part

## Summary by Sourcery

Enhance CI workflows to update existing bot comments instead of creating duplicates

CI:
- Add "Find Comment" step using peter-evans/find-comment to locate existing GitHub Actions bot comments in copilot-pr-review.yml and main.yml
- Include comment-id and replace: true in create-or-update-comment steps to update the found comment rather than posting a new one