### PR TITLE
Report Office365 changes to production branch

### DIFF
--- a/Office 365/o365/_meta/fields.yml
+++ b/Office 365/o365/_meta/fields.yml
@@ -84,6 +84,16 @@ office365.app:
   name: office365.app
   type: keyword
 
+office365.application.id:
+  description: Identifier of the application
+  name: office365.application.id
+  type: keyword
+
+office365.application.name:
+  description: Name of the application
+  name: office365.application.name
+  type: keyword
+
 office365.audit.event_source:
   description: ''
   name: office365.audit.event_source

--- a/Office 365/o365/ingest/parser.yml
+++ b/Office 365/o365/ingest/parser.yml
@@ -32,6 +32,22 @@ pipeline:
         pattern: "::ffff:%{IP:ip}|%{IP:ip}(:%{INT:port})?"
     filter: '{{json_event.message.ClientIPAddress != null and json_event.message.ClientIPAddress != "" and json_event.message.ClientIPAddress != "<null>" }}'
 
+  - name: parse_display_name
+    filter: "{{json_event.message.ModifiedProperties | length > 0 and json_event.message.ModifiedProperties | selectattr('Name', 'equalto', 'DisplayName') | list | length == 1}}"
+    external:
+      name: json.parse-json
+      properties:
+        input_field: "{{(json_event.message.ModifiedProperties | selectattr('Name', 'equalto', 'DisplayName') | list)[0].NewValue}}"
+        output_field: values
+
+  - name: parse_app_id
+    filter: "{{json_event.message.ModifiedProperties | length > 0 and json_event.message.ModifiedProperties | selectattr('Name', 'equalto', 'AppId') | list | length == 1}}"
+    external:
+      name: json.parse-json
+      properties:
+        input_field: "{{(json_event.message.ModifiedProperties | selectattr('Name', 'equalto', 'AppId') | list)[0].NewValue}}"
+        output_field: values
+
   - name: set_common_fields
   - name: set_office365_fields
   - name: parse_exchange_admin
@@ -100,6 +116,11 @@ stages:
           user.name: "{{json_event.message.UserId.removeprefix('urn:spo:guest#')}}"
           user.id: "{{json_event.message.UserKey}}"
         filter: "{{json_event.message.RecordType not in [40]}}"
+
+      - set:
+          office365.application.id: "{{ parse_app_id.values[0] }}"
+          office365.application.name: "{{ parse_display_name.values[0] }}"
+        filter: "{{parse_display_name.values | length > 0 and parse_app_id.values | length > 0}}"
 
       - set:
           event.action: "{{json_event.message.Operation.rstrip('.')}}"

