### PR TITLE
feat(Fortinet): proxied traffic to FortiWeb

### DIFF
--- a/Fortinet/fortiweb/ingest/parser.yml
+++ b/Fortinet/fortiweb/ingest/parser.yml
@@ -50,6 +50,11 @@ stages:
           fortiweb.policy.type: "{{parsed_event.message.policytype}}"
 
       - set:
+          source.nat.ip: "{{set_fields.source.ip}}"
+          source.ip: "{{parsed_event.message.original_src}}"
+        filter: "{{parsed_event.message.get('original_src') != None and parsed_event.message.original_src != set_fields.source.ip}}"
+
+      - set:
           user.name: "{{parsed_event.message.user_name.split('@')[0]}}"
           user.domain: "{{parsed_event.message.user_name.split('@')[1]}}"
           user.email: "{{parsed_event.message.user_name}}"

--- a/Fortinet/fortiweb/tests/https_forwarded_traffic.json
+++ b/Fortinet/fortiweb/tests/https_forwarded_traffic.json
@@ -1,0 +1,106 @@
+{
+  "input": {
+    "message": "timestamp=1771428616 devname=\"FWBVMSTM25000384\" devid=\"FWBVMSTM25000384\" vd=\"root\" itime=1771421415 logver=\"0706061097\" date=\"2026-02-18\" time=\"14:30:15\" log_id=\"30001000\" msg_id=\"000486302375\" device_id=\"FWBVMSTM25000384\" eventtime=\"1771421415951634454\" timezone=\"(GMT+1:00)Brussels,Copenhagen,Madrid,Paris\" timezone_dayst=\"GMTc-1\" type=\"traffic\" subtype=\"https\" pri=\"notice\" proto=\"tcp\" service=\"https/tls1.3\" status=\"success\" reason=\"none\" policy=\"POL_PROD_Abc\" original_src=\"192.0.2.1\" src=\"192.0.2.2\" src_port=\"10161\" dst=\"192.0.2.3\" dst_port=\"443\" http_request_time=\"0\" http_response_time=\"2\" http_request_bytes=\"900\" http_response_bytes=\"60972\" http_method=\"get\" http_url=\"/example.php\" http_agent=\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36\" http_retcode=\"200\" msg=\"HTTPS get request from 192.0.2.2:10161 to 192.0.2.3:443\" original_srccountry=\"Japan\" srccountry=\"Japan\" content_switch_name=\"HTTP_content\" server_pool_name=\"192.0.2.3\" http_host=\"example.com\" user_name=\"Unknown\" http_refer=\"none\" http_version=\"1.x\" dev_id=\"A7F3E8C2D9B1F4A6C8E5D2B7F9A3C6E1B4D8\" cipher_suite=\"TLS_AES_256_GCM_SHA384\" x509_cert_subject=\"none\" tz=\"-0100\"",
+    "event": {
+      "created": "2026-02-18T13:30:16.860771Z",
+      "id": "cad1746c-2b24-4276-a0bd-9b728a484e88"
+    },
+    "log": {
+      "hostname": "192.0.2.10"
+    }
+  },
+  "expected": {
+    "message": "timestamp=1771428616 devname=\"FWBVMSTM25000384\" devid=\"FWBVMSTM25000384\" vd=\"root\" itime=1771421415 logver=\"0706061097\" date=\"2026-02-18\" time=\"14:30:15\" log_id=\"30001000\" msg_id=\"000486302375\" device_id=\"FWBVMSTM25000384\" eventtime=\"1771421415951634454\" timezone=\"(GMT+1:00)Brussels,Copenhagen,Madrid,Paris\" timezone_dayst=\"GMTc-1\" type=\"traffic\" subtype=\"https\" pri=\"notice\" proto=\"tcp\" service=\"https/tls1.3\" status=\"success\" reason=\"none\" policy=\"POL_PROD_Abc\" original_src=\"192.0.2.1\" src=\"192.0.2.2\" src_port=\"10161\" dst=\"192.0.2.3\" dst_port=\"443\" http_request_time=\"0\" http_response_time=\"2\" http_request_bytes=\"900\" http_response_bytes=\"60972\" http_method=\"get\" http_url=\"/example.php\" http_agent=\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36\" http_retcode=\"200\" msg=\"HTTPS get request from 192.0.2.2:10161 to 192.0.2.3:443\" original_srccountry=\"Japan\" srccountry=\"Japan\" content_switch_name=\"HTTP_content\" server_pool_name=\"192.0.2.3\" http_host=\"example.com\" user_name=\"Unknown\" http_refer=\"none\" http_version=\"1.x\" dev_id=\"A7F3E8C2D9B1F4A6C8E5D2B7F9A3C6E1B4D8\" cipher_suite=\"TLS_AES_256_GCM_SHA384\" x509_cert_subject=\"none\" tz=\"-0100\"",
+    "event": {
+      "category": "https",
+      "kind": "traffic",
+      "message": "HTTPS get request from 192.0.2.2:10161 to 192.0.2.3:443",
+      "outcome": "success"
+    },
+    "action": {
+      "outcome": "success",
+      "outcome_reason": "none",
+      "properties": {
+        "device_id": "FWBVMSTM25000384",
+        "log_id": "30001000",
+        "service": "https/tls1.3"
+      }
+    },
+    "destination": {
+      "address": "192.0.2.3",
+      "ip": "192.0.2.3",
+      "port": 443
+    },
+    "http": {
+      "request": {
+        "bytes": 900,
+        "method": "get",
+        "referrer": "none"
+      },
+      "response": {
+        "bytes": 60972,
+        "status_code": 200
+      },
+      "version": "1.x"
+    },
+    "log": {
+      "hostname": "192.0.2.10",
+      "level": "notice"
+    },
+    "network": {
+      "protocol": "tcp"
+    },
+    "related": {
+      "hosts": [
+        "example.com"
+      ],
+      "ip": [
+        "192.0.2.1",
+        "192.0.2.2",
+        "192.0.2.3"
+      ],
+      "user": [
+        "Unknown"
+      ]
+    },
+    "rule": {
+      "ruleset": "POL_PROD_Abc"
+    },
+    "source": {
+      "address": "192.0.2.1",
+      "geo": {
+        "name": "Japan"
+      },
+      "ip": "192.0.2.1",
+      "nat": {
+        "ip": "192.0.2.2"
+      },
+      "port": 10161
+    },
+    "tls": {
+      "cipher": "TLS_AES_256_GCM_SHA384"
+    },
+    "url": {
+      "domain": "example.com",
+      "path": "/example.php",
+      "registered_domain": "example.com",
+      "top_level_domain": "com",
+      "username": "Unknown"
+    },
+    "user": {
+      "name": "Unknown"
+    },
+    "user_agent": {
+      "device": {
+        "name": "Other"
+      },
+      "name": "Chrome",
+      "original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+      "os": {
+        "name": "Windows",
+        "version": "10"
+      },
+      "version": "120.0.0"
+    }
+  }
+}


