### PR TITLE
CI: fix typo

### DIFF
--- a/.github/workflows/upload_checks_comment.yml
+++ b/.github/workflows/upload_checks_comment.yml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
 
     steps:
-      - uses: actions/download-artifact@v018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
           name: pr_comment.md
           github-token: ${{ github.token }}

--- a/.github/workflows/upload_copilot_comments.yml
+++ b/.github/workflows/upload_copilot_comments.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
           name: pr_comment.md
           github-token: ${{ github.token }}

--- a/.github/workflows/upload_smart_desc.yml
+++ b/.github/workflows/upload_smart_desc.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
           name: pr_comment.md
           github-token: ${{ github.token }}


### PR DESCRIPTION
Fix typo in the version of the Github Action

## Summary by Sourcery

CI:
- Remove extraneous 'v' prefix from actions/download-artifact SHA in upload_checks_comment, upload_copilot_comments, and upload_smart_desc workflows