### PR TITLE
fix auth failure

### DIFF
--- a/Stormshield/stormshield_network_security/ingest/parser.yml
+++ b/Stormshield/stormshield_network_security/ingest/parser.yml
@@ -181,7 +181,7 @@ stages:
           stormshield.auth.configid: "{{ kv.result.confid }}"
           stormshield.auth.totpused: "{{ kv.result.totp }}"
           stormshield.auth.method: "{{ kv.result.method }}"
-          action.outcome: '{% if kv.result.get("error", "0") == "0" %}success{% else %}failure{% endif %}'
+          action.outcome: '{% if "failed" in kv.result.msg.lower() %}failure{% elif kv.result.get("error", "0") != "0" %}failure{% else %}success{% endif %}'
           network.protocol: "{% if 'SSH' in kv.result.msg %}ssh{% else %}https{% endif %}"
         filter: '{{ kv.result.logtype == "auth" }}'
 

--- a/Stormshield/stormshield_network_security/tests/ssh_auth_failed.json
+++ b/Stormshield/stormshield_network_security/tests/ssh_auth_failed.json
@@ -1,0 +1,62 @@
+{
+  "input": {
+    "message": "id=firewall time=\"2026-02-07 09:12:44\" fw=\"SN820X99C1234D5\" tz=+0100 startime=\"2026-02-07 09:12:44\" src=11.22.33.44 user=\"john.doe\" domain=\"\" msg=\"SSH authentication failed: user not found in ldap\" totp=\"no\" logtype=\"auth\""
+  },
+  "expected": {
+    "message": "id=firewall time=\"2026-02-07 09:12:44\" fw=\"SN820X99C1234D5\" tz=+0100 startime=\"2026-02-07 09:12:44\" src=11.22.33.44 user=\"john.doe\" domain=\"\" msg=\"SSH authentication failed: user not found in ldap\" totp=\"no\" logtype=\"auth\"",
+    "event": {
+      "action": "authentication",
+      "category": [
+        "authentication"
+      ],
+      "dataset": "auth",
+      "outcome": "failure",
+      "start": "2026-02-07T08:12:44Z",
+      "timezone": "+0100",
+      "type": [
+        "info"
+      ]
+    },
+    "@timestamp": "2026-02-07T08:12:44Z",
+    "action": {
+      "outcome": "failure",
+      "outcome_reason": "SSH authentication failed: user not found in ldap"
+    },
+    "network": {
+      "protocol": "ssh"
+    },
+    "observer": {
+      "hostname": "SN820X99C1234D5",
+      "product": "Stormshield Network Security",
+      "serial_number": "SN820X99C1234D5",
+      "type": "firewall",
+      "vendor": "Stormshield"
+    },
+    "related": {
+      "hosts": [
+        "SN820X99C1234D5"
+      ],
+      "ip": [
+        "11.22.33.44"
+      ],
+      "user": [
+        "john.doe"
+      ]
+    },
+    "source": {
+      "address": "11.22.33.44",
+      "ip": "11.22.33.44"
+    },
+    "stormshield": {
+      "auth": {
+        "totpused": "no"
+      },
+      "filter": {
+        "action": "log"
+      }
+    },
+    "user": {
+      "name": "john.doe"
+    }
+  }
+}


### PR DESCRIPTION
## Description

[<!-- Provide a clear and concise description of your changes -->](https://github.com/SekoiaLab/integration/issues/1316)

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] New intake format
- [ ] Update to existing intake format
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (please describe):

## Affected Intake Formats

<!-- List the vendor/product formats affected by this PR -->

- Vendor/product:

## Checklist

<!-- Ensure all requirements are met before submitting -->

### 🔒 CRITICAL - Security Requirements (MUST BE VERIFIED FIRST)

- [ ] **No real email addresses** in test files (use: user@example.com, test@example.org)
- [ ] **No real passwords or API keys** (use: "P@ssw0rd!", "xxxxxxxxxxxx", "FAKE_TOKEN_123")
- [ ] **No real IP addresses** (use TEST-NET ranges: 192.0.2.x, 198.51.100.x, 203.0.113.x)
- [ ] **No real phone numbers** (use: +1-555-0100 or similar test numbers)
- [ ] **No real names or PII** (use: "John Doe", "Jane Smith", "User123")
- [ ] **No real company/organization names** in test data (unless public vendors)
- [ ] **No real usernames, hostnames, or domain names** (use: user1, host.example.com, test.corp)
- [ ] All test data has been anonymized and verified

### Required for All PRs

- [ ] Code has been linted
    - [ ] with the linter for manifest, smart-descriptions, and test files (`poetry run python linter.py check --changes` in utils/)
    - [ ] with Prettier for the parser code files (`npx prettier --write <module>/<format>/ingest/parser.yml`)
- [ ] All CI/CD checks pass
- [ ] Changes follow the contribution guidelines in `CONTRIBUTING.md`

### Required for New/Updated Intake Formats

- [ ] Clear descriptions provided for modules and formats
- [ ] Logo files included for new modules/formats
- [ ] Parser test coverage is at least 75%
- [ ] At least one smart-description is provided
- [ ] README.md updated (if applicable)
- [ ] Taxonomy mappings are correct and documented
- [ ] Test cases cover edge cases and error handling

### Testing

- [ ] Local tests pass (`poetry run pytest` in utils/)
- [ ] Sample data is representative and **completely anonymized**
- [ ] **No sensitive information** (PII, credentials, real IPs, real emails) in test files
- [ ] Test data uses example.com/example.org domains and TEST-NET IP ranges
- [ ] Parser handles malformed data gracefully

### Documentation

- [ ] Code changes are documented
- [ ] Smart-descriptions are clear and informative
- [ ] Field mappings are explained

## Additional Notes

<!-- Add any additional context, screenshots, or information that would help reviewers -->

## Related Issues

<!-- Link any related issues using #issue_number -->

Closes #

## Summary by Sourcery

Adjust Stormshield auth parsing to correctly classify authentication outcomes and cover SSH auth failures with tests.

Bug Fixes:
- Correct authentication outcome mapping by considering failure indicators in the Stormshield log message in addition to the error code.

Tests:
- Add a test fixture for failed SSH authentication events in the Stormshield Network Security parser.