### PR DESCRIPTION
## Description

Adds support for proxied traffic sent to FortiWeb (X-Forwarded-For and such).

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] New intake format
- [x] Update to existing intake format
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (please describe):

## Affected Intake Formats

<!-- List the vendor/product formats affected by this PR -->

- Vendor/product: Fortinet FortiWeb

## Checklist

<!-- Ensure all requirements are met before submitting -->

### 🔒 CRITICAL - Security Requirements (MUST BE VERIFIED FIRST)

- [x] **No real email addresses** in test files (use: user@example.com, test@example.org)
- [x] **No real passwords or API keys** (use: "P@ssw0rd!", "xxxxxxxxxxxx", "FAKE_TOKEN_123")
- [x] **No real IP addresses** (use TEST-NET ranges: 192.0.2.x, 198.51.100.x, 203.0.113.x)
- [x] **No real phone numbers** (use: +1-555-0100 or similar test numbers)
- [x] **No real names or PII** (use: "John Doe", "Jane Smith", "User123")
- [x] **No real company/organization names** in test data (unless public vendors)
- [x] **No real usernames, hostnames, or domain names** (use: user1, host.example.com, test.corp)
- [x] All test data has been anonymized and verified

### Required for All PRs

- [x] Code has been linted
    - [x] with the linter for manifest, smart-descriptions, and test files (`poetry run python linter.py check --changes` in utils/)
    - [x] with Prettier for the parser code files (`npx prettier --write <module>/<format>/ingest/parser.yml`)
- [ ] All CI/CD checks pass
- [x] Changes follow the contribution guidelines in `CONTRIBUTING.md`

### Required for New/Updated Intake Formats

- [x] Clear descriptions provided for modules and formats
- [x] Logo files included for new modules/formats
- [x] Parser test coverage is at least 75%
- [x] At least one smart-description is provided
- [ ] README.md updated (if applicable)
- [x] Taxonomy mappings are correct and documented
- [x] Test cases cover edge cases and error handling

### Testing

- [x] Local tests pass (`poetry run pytest` in utils/)
- [x] Sample data is representative and **completely anonymized**
- [x] **No sensitive information** (PII, credentials, real IPs, real emails) in test files
- [x] Test data uses example.com/example.org domains and TEST-NET IP ranges
- [x] Parser handles malformed data gracefully

### Documentation

- [x] Code changes are documented
- [x] Smart-descriptions are clear and informative
- [x] Field mappings are explained

## Additional Notes

ECS maintainers recommend the use of `source.nat.ip` [1] for proxy IPs, that's why it's used here.

[1] https://github.com/elastic/ecs/issues/771

## Related Issues

<!-- Link any related issues using #issue_number -->

None, AFAIA

## Summary by Sourcery

Add support for handling proxied FortiWeb traffic by correctly distinguishing between original client and proxy IPs in Fortinet FortiWeb events.

Enhancements:
- Map proxy/source IPs to ECS fields using source.nat.ip for the proxy and source.ip for the original client when present.

Tests:
- Add test coverage for HTTPS traffic with forwarded/proxied client IP information.