### PR TITLE
Nanocorp: fix test

### DIFF
--- a/Nanocorp/nanocorp/tests/external_connection.json
+++ b/Nanocorp/nanocorp/tests/external_connection.json
@@ -1,34 +1,49 @@
 {
   "input": {
+    "message": "{\n  \"event_id\": 7077685489580260926,\n  \"event_type\": \"External connection\",\n  \"source\": 8903162277747742819,\n  \"seen_at\": 1764596280793,\n  \"source_ip\": \"192.0.2.0\",\n  \"source_mac\": \"00:1A:2B:3C:4D:5E\",\n  \"dest_ip\": \"198.51.100.0\",\n  \"dest_mac\": \"00:1A:2B:3C:4D:5E\",\n  \"proto_path\": \"/Ethernet/Ipv4/Tcp/Http/\",\n  \"network_protocol\": \"http\"\n}\n",
     "sekoiaio": {
       "intake": {
         "dialect": "Nanocorp",
         "dialect_uuid": "48121ba7-6091-4bbc-accd-50e7c286e7af"
       }
-    },
-    "message": "{\n  \"event_id\": 7077685489580260926,\n  \"event_type\": \"External connection\",\n  \"source\": 8903162277747742819,\n  \"seen_at\": 1764596280793,\n  \"source_ip\": \"192.0.2.0\",\n  \"source_mac\": \"00:1A:2B:3C:4D:5E\",\n  \"dest_ip\": \"198.51.100.0\",\n  \"dest_mac\": \"00:1A:2B:3C:4D:5E\",\n  \"proto_path\": \"/Ethernet/Ipv4/Tcp/Http/\",\n  \"network_protocol\": \"http\"\n}\n"
+    }
   },
   "expected": {
+    "message": "{\n  \"event_id\": 7077685489580260926,\n  \"event_type\": \"External connection\",\n  \"source\": 8903162277747742819,\n  \"seen_at\": 1764596280793,\n  \"source_ip\": \"192.0.2.0\",\n  \"source_mac\": \"00:1A:2B:3C:4D:5E\",\n  \"dest_ip\": \"198.51.100.0\",\n  \"dest_mac\": \"00:1A:2B:3C:4D:5E\",\n  \"proto_path\": \"/Ethernet/Ipv4/Tcp/Http/\",\n  \"network_protocol\": \"http\"\n}\n",
+    "event": {
+      "action": "External connection",
+      "category": [
+        "network"
+      ],
+      "outcome": "Success",
+      "start": "2025-12-01T13:38:00.793000Z",
+      "type": [
+        "connection"
+      ]
+    },
     "@timestamp": "2025-12-01T13:38:00.793000Z",
     "destination": {
       "address": "198.51.100.0",
       "ip": "198.51.100.0",
       "mac": "00:1A:2B:3C:4D:5E"
     },
-    "event": {
-      "action": "External connection",
-      "category": ["network"],
-      "type": ["connection"],
-      "outcome": "Success",
-      "start": "2025-12-01T13:38:00.793000Z"
+    "network": {
+      "protocol": "http"
+    },
+    "observer": {
+      "product": "Nanocorp",
+      "vendor": "Nanocorp"
+    },
+    "related": {
+      "ip": [
+        "192.0.2.0",
+        "198.51.100.0"
+      ]
     },
     "source": {
       "address": "192.0.2.0",
       "ip": "192.0.2.0",
       "mac": "00:1A:2B:3C:4D:5E"
-    },
-    "observer": {"product": "Nanocorp", "vendor": "Nanocorp"},
-    "related": {"ip": ["198.51.100.0", "192.0.2.0"]},
-    "network": {"protocol": "http"}
+    }
   }
 }


### PR DESCRIPTION
message is missing from the expectation part

## Summary by Sourcery

Fix test data for external connection expectations.

Bug Fixes:
- Correct the missing message field in the external connection test expectation data.

Tests:
- Update external_connection.json test fixture to include the expected message value.