### PR TITLE
ci: Harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,16 @@ updates:
     directory: "/utils" # Location of package manifests
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Cooldown applies only to version updates, not security updates
+    cooldown:
+      default-days: 14
+    groups:
+      # Group all version updates into a single PR; security updates remain ungrouped
+      github-actions:
+        applies-to: version-updates
+        patterns: ["*"]

--- a/.github/workflows/build-intakes.yml
+++ b/.github/workflows/build-intakes.yml
@@ -17,7 +17,7 @@ jobs:
       matrix: ${{ steps.list-intakes.outputs.matrix }}
     steps:
       - name: Check-out the repo under $GITHUB_WORKSPACE
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
 
@@ -49,13 +49,13 @@ jobs:
     steps:
       - name: my-app-install token
         id: my-app
-        uses: getsentry/action-github-app-token@v1
+        uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3.0.0
         with:
           app_id: ${{ secrets.PRIVATE_DISPATCH_APP_ID }}
           private_key: ${{ secrets.PRIVATE_DISPATCH_APP_SECRET_KEY }}
 
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ steps.my-app.outputs.token }}
           event-type: publish-intakes

--- a/.github/workflows/build-intakes.yml
+++ b/.github/workflows/build-intakes.yml
@@ -9,8 +9,12 @@ on:
       - develop
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   find-intakes:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
     name: Find intakes in repo
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/build-intakes.yml
+++ b/.github/workflows/build-intakes.yml
@@ -29,17 +29,17 @@ jobs:
         name: List intakes having changed files
         run: |
           if ${{ github.event_name == 'workflow_dispatch' }}; then
-            echo "matrix=$(find . -maxdepth 2 -type d ! -name '.*' ! -path './.git*' ! -path './utils*' ! -name '_meta' | awk -F/ 'NF == 3 && $2 {print $2 "/" $3}' | sort | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+            echo "matrix=$(find . -maxdepth 2 -type d ! -name '.*' ! -path './.git*' ! -path './utils*' ! -name '_meta' | awk -F/ 'NF == 3 && $2 {print $2 "/" $3}' | sort | jq -R -s -c 'split("\n")[:-1]')" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           if ${{ github.event_name == 'pull_request' }}; then
             start="HEAD^1"
             end="HEAD"
           else
-            start=${{ github.event.before }}
-            end=${{ github.event.after }}
+            start="${{ github.event.before }}"
+            end="${{ github.event.after }}"
           fi
-          echo "matrix=$(comm -12 <(cut -d "/" -f 1,2 <<< "$(git diff --name-only -r $start $end | sort | uniq)") <(find . -maxdepth 2 -type d ! -name '.*' ! -path './.git*' ! -path './utils*' ! -name '_meta' | awk -F/ 'NF == 3 && $2 {print $2 "/" $3}' | sort | uniq) | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          echo "matrix=$(comm -12 <(cut -d "/" -f 1,2 <<< "$(git diff --name-only -r "$start" "$end" | sort | uniq)") <(find . -maxdepth 2 -type d ! -name '.*' ! -path './.git*' ! -path './utils*' ! -name '_meta' | awk -F/ 'NF == 3 && $2 {print $2 "/" $3}' | sort | uniq) | jq -R -s -c 'split("\n")[:-1]')" >> "$GITHUB_OUTPUT"
 
   deploy-intakes:
     name: Deploy intakes

--- a/.github/workflows/copilot-pr-review.yml
+++ b/.github/workflows/copilot-pr-review.yml
@@ -43,7 +43,7 @@ jobs:
           if [ -n "$vendors" ]; then
             echo "The following intake formats were modified:" >> analysis.md
             echo "" >> analysis.md
-            echo "$vendors" | while read format; do
+            echo "$vendors" | while read -r format; do
               echo "- '$format'" >> analysis.md
             done
           else
@@ -59,9 +59,9 @@ jobs:
             echo "- No specific file types detected" >> analysis.md
           
           # Save analysis for next step
-          echo "analysis<<EOF" >> $GITHUB_OUTPUT
-          cat analysis.md >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "analysis<<EOF" >> "$GITHUB_OUTPUT"
+          cat analysis.md >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
         env:
           STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
 
@@ -76,7 +76,7 @@ jobs:
             grep -oP '^[^/]+/[^/]+' | sort -u || echo "")
           
           if [ -n "$vendors" ]; then
