### PR TITLE
fix destination port parsing

### DIFF
--- a/Fortinet/fortigate/ingest/parser.yml
+++ b/Fortinet/fortigate/ingest/parser.yml
@@ -204,7 +204,6 @@ stages:
           destination.mac: "{{parsed_event.message.dstmac}}"
           destination.nat.port: "{{parsed_event.message.destinationTranslatedPort}}"
           destination.packets: "{{parsed_event.message.rcvdpkt or parsed_event.message.get('Packets Received')}}"
-          destination.port: "{{parsed_event.message.dstport or parsed_event.message.dpt or parsed_event.message.locport}}"
           destination.user.name: "{{parsed_event.message.duser}}"
           dns.question.name: "{{parsed_event.message.qname}}"
           dns.question.type: "{{parsed_event.message.qtype}}"
@@ -255,7 +254,6 @@ stages:
           source.mac: "{{parsed_event.message.srcmac or parsed_event.message.mac}}"
           source.nat.port: "{{parsed_event.message.sourceTranslatedPort}}"
           source.packets: "{{parsed_event.message.sentpkt or parsed_event.message.get('Packets Sent')}}"
-          source.port: "{{parsed_event.message.srcport or parsed_event.message.spt or parsed_event.message.remport}}"
           fortinet.fortigate.icmp.request.type: "{{parsed_event.message.icmptype}}"
           fortinet.fortigate.icmp.request.code: "{{parsed_event.message.icmpcode}}"
           url.original: "{{parsed_event.message.url or parsed_event.message.request}}"
@@ -362,6 +360,26 @@ stages:
       - set:
           source.nat.ip: "{{parsed_event.message.transip}}"
         filter: "{{parsed_event.message.get('transip') | is_ipaddress}}"
+
+      - set:
+          destination.port: "{{parsed_event.message.dstport}}"
+        filter: "{{parsed_event.message.dstport | int(-1) >= 0}}"
+      - set:
+          destination.port: "{{parsed_event.message.dpt}}"
+        filter: "{{parsed_event.message.dpt | int(-1) >= 0}}"
+      - set:
+          destination.port: "{{parsed_event.message.locport}}"
+        filter: "{{parsed_event.message.locport | int(-1) >= 0}}"
+
+      - set:
+          source.port: "{{parsed_event.message.srcport}}"
+        filter: "{{parsed_event.message.srcport | int(-1) >= 0}}"
+      - set:
+          source.port: "{{parsed_event.message.spt}}"
+        filter: "{{parsed_event.message.spt | int(-1) >= 0}}"
+      - set:
+          source.port: "{{parsed_event.message.remport}}"
+        filter: "{{parsed_event.message.remport | int(-1) >= 0}}"
 
       - set:
           dns.question.name: "{{parsed_event.message.qname.strip()[1:-1]}}"

