### PR TITLE
Nanocorp: some fixes

### DIFF
--- a/Nanocorp/nanocorp/_meta/manifest.yml
+++ b/Nanocorp/nanocorp/_meta/manifest.yml
@@ -1,3 +1,4 @@
+automation_module_uuid: 0ebb28ba-5748-4617-af1f-51b7ca31bf9a
 uuid: 48121ba7-6091-4bbc-accd-50e7c286e7af
 name: Nanocorp
 slug: nanocorp

--- a/Nanocorp/nanocorp/_meta/manifest.yml
+++ b/Nanocorp/nanocorp/_meta/manifest.yml
@@ -1,6 +1,6 @@
 automation_module_uuid: 0ebb28ba-5748-4617-af1f-51b7ca31bf9a
 uuid: 48121ba7-6091-4bbc-accd-50e7c286e7af
-name: Nanocorp
+name: Nanocorp [BETA]
 slug: nanocorp
 
 description: >-


### PR DESCRIPTION
- add automation module uuid
- add beta flag

## Summary by Sourcery

Add an automation module UUID to the Nanocorp manifest and mark the Nanocorp integration as beta in its metadata.

New Features:
- Introduce an automation module UUID field in the Nanocorp manifest metadata.

Enhancements:
- Label the Nanocorp integration as beta in the manifest name to reflect its maturity state.