-            echo "$vendors" | while read format; do
+            echo "$vendors" | while read -r format; do
               vendor=$(echo "$format" | cut -d'/' -f1)
               product=$(echo "$format" | cut -d'/' -f2)
               
@@ -103,11 +103,11 @@ jobs:
           fi
           
           if [ -n "$warnings" ]; then
-            echo "warnings<<EOF" >> $GITHUB_OUTPUT
-            echo -e "$warnings" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
+            echo "warnings<<EOF" >> "$GITHUB_OUTPUT"
+            echo -e "$warnings" >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
           else
-            echo "warnings=No issues detected" >> $GITHUB_OUTPUT
+            echo "warnings=No issues detected" >> "$GITHUB_OUTPUT"
           fi
         env:
           STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
@@ -123,7 +123,7 @@ jobs:
           
           if [ -z "$test_files" ]; then
             echo "No test files changed"
-            echo "security_issues=No test files in this PR" >> $GITHUB_OUTPUT
+            echo "security_issues=No test files in this PR" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           
@@ -143,7 +143,7 @@ jobs:
             
             if [ -n "$real_emails" ]; then
               security_issues="$security_issues\n🚨 **CRITICAL** - '$file' contains potential real email addresses:\n"
-              echo "$real_emails" | while read email; do
+              echo "$real_emails" | while read -r email; do
                 if [ -n "$email" ]; then
                   security_issues="$security_issues  - '$email' - Replace with user@example.com\n"
                 fi
@@ -166,7 +166,7 @@ jobs:
             
             if [ -n "$real_ips" ]; then
               security_issues="$security_issues\n⚠️ **WARNING** - '$file' contains IP addresses that should use TEST-NET ranges:\n"
-              echo "$real_ips" | while read ip; do
+              echo "$real_ips" | while read -r ip; do
                 if [ -n "$ip" ]; then
                   security_issues="$security_issues  - '$ip' - Use 192.0.2.x, 198.51.100.x, or 203.0.113.x\n"
                 fi
@@ -192,11 +192,11 @@ jobs:
           done
           
           if [ -n "$security_issues" ]; then
-            echo "security_issues<<EOF" >> $GITHUB_OUTPUT
-            echo -e "$security_issues" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
+            echo "security_issues<<EOF" >> "$GITHUB_OUTPUT"
+            echo -e "$security_issues" >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
           else
-            echo "security_issues=✅ No obvious sensitive information detected in test files" >> $GITHUB_OUTPUT
+            echo "security_issues=✅ No obvious sensitive information detected in test files" >> "$GITHUB_OUTPUT"
           fi
         env:
           STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/copilot-pr-review.yml
