### PR TITLE
CI: fix how to update existing comments

### DIFF
--- a/.github/workflows/copilot-pr-review.yml
+++ b/.github/workflows/copilot-pr-review.yml
@@ -304,7 +304,7 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: ${{ steps.prepare-comment.outputs.body }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          replace: true
+          edit-mode: replace
 
       - name: Request Copilot Review
         uses: actions/github-script@v7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,7 +134,7 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: ${{ steps.prepare-comment.outputs.body }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          replace: true
+          edit-mode: replace
 
       - name: Fail workflow if checks failed
         if: steps.checks.outcome == 'failure'


### PR DESCRIPTION
Fix the step to update an existing comment

## Summary by Sourcery

CI:
- Replace deprecated 'replace: true' with 'edit-mode: replace' in the comment update steps of copilot-pr-review and main workflows