--- a/Fortinet/fortigate/tests/test_ssl_certificate_error.json
+++ b/Fortinet/fortigate/tests/test_ssl_certificate_error.json
@@ -1,0 +1,46 @@
+{
+  "input": {
+    "message": "time=16:45:21 devname=\"TEST_DEVICE\" devid=\"TEST_DEVICE_ID\" eventtime=1770824721111372922 tz=\"+0100\" logid=\"XXXXXXXXXX\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"SSL connection failed\" dstip=N/A dstport=N/A reason=\"self-signed certificate in certificate chain\" action=\"info\" status=\"failure\" msg=\"Certificate is invalid, subject: /C=XX/ST=XXXXXXXX/L=XXXXXXXXX/O=Fortinet/OU=Certificate Authority/CN=XXXXXXXXXXXXX/emailAddress=example@example.com\""
+  },
+  "expected": {
+    "message": "time=16:45:21 devname=\"TEST_DEVICE\" devid=\"TEST_DEVICE_ID\" eventtime=1770824721111372922 tz=\"+0100\" logid=\"XXXXXXXXXX\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"SSL connection failed\" dstip=N/A dstport=N/A reason=\"self-signed certificate in certificate chain\" action=\"info\" status=\"failure\" msg=\"Certificate is invalid, subject: /C=XX/ST=XXXXXXXX/L=XXXXXXXXX/O=Fortinet/OU=Certificate Authority/CN=XXXXXXXXXXXXX/emailAddress=example@example.com\"",
+    "event": {
+      "action": "info",
+      "category": "event",
+      "code": "XXXXXXXXXX",
+      "dataset": "event:system",
+      "outcome": "failure",
+      "reason": "self-signed certificate in certificate chain",
+      "timezone": "+0100"
+    },
+    "@timestamp": "2026-02-11T15:45:21.111373Z",
+    "action": {
+      "name": "info",
+      "outcome": "failure",
+      "outcome_reason": "Certificate is invalid, subject: /C=XX/ST=XXXXXXXX/L=XXXXXXXXX/O=Fortinet/OU=Certificate Authority/CN=XXXXXXXXXXXXX/emailAddress=example@example.com",
+      "type": "system"
+    },
+    "fortinet": {
+      "fortigate": {
+        "event": {
+          "type": "event"
+        },
+        "virtual_domain": "root"
+      }
+    },
+    "log": {
+      "description": "SSL connection failed",
+      "hostname": "TEST_DEVICE",
+      "level": "information"
+    },
+    "observer": {
+      "hostname": "TEST_DEVICE",
+      "serial_number": "TEST_DEVICE_ID"
+    },
+    "related": {
+      "hosts": [
+        "TEST_DEVICE"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Description

https://github.com/SekoiaLab/integration/issues/1324

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] New intake format
- [ ] Update to existing intake format
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (please describe):

## Affected Intake Formats

<!-- List the vendor/product formats affected by this PR -->

- Vendor/product:

## Checklist

<!-- Ensure all requirements are met before submitting -->

### 🔒 CRITICAL - Security Requirements (MUST BE VERIFIED FIRST)

- [ ] **No real email addresses** in test files (use: user@example.com, test@example.org)
- [ ] **No real passwords or API keys** (use: "P@ssw0rd!", "xxxxxxxxxxxx", "FAKE_TOKEN_123")
- [ ] **No real IP addresses** (use TEST-NET ranges: 192.0.2.x, 198.51.100.x, 203.0.113.x)
- [ ] **No real phone numbers** (use: +1-555-0100 or similar test numbers)
- [ ] **No real names or PII** (use: "John Doe", "Jane Smith", "User123")
- [ ] **No real company/organization names** in test data (unless public vendors)
- [ ] **No real usernames, hostnames, or domain names** (use: user1, host.example.com, test.corp)
- [ ] All test data has been anonymized and verified

### Required for All PRs

- [ ] Code has been linted
    - [ ] with the linter for manifest, smart-descriptions, and test files (`poetry run python linter.py check --changes` in utils/)
    - [ ] with Prettier for the parser code files (`npx prettier --write <module>/<format>/ingest/parser.yml`)
- [ ] All CI/CD checks pass
- [ ] Changes follow the contribution guidelines in `CONTRIBUTING.md`

### Required for New/Updated Intake Formats

- [ ] Clear descriptions provided for modules and formats
- [ ] Logo files included for new modules/formats
- [ ] Parser test coverage is at least 75%
- [ ] At least one smart-description is provided
- [ ] README.md updated (if applicable)
- [ ] Taxonomy mappings are correct and documented
- [ ] Test cases cover edge cases and error handling

### Testing

- [ ] Local tests pass (`poetry run pytest` in utils/)
- [ ] Sample data is representative and **completely anonymized**
- [ ] **No sensitive information** (PII, credentials, real IPs, real emails) in test files
- [ ] Test data uses example.com/example.org domains and TEST-NET IP ranges
- [ ] Parser handles malformed data gracefully

### Documentation

- [ ] Code changes are documented
- [ ] Smart-descriptions are clear and informative
- [ ] Field mappings are explained

## Additional Notes

<!-- Add any additional context, screenshots, or information that would help reviewers -->

## Related Issues

<!-- Link any related issues using #issue_number -->

Closes #

## Summary by Sourcery

Correct destination and source port extraction in the Fortinet Fortigate intake parser while validating parsed port values.

Bug Fixes:
- Ensure destination.port and source.port are populated from the appropriate Fortigate fields only when they contain valid non-negative integer values.

Tests:
- Add test coverage for Fortigate SSL certificate error events to validate the updated port parsing behavior.