### PR TITLE
Azure: deprecate format

### DIFF
--- a/Azure/azure-network-watcher/_meta/manifest.yml
+++ b/Azure/azure-network-watcher/_meta/manifest.yml
@@ -1,12 +1,14 @@
 uuid: 340e3bc7-2b76-48e4-9833-e971451b2979
 automation_connector_uuid: 626f4d84-5ab7-11ee-8c99-0242ac120002
 automation_module_uuid: 525eecc0-9eee-484d-92bd-039117cf4dac
-name: Azure Network Watcher
+name: Azure Network Watcher [DEPRECATED]
 slug: azure-network-watcher
 description: >-
   Azure Network Watcher allows to log information about IP traffic flowing through a network security group (NSG flow logs).
 
   Sending flow logs to Sekoia.io will allow you to detect threats from the IP traffic, thanks to daily contextualized and actionable cyber threat indicators.
+
+  This format is deprecated in favor of the  Azure Network Watcher Flow Logs format.
 data_sources:
   Host network interface: every packets passing through the Network Security Group are logged
   Netflow/Enclave netflow: Azure Network Watcher NSG Flow Logs are Netflow-like


### PR DESCRIPTION
Deprecate the format

## Summary by Sourcery

Documentation:
- Clarify in the manifest description that the Azure Network Watcher format is deprecated in favor of the Azure Network Watcher Flow Logs format.