--- a/Office 365/o365/tests/event_add_application.json
+++ b/Office 365/o365/tests/event_add_application.json
@@ -1,0 +1,117 @@
+{
+  "input": {
+    "message": "{\"CreationTime\":\"2025-11-25T10:41:35\",\"Id\":\"TEST_RECORD_ID\",\"Operation\":\"Add application.\",\"OrganizationId\":\"ANONYMIZED_VALUE\",\"RecordType\":8,\"ResultStatus\":\"Success\",\"UserKey\":\"user1\",\"UserType\":4,\"Version\":1,\"Workload\":\"AzureActiveDirectory\",\"ObjectId\":\"Application_123123123123213\",\"UserId\":\"user1\",\"AzureActiveDirectoryEventType\":1,\"ExtendedProperties\":[{\"Name\":\"additionalDetails\",\"Value\":\"{\\\"AppId\\\":\\\"TEST_APP_Id\\\",\\\"Source\\\":\\\"{\\\\\\\"TYPE\\\\\\\":\\\\\\\"USER\\\\\\\",\\\\\\\"OBJECT ID\\\\\\\":\\\\\\\"e0e46298-ec85-4e8e-8efb-3d4c0df02778\\\\\\\"}\\\"}\"},{\"Name\":\"extendedAuditEventCategory\",\"Value\":\"Application\"}],\"ModifiedProperties\":[{\"Name\":\"AppAddress\",\"NewValue\":\"[\\r\\n  {\\r\\n    \\\"AddressType\\\": 0,\\r\\n    \\\"Address\\\": \\\"https://*.services.adobe.com/federated/saml/SSO/alias/*\\\",\\r\\n    \\\"ReplyAddressClientType\\\": 0,\\r\\n    \\\"ReplyAddressIndex\\\": null,\\r\\n    \\\"IsReplyAddressDefault\\\": false\\r\\n  }\\r\\n]\",\"OldValue\":\"[]\"},{\"Name\":\"AppId\",\"NewValue\":\"[\\r\\n  \\\"TEST_APP_Id\\\"\\r\\n]\",\"OldValue\":\"[]\"},{\"Name\":\"AvailableToOtherTenants\",\"NewValue\":\"[\\r\\n  false\\r\\n]\",\"OldValue\":\"[]\"},{\"Name\":\"DisplayName\",\"NewValue\":\"[\\r\\n  \\\"Adobe Identity Management (SAML)\\\"\\r\\n]\",\"OldValue\":\"[]\"},{\"Name\":\"Entitlement\",\"NewValue\":\"[\\r\\n  {\\r\\n    \\\"EntitlementEncodingVersion\\\": 2,\\r\\n    \\\"EntitlementId\\\": \\\"abfb7ab0-bfe1-483b-b457-d10e9bf9b07d\\\",\\r\\n    \\\"IsDisabled\\\": false,\\r\\n    \\\"Origin\\\": 0,\\r\\n    \\\"Name\\\": \\\"Access Adobe Identity Management (SAML)\\\",\\r\\n    \\\"Description\\\": \\\"Allow the application to access Adobe Identity Management (SAML) on behalf of the signed-in user.\\\",\\r\\n    \\\"Definition\\\": null,\\r\\n    \\\"ClaimValue\\\": \\\"user_impersonation\\\",\\r\\n    \\\"ResourceScopeType\\\": 1,\\r\\n    \\\"IsPrivate\\\": false,\\r\\n    \\\"UserConsentDisplayName\\\": \\\"Access Adobe Identity Management (SAML)\\\",\\r\\n    \\\"UserConsentDescription\\\": \\\"Allow the application to access Adobe Identity Management (SAML) on your behalf.\\\",\\r\\n    \\\"DirectAccessGrantTypes\\\": [],\\r\\n    \\\"ImpersonationAccessGrantTypes\\\": [\\r\\n      {\\r\\n        \\\"Impersonator\\\": 29,\\r\\n        \\\"Impersonated\\\": 20\\r\\n      }\\r\\n    ],\\r\\n    \\\"EntitlementCategory\\\": 0,\\r\\n    \\\"DependentMicrosoftGraphPermissions\\\": [],\\r\\n    \\\"IsPreauthzOnlyDirectAccessGrant\\\": false,\\r\\n    \\\"IsPreauthzOnlyImpersonationGrant\\\": false\\r\\n  }\\r\\n]\",\"OldValue\":\"[]\"},{\"Name\":\"PublicClient\",\"NewValue\":\"[\\r\\n  false\\r\\n]\",\"OldValue\":\"[]\"},{\"Name\":\"WwwHomepage\",\"NewValue\":\"[\\r\\n  \\\"https://*.services.adobe.com/federated/saml/SSO/alias/*?metadata=adobeidentitymanagement|ISV9.1|primary|z\\\"\\r\\n]\",\"OldValue\":\"[]\"},{\"Name\":\"PublisherDomain\",\"NewValue\":\"[\\r\\n  \\\"ocd-testing.com\\\"\\r\\n]\",\"OldValue\":\"[]\"},{\"Name\":\"SignInAudience\",\"NewValue\":\"[\\r\\n  \\\"AzureADMyOrg\\\"\\r\\n]\",\"OldValue\":\"[]\"},{\"Name\":\"Included Updated Properties\",\"NewValue\":\"AppAddress, AppId, AvailableToOtherTenants, DisplayName, Entitlement, PublicClient, WwwHomepage, PublisherDomain, SignInAudience\",\"OldValue\":\"\"}],\"Actor\":[{\"ID\":\"AAD App Management\",\"Type\":1},{\"ID\":\"f0ae4899-d877-4d3c-ae25-679e38eea492\",\"Type\":2},{\"ID\":\"user1\",\"Type\":2},{\"ID\":\"4d0745aa-f7e3-424b-8228-6c3455fa8af1\",\"Type\":2},{\"ID\":\"ServicePrincipal\",\"Type\":2}],\"ActorContextId\":\"ANONYMIZED_VALUE\",\"InterSystemsId\":\"TEST_CORRELATION_ID\",\"IntraSystemId\":\"00000000-0000-0000-0000-000000000000\",\"SupportTicketId\":\"\",\"Target\":[{\"ID\":\"Application_123123123123213\",\"Type\":2},{\"ID\":\"123123123123213\",\"Type\":2},{\"ID\":\"Application\",\"Type\":2},{\"ID\":\"Adobe Identity Management (SAML)\",\"Type\":1},{\"ID\":\"TEST_APP_Id\",\"Type\":2}],\"TargetContextId\":\"ANONYMIZED_VALUE\"}"
+  },
+  "expected": {
+    "message": "{\"CreationTime\":\"2025-11-25T10:41:35\",\"Id\":\"TEST_RECORD_ID\",\"Operation\":\"Add application.\",\"OrganizationId\":\"ANONYMIZED_VALUE\",\"RecordType\":8,\"ResultStatus\":\"Success\",\"UserKey\":\"user1\",\"UserType\":4,\"Version\":1,\"Workload\":\"AzureActiveDirectory\",\"ObjectId\":\"Application_123123123123213\",\"UserId\":\"user1\",\"AzureActiveDirectoryEventType\":1,\"ExtendedProperties\":[{\"Name\":\"additionalDetails\",\"Value\":\"{\\\"AppId\\\":\\\"TEST_APP_Id\\\",\\\"Source\\\":\\\"{\\\\\\\"TYPE\\\\\\\":\\\\\\\"USER\\\\\\\",\\\\\\\"OBJECT ID\\\\\\\":\\\\\\\"e0e46298-ec85-4e8e-8efb-3d4c0df02778\\\\\\\"}\\\"}\"},{\"Name\":\"extendedAuditEventCategory\",\"Value\":\"Application\"}],\"ModifiedProperties\":[{\"Name\":\"AppAddress\",\"NewValue\":\"[\\r\\n  {\\r\\n    \\\"AddressType\\\": 0,\\r\\n    \\\"Address\\\": \\\"https://*.services.adobe.com/federated/saml/SSO/alias/*\\\",\\r\\n    \\\"ReplyAddressClientType\\\": 0,\\r\\n    \\\"ReplyAddressIndex\\\": null,\\r\\n    \\\"IsReplyAddressDefault\\\": false\\r\\n  }\\r\\n]\",\"OldValue\":\"[]\"},{\"Name\":\"AppId\",\"NewValue\":\"[\\r\\n  \\\"TEST_APP_Id\\\"\\r\\n]\",\"OldValue\":\"[]\"},{\"Name\":\"AvailableToOtherTenants\",\"NewValue\":\"[\\r\\n  false\\r\\n]\",\"OldValue\":\"[]\"},{\"Name\":\"DisplayName\",\"NewValue\":\"[\\r\\n  \\\"Adobe Identity Management (SAML)\\\"\\r\\n]\",\"OldValue\":\"[]\"},{\"Name\":\"Entitlement\",\"NewValue\":\"[\\r\\n  {\\r\\n    \\\"EntitlementEncodingVersion\\\": 2,\\r\\n    \\\"EntitlementId\\\": \\\"abfb7ab0-bfe1-483b-b457-d10e9bf9b07d\\\",\\r\\n    \\\"IsDisabled\\\": false,\\r\\n    \\\"Origin\\\": 0,\\r\\n    \\\"Name\\\": \\\"Access Adobe Identity Management (SAML)\\\",\\r\\n    \\\"Description\\\": \\\"Allow the application to access Adobe Identity Management (SAML) on behalf of the signed-in user.\\\",\\r\\n    \\\"Definition\\\": null,\\r\\n    \\\"ClaimValue\\\": \\\"user_impersonation\\\",\\r\\n    \\\"ResourceScopeType\\\": 1,\\r\\n    \\\"IsPrivate\\\": false,\\r\\n    \\\"UserConsentDisplayName\\\": \\\"Access Adobe Identity Management (SAML)\\\",\\r\\n    \\\"UserConsentDescription\\\": \\\"Allow the application to access Adobe Identity Management (SAML) on your behalf.\\\",\\r\\n    \\\"DirectAccessGrantTypes\\\": [],\\r\\n    \\\"ImpersonationAccessGrantTypes\\\": [\\r\\n      {\\r\\n        \\\"Impersonator\\\": 29,\\r\\n        \\\"Impersonated\\\": 20\\r\\n      }\\r\\n    ],\\r\\n    \\\"EntitlementCategory\\\": 0,\\r\\n    \\\"DependentMicrosoftGraphPermissions\\\": [],\\r\\n    \\\"IsPreauthzOnlyDirectAccessGrant\\\": false,\\r\\n    \\\"IsPreauthzOnlyImpersonationGrant\\\": false\\r\\n  }\\r\\n]\",\"OldValue\":\"[]\"},{\"Name\":\"PublicClient\",\"NewValue\":\"[\\r\\n  false\\r\\n]\",\"OldValue\":\"[]\"},{\"Name\":\"WwwHomepage\",\"NewValue\":\"[\\r\\n  \\\"https://*.services.adobe.com/federated/saml/SSO/alias/*?metadata=adobeidentitymanagement|ISV9.1|primary|z\\\"\\r\\n]\",\"OldValue\":\"[]\"},{\"Name\":\"PublisherDomain\",\"NewValue\":\"[\\r\\n  \\\"ocd-testing.com\\\"\\r\\n]\",\"OldValue\":\"[]\"},{\"Name\":\"SignInAudience\",\"NewValue\":\"[\\r\\n  \\\"AzureADMyOrg\\\"\\r\\n]\",\"OldValue\":\"[]\"},{\"Name\":\"Included Updated Properties\",\"NewValue\":\"AppAddress, AppId, AvailableToOtherTenants, DisplayName, Entitlement, PublicClient, WwwHomepage, PublisherDomain, SignInAudience\",\"OldValue\":\"\"}],\"Actor\":[{\"ID\":\"AAD App Management\",\"Type\":1},{\"ID\":\"f0ae4899-d877-4d3c-ae25-679e38eea492\",\"Type\":2},{\"ID\":\"user1\",\"Type\":2},{\"ID\":\"4d0745aa-f7e3-424b-8228-6c3455fa8af1\",\"Type\":2},{\"ID\":\"ServicePrincipal\",\"Type\":2}],\"ActorContextId\":\"ANONYMIZED_VALUE\",\"InterSystemsId\":\"TEST_CORRELATION_ID\",\"IntraSystemId\":\"00000000-0000-0000-0000-000000000000\",\"SupportTicketId\":\"\",\"Target\":[{\"ID\":\"Application_123123123123213\",\"Type\":2},{\"ID\":\"123123123123213\",\"Type\":2},{\"ID\":\"Application\",\"Type\":2},{\"ID\":\"Adobe Identity Management (SAML)\",\"Type\":1},{\"ID\":\"TEST_APP_Id\",\"Type\":2}],\"TargetContextId\":\"ANONYMIZED_VALUE\"}",
+    "event": {
+      "action": "Add application",
+      "category": [
+        "iam"
+      ],
+      "code": "8",
+      "outcome": "success",
+      "type": [
+        "info"
+      ]
+    },
+    "@timestamp": "2025-11-25T10:41:35Z",
+    "action": {
+      "id": 8,
+      "name": "Add application",
+      "outcome": "success",
+      "target": "user"
+    },
+    "office365": {
+      "application": {
+        "id": "TEST_APP_Id",
+        "name": "Adobe Identity Management (SAML)"
+      },
+      "audit": {
+        "object_id": "Application_123123123123213"
+      },
+      "context": {
+        "correlation": {
+          "id": "TEST_CORRELATION_ID"
+        },
+        "modified_properties": [
+          {
+            "Name": "AppAddress",
+            "NewValue": "[\r\n  {\r\n    \"AddressType\": 0,\r\n    \"Address\": \"https://*.services.adobe.com/federated/saml/SSO/alias/*\",\r\n    \"ReplyAddressClientType\": 0,\r\n    \"ReplyAddressIndex\": null,\r\n    \"IsReplyAddressDefault\": false\r\n  }\r\n]",
+            "OldValue": "[]"
+          },
+          {
+            "Name": "AppId",
+            "NewValue": "[\r\n  \"TEST_APP_Id\"\r\n]",
+            "OldValue": "[]"
+          },
+          {
+            "Name": "AvailableToOtherTenants",
+            "NewValue": "[\r\n  false\r\n]",
+            "OldValue": "[]"
+          },
+          {
+            "Name": "DisplayName",
+            "NewValue": "[\r\n  \"Adobe Identity Management (SAML)\"\r\n]",
+            "OldValue": "[]"
+          },
+          {
+            "Name": "Entitlement",
+            "NewValue": "[\r\n  {\r\n    \"EntitlementEncodingVersion\": 2,\r\n    \"EntitlementId\": \"abfb7ab0-bfe1-483b-b457-d10e9bf9b07d\",\r\n    \"IsDisabled\": false,\r\n    \"Origin\": 0,\r\n    \"Name\": \"Access Adobe Identity Management (SAML)\",\r\n    \"Description\": \"Allow the application to access Adobe Identity Management (SAML) on behalf of the signed-in user.\",\r\n    \"Definition\": null,\r\n    \"ClaimValue\": \"user_impersonation\",\r\n    \"ResourceScopeType\": 1,\r\n    \"IsPrivate\": false,\r\n    \"UserConsentDisplayName\": \"Access Adobe Identity Management (SAML)\",\r\n    \"UserConsentDescription\": \"Allow the application to access Adobe Identity Management (SAML) on your behalf.\",\r\n    \"DirectAccessGrantTypes\": [],\r\n    \"ImpersonationAccessGrantTypes\": [\r\n      {\r\n        \"Impersonator\": 29,\r\n        \"Impersonated\": 20\r\n      }\r\n    ],\r\n    \"EntitlementCategory\": 0,\r\n    \"DependentMicrosoftGraphPermissions\": [],\r\n    \"IsPreauthzOnlyDirectAccessGrant\": false,\r\n    \"IsPreauthzOnlyImpersonationGrant\": false\r\n  }\r\n]",
+            "OldValue": "[]"
+          },
+          {
+            "Name": "PublicClient",
+            "NewValue": "[\r\n  false\r\n]",
+            "OldValue": "[]"
+          },
+          {
+            "Name": "WwwHomepage",
+            "NewValue": "[\r\n  \"https://*.services.adobe.com/federated/saml/SSO/alias/*?metadata=adobeidentitymanagement|ISV9.1|primary|z\"\r\n]",
+            "OldValue": "[]"
+          },
+          {
+            "Name": "PublisherDomain",
+            "NewValue": "[\r\n  \"ocd-testing.com\"\r\n]",
+            "OldValue": "[]"
+          },
+          {
+            "Name": "SignInAudience",
+            "NewValue": "[\r\n  \"AzureADMyOrg\"\r\n]",
+            "OldValue": "[]"
+          },
+          {
+            "Name": "Included Updated Properties",
+            "NewValue": "AppAddress, AppId, AvailableToOtherTenants, DisplayName, Entitlement, PublicClient, WwwHomepage, PublisherDomain, SignInAudience",
+            "OldValue": ""
+          }
+        ]
+      },
+      "record_id": "TEST_RECORD_ID",
+      "record_type": 8,
+      "result_status": "Success",
+      "target": {
+        "displayName": "Adobe Identity Management (SAML)"
+      },
+      "user_type": {
+        "code": 4,
+        "name": "System"
+      }
+    },
+    "organization": {
+      "id": "ANONYMIZED_VALUE"
+    },
+    "related": {
+      "user": [
+        "user1"
+      ]
+    },
+    "service": {
+      "name": "AzureActiveDirectory"
+    },
+    "user": {
+      "id": "user1",
+      "name": "user1"
+    }
+  }
+}


### PR DESCRIPTION
The previous PR was closed: https://github.com/SEKOIA-IO/intake-formats/pull/2087

## Summary by Sourcery

Capture Office 365 application identifiers and names from audit events and expose them as structured fields.

New Features:
- Extract application display name and AppId from Office 365 audit messages when present.
- Populate new structured fields for Office 365 application ID and application name in parsed events.

Tests:
- Add a test event fixture covering Office 365 audit events that include application information.