### PR TITLE
O365: deprecate the old O365 Message Trace format

### DIFF
--- a/Office 365/message-trace/_meta/manifest.yml
+++ b/Office 365/message-trace/_meta/manifest.yml
@@ -1,10 +1,11 @@
 uuid: 8461aabe-6eba-4044-ad7f-a0c39a2b2279
 automation_connector_uuid: 469807d0-4783-4136-8c48-2c5fc83526a0
 automation_module_uuid: 2dc2855e-3f9a-441c-af2a-30c64e0d0f4a
-name: Microsoft 365 Message Trace
+name: Microsoft 365 Message Trace [DEPRECATED]
 slug: o365-message-trace
 description: >-
   Microsoft 365 Message Trace follows email messages as they travel through your Exchange Online organization. You can determine if a message was received, rejected, deferred, or delivered by the service. It also shows what actions were taken on the message before it reached its final status. You can use the information from message trace to efficiently answer user questions about what happened to messages, troubleshoot mail flow issues, and validate policy changes.
+  This integration is deprecated in favor of `Microsoft 365 Message Trace (Graph API)`
 data_sources:
   Mail server: Message trace follows email messages as they travel through your Exchange Online organization.
   Email gateway: Message trace follows email messages as they travel through your Exchange Online organization.


### PR DESCRIPTION
Tag as deprecated the old 0365 Message Trace format (in favor of the one using GraphAPI)

## Summary by Sourcery

Enhancements:
- Update the Microsoft 365 Message Trace integration metadata to mark it as deprecated and reference the replacement Graph API integration.