### PR TITLE
Microsoft: add registry event as test

### DIFF
--- a/Microsoft/microsoft-365-defender/tests/test_device_registry_event2.json
+++ b/Microsoft/microsoft-365-defender/tests/test_device_registry_event2.json
@@ -1,0 +1,101 @@
+{
+  "input": {
+    "message": "{\"time\":\"2026-02-09T13:13:00.4781979Z\",\"tenantId\":\"00000000-0000-0000-0000-000000000000\",\"operationName\":\"Publish\",\"category\":\"AdvancedHunting-DeviceRegistryEvents\",\"_TimeReceivedBySvc\":\"2026-02-09T13:12:14.3773992Z\",\"properties\":{\"DeviceName\":\"hostname\",\"DeviceId\":\"1111111111111111111111111111111111111111\",\"ReportId\":43051,\"RegistryKey\":\"HKEY_LOCAL_MACHINE\\\\SOFTWARE\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\RunOnce\",\"RegistryValueName\":\"msedge_cleanup_{00000000-0000-0000-0000-000000000000}\",\"RegistryValueType\":\"String\",\"RegistryValueData\":\"\\\"C:\\\\Program Files (x86)\\\\Microsoft\\\\EdgeWebView\\\\Application\\\\144.0.3719.115\\\\Installer\\\\setup.exe\\\" --msedgewebview --delete-old-versions --system-level --verbose-logging --on-logon\",\"PreviousRegistryValueData\":null,\"InitiatingProcessSHA1\":\"adc83b19e793491b1c6ea0fd8b46cd9f32e592fc\",\"InitiatingProcessFileSize\":7771728,\"InitiatingProcessMD5\":\"68b329da9893e34099c7d8ad5cb9c940\",\"InitiatingProcessFileName\":\"setup.exe\",\"InitiatingProcessParentFileName\":\"setup.exe\",\"InitiatingProcessFolderPath\":\"c:\\\\program files (x86)\\\\microsoft\\\\edgewebview\\\\application\\\\144.0.3719.115\\\\installer\\\\setup.exe\",\"InitiatingProcessCommandLine\":\"\\\"setup.exe\\\" --msedgewebview --delete-old-versions --system-level --verbose-logging\",\"InitiatingProcessCreationTime\":\"2026-02-09T12:59:50.3477956Z\",\"InitiatingProcessParentCreationTime\":\"2026-02-09T12:59:07.8025639Z\",\"InitiatingProcessAccountName\":\"syst\u00e8me\",\"InitiatingProcessAccountDomain\":\"system\",\"InitiatingProcessAccountSid\":\"S-1-5-18\",\"InitiatingProcessParentId\":18352,\"InitiatingProcessId\":22028,\"InitiatingProcessIntegrityLevel\":\"System\",\"InitiatingProcessTokenElevation\":\"TokenElevationTypeDefault\",\"PreviousRegistryKey\":\"\",\"PreviousRegistryValueName\":\"msedge_cleanup_{00000000-0000-0000-0000-000000000000}\",\"AppGuardContainerId\":\"\",\"ActionType\":\"RegistryValueSet\",\"InitiatingProcessSHA256\":\"01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b\",\"InitiatingProcessAccountUpn\":null,\"InitiatingProcessAccountObjectId\":null,\"InitiatingProcessVersionInfoCompanyName\":\"Microsoft Corporation\",\"InitiatingProcessVersionInfoProductName\":\"Microsoft Edge Installer\",\"InitiatingProcessVersionInfoProductVersion\":\"144.0.3719.115\",\"InitiatingProcessVersionInfoInternalFileName\":\"setup_exe\",\"InitiatingProcessVersionInfoOriginalFileName\":\"setup.exe\",\"InitiatingProcessVersionInfoFileDescription\":\"Microsoft Edge Installer\",\"InitiatingProcessSessionId\":0,\"IsInitiatingProcessRemoteSession\":false,\"InitiatingProcessRemoteSessionDeviceName\":null,\"InitiatingProcessRemoteSessionIP\":null,\"InitiatingProcessUniqueId\":\"1111111111111111\",\"Timestamp\":\"2026-02-09T13:10:05.872908Z\",\"MachineGroup\":\"UnassignedGroup\"},\"Tenant\":\"DefaultTenant\"}\n",
+    "sekoiaio": {
+      "intake": {
+        "dialect": "Microsoft Defender XDR / Microsoft 365 Defender",
+        "dialect_uuid": "05e6f36d-cee0-4f06-b575-9e43af779f9f"
+      }
+    }
+  },
+  "expected": {
+    "message": "{\"time\":\"2026-02-09T13:13:00.4781979Z\",\"tenantId\":\"00000000-0000-0000-0000-000000000000\",\"operationName\":\"Publish\",\"category\":\"AdvancedHunting-DeviceRegistryEvents\",\"_TimeReceivedBySvc\":\"2026-02-09T13:12:14.3773992Z\",\"properties\":{\"DeviceName\":\"hostname\",\"DeviceId\":\"1111111111111111111111111111111111111111\",\"ReportId\":43051,\"RegistryKey\":\"HKEY_LOCAL_MACHINE\\\\SOFTWARE\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\RunOnce\",\"RegistryValueName\":\"msedge_cleanup_{00000000-0000-0000-0000-000000000000}\",\"RegistryValueType\":\"String\",\"RegistryValueData\":\"\\\"C:\\\\Program Files (x86)\\\\Microsoft\\\\EdgeWebView\\\\Application\\\\144.0.3719.115\\\\Installer\\\\setup.exe\\\" --msedgewebview --delete-old-versions --system-level --verbose-logging --on-logon\",\"PreviousRegistryValueData\":null,\"InitiatingProcessSHA1\":\"adc83b19e793491b1c6ea0fd8b46cd9f32e592fc\",\"InitiatingProcessFileSize\":7771728,\"InitiatingProcessMD5\":\"68b329da9893e34099c7d8ad5cb9c940\",\"InitiatingProcessFileName\":\"setup.exe\",\"InitiatingProcessParentFileName\":\"setup.exe\",\"InitiatingProcessFolderPath\":\"c:\\\\program files (x86)\\\\microsoft\\\\edgewebview\\\\application\\\\144.0.3719.115\\\\installer\\\\setup.exe\",\"InitiatingProcessCommandLine\":\"\\\"setup.exe\\\" --msedgewebview --delete-old-versions --system-level --verbose-logging\",\"InitiatingProcessCreationTime\":\"2026-02-09T12:59:50.3477956Z\",\"InitiatingProcessParentCreationTime\":\"2026-02-09T12:59:07.8025639Z\",\"InitiatingProcessAccountName\":\"syst\u00e8me\",\"InitiatingProcessAccountDomain\":\"system\",\"InitiatingProcessAccountSid\":\"S-1-5-18\",\"InitiatingProcessParentId\":18352,\"InitiatingProcessId\":22028,\"InitiatingProcessIntegrityLevel\":\"System\",\"InitiatingProcessTokenElevation\":\"TokenElevationTypeDefault\",\"PreviousRegistryKey\":\"\",\"PreviousRegistryValueName\":\"msedge_cleanup_{00000000-0000-0000-0000-000000000000}\",\"AppGuardContainerId\":\"\",\"ActionType\":\"RegistryValueSet\",\"InitiatingProcessSHA256\":\"01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b\",\"InitiatingProcessAccountUpn\":null,\"InitiatingProcessAccountObjectId\":null,\"InitiatingProcessVersionInfoCompanyName\":\"Microsoft Corporation\",\"InitiatingProcessVersionInfoProductName\":\"Microsoft Edge Installer\",\"InitiatingProcessVersionInfoProductVersion\":\"144.0.3719.115\",\"InitiatingProcessVersionInfoInternalFileName\":\"setup_exe\",\"InitiatingProcessVersionInfoOriginalFileName\":\"setup.exe\",\"InitiatingProcessVersionInfoFileDescription\":\"Microsoft Edge Installer\",\"InitiatingProcessSessionId\":0,\"IsInitiatingProcessRemoteSession\":false,\"InitiatingProcessRemoteSessionDeviceName\":null,\"InitiatingProcessRemoteSessionIP\":null,\"InitiatingProcessUniqueId\":\"1111111111111111\",\"Timestamp\":\"2026-02-09T13:10:05.872908Z\",\"MachineGroup\":\"UnassignedGroup\"},\"Tenant\":\"DefaultTenant\"}\n",
+    "event": {
+      "category": [
+        "process"
+      ],
+      "dataset": "device_registry_events",
+      "type": [
+        "info"
+      ]
+    },
+    "@timestamp": "2026-02-09T13:10:05.872908Z",
+    "action": {
+      "name": "Publish",
+      "properties": {
+        "InitiatingProcessCommandLine": "\"setup.exe\" --msedgewebview --delete-old-versions --system-level --verbose-logging",
+        "InitiatingProcessFileSize": 7771728,
+        "InitiatingProcessIntegrityLevel": "System",
+        "InitiatingProcessSessionId": "0",
+        "InitiatingProcessTokenElevation": "TokenElevationTypeDefault",
+        "InitiatingProcessVersionInfoCompanyName": "Microsoft Corporation",
+        "InitiatingProcessVersionInfoFileDescription": "Microsoft Edge Installer",
+        "InitiatingProcessVersionInfoInternalFileName": "setup_exe",
+        "InitiatingProcessVersionInfoOriginalFileName": "setup.exe",
+        "InitiatingProcessVersionInfoProductName": "Microsoft Edge Installer",
+        "InitiatingProcessVersionInfoProductVersion": "144.0.3719.115",
+        "IsInitiatingProcessRemoteSession": "false",
+        "PreviousRegistryValueName": "msedge_cleanup_{00000000-0000-0000-0000-000000000000}"
+      },
+      "type": "RegistryValueSet"
+    },
+    "agent": {
+      "id": "1111111111111111111111111111111111111111"
+    },
+    "host": {
+      "id": "1111111111111111111111111111111111111111",
+      "name": "hostname"
+    },
+    "microsoft": {
+      "defender": {
+        "report": {
+          "id": "43051"
+        }
+      }
+    },
+    "process": {
+      "args": [
+        "--delete-old-versions",
+        "--msedgewebview",
+        "--system-level",
+        "--verbose-logging"
+      ],
+      "command_line": "\"setup.exe\" --msedgewebview --delete-old-versions --system-level --verbose-logging",
+      "executable": "c:\\program files (x86)\\microsoft\\edgewebview\\application\\144.0.3719.115\\installer\\setup.exe",
+      "hash": {
+        "md5": "68b329da9893e34099c7d8ad5cb9c940",
+        "sha1": "adc83b19e793491b1c6ea0fd8b46cd9f32e592fc",
+        "sha256": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"
+      },
+      "name": "setup.exe",
+      "parent": {
+        "name": "setup.exe",
+        "pid": 18352,
+        "start": "2026-02-09T12:59:07.802563Z"
+      },
+      "pid": 22028,
+      "start": "2026-02-09T12:59:50.347795Z",
+      "user": {
+        "domain": "system",
+        "id": "S-1-5-18",
+        "name": "syst\u00e8me"
+      },
+      "working_directory": "c:\\program files (x86)\\microsoft\\edgewebview\\application\\144.0.3719.115\\installer"
+    },
+    "registry": {
+      "data": {
+        "strings": "[\"\"C:\\Program Files (x86)\\Microsoft\\EdgeWebView\\Application\\144.0.3719.115\\Installer\\setup.exe\" --msedgewebview --delete-old-versions --system-level --verbose-logging --on-logon\"]",
+        "type": "String"
+      },
+      "key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\RunOnce",
+      "value": "msedge_cleanup_{00000000-0000-0000-0000-000000000000}"
+    },
+    "related": {
+      "hash": [
+        "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+        "68b329da9893e34099c7d8ad5cb9c940",
+        "adc83b19e793491b1c6ea0fd8b46cd9f32e592fc"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Add new test with `registry.*` extraction

## Summary by Sourcery

Tests:
- Add a new JSON test file covering registry.* field extraction for Microsoft 365 Defender device registry events.