### PR TITLE
chore: remove invalid gitattribute

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-git config --global core.autocrlf false


### PR DESCRIPTION
Remove the .gitattribute file that contains an invalid content (see [documentation](https://git-scm.com/docs/gitattributes)).

## Summary by Sourcery

Chores:
- Delete the obsolete .gitattributes file containing invalid configuration.