+++ b/.github/workflows/copilot-pr-review.yml
@@ -15,13 +15,13 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
         with:
           files: |
             **/*.yml
@@ -282,13 +282,13 @@ jobs:
           For more details, see the [Contribution Guidelines](../CONTRIBUTING.md).
           COMMENT_EOF
       
-      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: pr_comment.md
           path: /tmp/pr_comment.md
 
       - name: Request Copilot Review
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/copilot-pr-review.yml
+++ b/.github/workflows/copilot-pr-review.yml
@@ -37,7 +37,7 @@ jobs:
           echo "" >> analysis.md
           
           # Extract vendor/product from changed files
-          vendors=$(echo "${{ steps.changed-files.outputs.all_changed_files }}" | \
+          vendors=$(echo "${STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES}" | \
             grep -oP '^[^/]+/[^/]+' | sort -u || echo "")
           
           if [ -n "$vendors" ]; then
@@ -53,7 +53,7 @@ jobs:
           echo "" >> analysis.md
           echo "## Changed File Types" >> analysis.md
           echo "" >> analysis.md
-          echo "${{ steps.changed-files.outputs.all_changed_files }}" | \
+          echo "${STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES}" | \
             grep -oE '\.[^.]+$' | sort | uniq -c | \
             awk '{print "- " $2 " files: " $1}' >> analysis.md || \
             echo "- No specific file types detected" >> analysis.md
@@ -62,6 +62,8 @@ jobs:
           echo "analysis<<EOF" >> $GITHUB_OUTPUT
           cat analysis.md >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+        env:
+          STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
 
       - name: Check for Required Files
         id: check-files
@@ -70,7 +72,7 @@ jobs:
           warnings=""
           
           # Get list of modified vendor/product directories
-          vendors=$(echo "${{ steps.changed-files.outputs.all_changed_files }}" | \
+          vendors=$(echo "${STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES}" | \
             grep -oP '^[^/]+/[^/]+' | sort -u || echo "")
           
           if [ -n "$vendors" ]; then
@@ -107,6 +109,8 @@ jobs:
           else
             echo "warnings=No issues detected" >> $GITHUB_OUTPUT
           fi
+        env:
+          STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
 
       - name: Scan for Sensitive Information (CRITICAL)
         id: security-scan
@@ -114,7 +118,7 @@ jobs:
           security_issues=""
           
           # Get all changed test files
-          test_files=$(echo "${{ steps.changed-files.outputs.all_changed_files }}" | \
+          test_files=$(echo "${STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES}" | \
             tr ' ' '\n' | grep -iE '(test|example|sample).*\.(py|json|txt|yml|yaml|log)$' || echo "")
           
           if [ -z "$test_files" ]; then
@@ -194,14 +198,16 @@ jobs:
           else
             echo "security_issues=✅ No obvious sensitive information detected in test files" >> $GITHUB_OUTPUT
           fi
+        env:
+          STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
 
       - name: Prepare PR comment
         if: github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize'
         id: prepare-comment
         run: |
-          analysis="${{ steps.analyze.outputs.analysis }}"
-          warnings="${{ steps.check-files.outputs.warnings }}"
-          security_issues="${{ steps.security-scan.outputs.security_issues }}"
+          analysis="${STEPS_ANALYZE_OUTPUTS_ANALYSIS}"
+          warnings="${STEPS_CHECK_FILES_OUTPUTS_WARNINGS}"
+          security_issues="${STEPS_SECURITY_SCAN_OUTPUTS_SECURITY_ISSUES}"
           
           # Use defaults if empty
           analysis="${analysis:-No analysis available}"
@@ -281,6 +287,10 @@ jobs:
 
           For more details, see the [Contribution Guidelines](../CONTRIBUTING.md).
           COMMENT_EOF
+        env:
+          STEPS_ANALYZE_OUTPUTS_ANALYSIS: ${{ steps.analyze.outputs.analysis }}
+          STEPS_CHECK_FILES_OUTPUTS_WARNINGS: ${{ steps.check-files.outputs.warnings }}
+          STEPS_SECURITY_SCAN_OUTPUTS_SECURITY_ISSUES: ${{ steps.security-scan.outputs.security_issues }}
       
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:

--- a/.github/workflows/generate-intakes-list.yml
+++ b/.github/workflows/generate-intakes-list.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check-out the repo under $GITHUB_WORKSPACE
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - id: list-intakes
         name: List intakes
@@ -21,13 +21,13 @@ jobs:
 
       - name: my-app-install token
         id: my-app
-        uses: getsentry/action-github-app-token@v1
+        uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3.0.0
         with:
           app_id: ${{ secrets.PRIVATE_DISPATCH_APP_ID }}
           private_key: ${{ secrets.PRIVATE_DISPATCH_APP_SECRET_KEY }}
 
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ steps.my-app.outputs.token }}
           event-type: refresh-intake-formats-list

--- a/.github/workflows/generate-intakes-list.yml
+++ b/.github/workflows/generate-intakes-list.yml
@@ -21,7 +21,7 @@ jobs:
       - id: list-intakes
         name: List intakes
         run: |
-          echo "intakes=$(find . -maxdepth 2 -type d ! -name '.*' ! -path './.git*' ! -path './utils*' ! -name '_meta' | awk -F/ 'NF == 3 && $2 {print $2 "/" $3}' | sort | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_ENV
+          echo "intakes=$(find . -maxdepth 2 -type d ! -name '.*' ! -path './.git*' ! -path './utils*' ! -name '_meta' | awk -F/ 'NF == 3 && $2 {print $2 "/" $3}' | sort | jq -R -s -c 'split("\n")[:-1]')" >> "$GITHUB_ENV"
 
       - name: my-app-install token
         id: my-app

--- a/.github/workflows/generate-intakes-list.yml
+++ b/.github/workflows/generate-intakes-list.yml
@@ -7,8 +7,12 @@ on:
       - main
       - develop
 
+permissions: {}
+
 jobs:
   generate-intakes-list:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
     steps:
       - name: Check-out the repo under $GITHUB_WORKSPACE

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,12 @@ defaults:
   run:
     working-directory: utils
 
+permissions: {}
+
 jobs:
   check_intakes:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,12 +20,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         id: setup-python
         with:
           python-version: "3.10"
@@ -116,7 +116,7 @@ jobs:
               f.write(body)
           EOF
       
-      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: pr_comment.md
           path: /tmp/pr_comment.md

--- a/.github/workflows/release_auto_approve.yml
+++ b/.github/workflows/release_auto_approve.yml
@@ -6,6 +6,8 @@ on:
     branches: [production]
     types: [opened, synchronize, reopened]
 
+permissions: {}
+
 jobs:
   auto-approve:
     runs-on: ubuntu-latest

--- a/.github/workflows/smart_desc.yml
+++ b/.github/workflows/smart_desc.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Generate smart descriptions
         id: smartdesc
         run: |
-          poetry run python show_smart_descriptions.py --changes --prsha=$GITHUB_SHA >> /tmp/pr_comment.md
+          poetry run python show_smart_descriptions.py --changes --prsha="$GITHUB_SHA" >> /tmp/pr_comment.md
       
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:

--- a/.github/workflows/smart_desc.yml
+++ b/.github/workflows/smart_desc.yml
@@ -10,8 +10,12 @@ defaults:
   run:
     working-directory: utils
 
+permissions: {}
+
 jobs:
   test:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/smart_desc.yml
+++ b/.github/workflows/smart_desc.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         id: setup-python
         with:
           python-version: "3.10"
@@ -39,7 +39,7 @@ jobs:
         run: |
           poetry run python show_smart_descriptions.py --changes --prsha=$GITHUB_SHA >> /tmp/pr_comment.md
       
-      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: pr_comment.md
           path: /tmp/pr_comment.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,12 @@ defaults:
   run:
     working-directory: utils
 
+permissions: {}
+
 jobs:
   test:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         id: setup-python
         with:
           python-version: "3.10"

--- a/.github/workflows/test_linting.yml
+++ b/.github/workflows/test_linting.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         id: setup-python
         with:
           python-version: "3.10"
@@ -36,7 +36,7 @@ jobs:
   prettier:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install
         run: npm install -g prettier
       - name: Run

--- a/.github/workflows/test_linting.yml
+++ b/.github/workflows/test_linting.yml
@@ -5,8 +5,12 @@ defaults:
   run:
     working-directory: utils
 
+permissions: {}
+
 jobs:
   test_linting:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
 
     steps:
@@ -34,6 +38,8 @@ jobs:
           poetry run python linter.py check --changes
 
   prettier:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/trigger-documentation-rebuild.yaml
+++ b/.github/workflows/trigger-documentation-rebuild.yaml
@@ -6,6 +6,8 @@ on:
       - main
       - develop
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/trigger-documentation-rebuild.yaml
+++ b/.github/workflows/trigger-documentation-rebuild.yaml
@@ -13,13 +13,13 @@ jobs:
     steps:
       - name: my-app-install token
         id: my-app
-        uses: getsentry/action-github-app-token@v1
+        uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3.0.0
         with:
           app_id: ${{ secrets.DISPATCH_APP_ID }}
           private_key: ${{ secrets.DISPATCH_APP_SECRET_KEY }}
 
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ steps.my-app.outputs.token }}
           event-type: rebuild-intake-documentation

--- a/.github/workflows/upload_checks_comment.yml
+++ b/.github/workflows/upload_checks_comment.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       actions: read  # for actions/download-artifact to download artifacts from other workflow runs
       issues: write  # for peter-evans/create-or-update-comment to create or update comment
+      pull-requests: write  # for peter-evans/create-or-update-comment to create or update comment
     runs-on: ubuntu-latest
     # Only run this job if the workflow run was "Check intakes" that failed
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}

--- a/.github/workflows/upload_checks_comment.yml
+++ b/.github/workflows/upload_checks_comment.yml
@@ -6,8 +6,13 @@ on:
     types:
       - completed
 
+permissions: {}
+
 jobs:
   comment_prs:
+    permissions:
+      actions: read  # for actions/download-artifact to download artifacts from other workflow runs
+      issues: write  # for peter-evans/create-or-update-comment to create or update comment
     runs-on: ubuntu-latest
     # Only run this job if the workflow run was "Check intakes" that failed
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}

--- a/.github/workflows/upload_checks_comment.yml
+++ b/.github/workflows/upload_checks_comment.yml
@@ -24,13 +24,6 @@ jobs:
           github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
 
-      - name: Prepare PR comment-author
-        id: prepare-comment
-        run: |
-          echo "body<<EOF" >> "$GITHUB_OUTPUT"
-          cat pr_comment.md >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
-
       - name: Find Comment
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: find-comment
@@ -43,6 +36,6 @@ jobs:
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
-          body: ${{ steps.prepare-comment.outputs.body }}
+          body-path: pr_comment.md
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           edit-mode: replace

--- a/.github/workflows/upload_checks_comment.yml
+++ b/.github/workflows/upload_checks_comment.yml
@@ -27,9 +27,9 @@ jobs:
       - name: Prepare PR comment-author
         id: prepare-comment
         run: |
-          echo "body<<EOF" >> $GITHUB_OUTPUT
-          cat pr_comment.md >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "body<<EOF" >> "$GITHUB_OUTPUT"
+          cat pr_comment.md >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Find Comment
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0

--- a/.github/workflows/upload_checks_comment.yml
+++ b/.github/workflows/upload_checks_comment.yml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
 
     steps:
-      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+      - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           name: pr_comment.md
           github-token: ${{ github.token }}
@@ -27,7 +27,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Find Comment
-        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: find-comment
         with:
           issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
@@ -35,7 +35,7 @@ jobs:
           body-includes: Intake Format Checks Failed
 
       - name: Comment on PR with Analysis
-        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
           body: ${{ steps.prepare-comment.outputs.body }}

--- a/.github/workflows/upload_copilot_comments.yml
+++ b/.github/workflows/upload_copilot_comments.yml
@@ -25,9 +25,9 @@ jobs:
       - name: Prepare PR comment-author
         id: prepare-comment
         run: |
-          echo "body<<EOF" >> $GITHUB_OUTPUT
-          cat pr_comment.md >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "body<<EOF" >> "$GITHUB_OUTPUT"
+          cat pr_comment.md >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Find Comment
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0

--- a/.github/workflows/upload_copilot_comments.yml
+++ b/.github/workflows/upload_copilot_comments.yml
@@ -6,8 +6,13 @@ on:
     types:
       - completed
 
+permissions: {}
+
 jobs:
   comment_prs:
+    permissions:
+      actions: read  # for actions/download-artifact to download artifacts from other workflow runs
+      issues: write  # for peter-evans/create-or-update-comment to create or update comment
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/upload_copilot_comments.yml
+++ b/.github/workflows/upload_copilot_comments.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       actions: read  # for actions/download-artifact to download artifacts from other workflow runs
       issues: write  # for peter-evans/create-or-update-comment to create or update comment
+      pull-requests: write  # for peter-evans/create-or-update-comment to create or update comment
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/upload_copilot_comments.yml
+++ b/.github/workflows/upload_copilot_comments.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+      - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           name: pr_comment.md
           github-token: ${{ github.token }}
@@ -25,7 +25,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Find Comment
-        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: find-comment
         with:
           issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
@@ -33,7 +33,7 @@ jobs:
           body-includes: Copilot Automated Review
 
       - name: Comment on PR with Analysis
-        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
           body: ${{ steps.prepare-comment.outputs.body }}

--- a/.github/workflows/upload_copilot_comments.yml
+++ b/.github/workflows/upload_copilot_comments.yml
@@ -22,13 +22,6 @@ jobs:
           github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
 
-      - name: Prepare PR comment-author
-        id: prepare-comment
-        run: |
-          echo "body<<EOF" >> "$GITHUB_OUTPUT"
-          cat pr_comment.md >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
-
       - name: Find Comment
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: find-comment
@@ -41,6 +34,6 @@ jobs:
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
-          body: ${{ steps.prepare-comment.outputs.body }}
+          body-path: pr_comment.md
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           edit-mode: replace

--- a/.github/workflows/upload_smart_desc.yml
+++ b/.github/workflows/upload_smart_desc.yml
@@ -25,9 +25,9 @@ jobs:
       - name: Prepare PR comment-author
         id: prepare-comment
         run: |
-          echo "body<<EOF" >> $GITHUB_OUTPUT
-          cat pr_comment.md >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "body<<EOF" >> "$GITHUB_OUTPUT"
+          cat pr_comment.md >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Find Comment
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
@@ -39,7 +39,7 @@ jobs:
 
       - name: Get current date
         id: date
-        run: echo "date=$(date +'%F %H:%M:%S')" >> $GITHUB_OUTPUT
+        run: echo "date=$(date +'%F %H:%M:%S')" >> "$GITHUB_OUTPUT"
 
       - name: Comment on PR with Analysis
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0

--- a/.github/workflows/upload_smart_desc.yml
+++ b/.github/workflows/upload_smart_desc.yml
@@ -23,11 +23,10 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Prepare PR comment-author
-        id: prepare-comment
         run: |
-          echo "body<<EOF" >> "$GITHUB_OUTPUT"
-          cat pr_comment.md >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          echo "Smart descriptions generated from the latest tests at $(date +'%F %H:%M:%S'):" > "$RUNNER_TEMP/comment.md"
+          cat pr_comment.md >> "$RUNNER_TEMP/comment.md"
+          mv "$RUNNER_TEMP/comment.md" pr_comment.md
 
       - name: Find Comment
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
@@ -37,16 +36,10 @@ jobs:
           comment-author: github-actions[bot]
           body-includes: Smart descriptions generated from the latest tests
 
-      - name: Get current date
-        id: date
-        run: echo "date=$(date +'%F %H:%M:%S')" >> "$GITHUB_OUTPUT"
-
       - name: Comment on PR with Analysis
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           edit-mode: replace
-          body: |
-            Smart descriptions generated from the latest tests at ${{ steps.date.outputs.date }}:
-            ${{ steps.prepare-comment.outputs.body }}
+          body-path: pr_comment.md

--- a/.github/workflows/upload_smart_desc.yml
+++ b/.github/workflows/upload_smart_desc.yml
@@ -6,8 +6,13 @@ on:
     types:
       - completed
 
+permissions: {}
+
 jobs:
   comment_prs:
+    permissions:
+      actions: read  # for actions/download-artifact to download artifacts from other workflow runs
+      issues: write  # for peter-evans/create-or-update-comment to create or update comment
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/upload_smart_desc.yml
+++ b/.github/workflows/upload_smart_desc.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       actions: read  # for actions/download-artifact to download artifacts from other workflow runs
       issues: write  # for peter-evans/create-or-update-comment to create or update comment
+      pull-requests: write  # for peter-evans/create-or-update-comment to create or update comment
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/upload_smart_desc.yml
+++ b/.github/workflows/upload_smart_desc.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+      - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           name: pr_comment.md
           github-token: ${{ github.token }}
@@ -25,7 +25,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Find Comment
-        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: find-comment
         with:
           issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
@@ -37,7 +37,7 @@ jobs:
         run: echo "date=$(date +'%F %H:%M:%S')" >> $GITHUB_OUTPUT
 
       - name: Comment on PR with Analysis
-        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}


### PR DESCRIPTION
## Summary

- Configure Dependabot for GitHub Actions (weekly, 14-day cooldown, grouped version updates)
- Pin actions to commit SHAs (14-day minimum age)
- Least-privilege `permissions` (deny-all at workflow level, minimal job-level grants)
- Fix zizmor findings (template injection in copilot-pr-review.yml via env var indirection)
- Fix actionlint findings (quote shell variables, add `-r` to `read`)
- Avoid passing untrusted artifact content through step outputs in `workflow_run` workflows (use `body-path` instead of reading into `GITHUB_OUTPUT`)

## Summary by Sourcery

Harden GitHub Actions workflows by tightening permissions, pinning actions to specific commits, and improving how workflow_run jobs handle artifacts and generated comments.

Bug Fixes:
- Address potential template injection in Copilot PR review workflow by avoiding direct use of untrusted step outputs in expressions.
- Fix shell scripting issues flagged by linters by quoting variables, using read -r, and correctly handling GITHUB_OUTPUT writes.
- Avoid passing untrusted artifact content through step outputs in workflow_run comment workflows by switching to file-based body inputs.

Enhancements:
- Pin all referenced GitHub Actions and third-party actions to specific commit SHAs and update them to current major versions.
- Define explicit deny-all workflow permissions with minimal job-level grants across CI workflows for least-privilege access.

CI:
- Configure Dependabot to manage GitHub Actions updates on a weekly schedule with cooldowns and grouped version updates for non-security changes.