### PR TITLE
Hotfix: ZScaler Linting

### DIFF
--- a/Zscaler/zscaler-zpa/_meta/fields.yml
+++ b/Zscaler/zscaler-zpa/_meta/fields.yml
@@ -28,94 +28,32 @@ zscaler.zpa.app_connector.version:
   name: zscaler.zpa.app_connector.version
   type: text
 
-zscaler.zpa.app_group_name:
-  description: The application group name
-  name: zscaler.zpa.app_group_name
-  type: text
-
-zscaler.zpa.client_connector_version:
-  description: The Zscaler Client Connector version
-  name: zscaler.zpa.client_connector_version
-  type: text
-
-zscaler.zpa.client_type:
-  description:
-    The client type for the request (i.e., Zscaler Client Connector, ZPA
-    LSS, or Web Browser)
-  name: zscaler.zpa.client_type
-  type: text
-
 zscaler.zpa.app_connector.zen:
   description: The ZPA Public Service Edge that sent the request from the App Connector
   name: zscaler.zpa.app_connector.zen
   type: text
 
-zscaler.zpa.inspection.controls_hit_count:
-  description: The number of AppProtection control hits
-  name: zscaler.zpa.inspection.controls_hit_count
-  type: number
-
-zscaler.zpa.inspection.policy:
-  description: The AppProtection policy
-  name: zscaler.zpa.inspection.policy
-  type: text
-
-zscaler.zpa.inspection.profile:
-  description: The AppProtection profile
-  name: zscaler.zpa.inspection.profile
-  type: text
-
-zscaler.zpa.paranoia_level:
-  description: The OWASP Predefined Paranoia Level
-  name: zscaler.zpa.paranoia_level
-  type: text
-
-zscaler.zpa.posture.hit:
-  description:
-    The posture profiles that the Zscaler Client Connector verified for
-    this device
-  name: zscaler.zpa.posture.hit
-  type: text
-
-zscaler.zpa.posture.miss:
-  description:
-    The posture profiles that the Zscaler Client Connector failed to verify
-    for this device
-  name: zscaler.zpa.posture.miss
-  type: text
-
-zscaler.zpa.trusted_networks.ids:
-  description:
-    The unique IDs for the trusted networks that the Zscaler Client Connector
-    has determined for this device
-  name: zscaler.zpa.trusted_networks.ids
-  type: text
-
-zscaler.zpa.trusted_networks.names:
-  description:
-    The names for the trusted networks that the Zscaler Client Connector
-    has determined for this device
-  name: zscaler.zpa.trusted_networks.names
+zscaler.zpa.app_group_name:
+  description: The application group name
+  name: zscaler.zpa.app_group_name
   type: text
 
 zscaler.zpa.audit.new_value:
-  description:
-    "The new value that was changed if the action type is create, sign
+  description: 'The new value that was changed if the action type is create, sign
     in, or update. If the modified object is policy related, the value depends on
-    the policy type. "
+    the policy type. '
   name: zscaler.zpa.audit.new_value
   type: text
 
 zscaler.zpa.audit.old_value:
-  description:
-    The previous value that was changed if the action type is delete, sign
+  description: The previous value that was changed if the action type is delete, sign
     out, or update. If the modified object is policy related, the value depends on
     the policy type.
   name: zscaler.zpa.audit.old_value
   type: text
 
 zscaler.zpa.audit.operation_type:
-  description: "The action performed.
+  description: 'The action performed.
 
     The expected values for this field:
 
@@ -135,8 +73,34 @@ zscaler.zpa.audit.operation_type:
 
     Update
 
-    "
+    '
   name: zscaler.zpa.audit.operation_type
+  type: text
+
+zscaler.zpa.client_connector_version:
+  description: The Zscaler Client Connector version
+  name: zscaler.zpa.client_connector_version
+  type: text
+
+zscaler.zpa.client_type:
+  description: The client type for the request (i.e., Zscaler Client Connector, ZPA
+    LSS, or Web Browser)
+  name: zscaler.zpa.client_type
+  type: text
+
+zscaler.zpa.inspection.controls_hit_count:
+  description: The number of AppProtection control hits
+  name: zscaler.zpa.inspection.controls_hit_count
+  type: number
+
+zscaler.zpa.inspection.policy:
+  description: The AppProtection policy
+  name: zscaler.zpa.inspection.policy
+  type: text
+
+zscaler.zpa.inspection.profile:
+  description: The AppProtection profile
+  name: zscaler.zpa.inspection.profile
   type: text
 
 zscaler.zpa.object.id:
@@ -145,15 +109,42 @@ zscaler.zpa.object.id:
   type: text
 
 zscaler.zpa.object.name:
-  description:
-    The name of the object. This corresponds to the Resource Name in the
+  description: The name of the object. This corresponds to the Resource Name in the
     Audit Log page.
   name: zscaler.zpa.object.name
   type: text
 
 zscaler.zpa.object.type:
-  description:
-    The location within the ZPA Admin Portal where the Action was performed.
+  description: The location within the ZPA Admin Portal where the Action was performed.
     This corresponds to the Resource Type on the Audit Log page.
   name: zscaler.zpa.object.type
+  type: text
+
+zscaler.zpa.paranoia_level:
+  description: The OWASP Predefined Paranoia Level
+  name: zscaler.zpa.paranoia_level
+  type: text
+
+zscaler.zpa.posture.hit:
+  description: The posture profiles that the Zscaler Client Connector verified for
+    this device
+  name: zscaler.zpa.posture.hit
+  type: text
+
+zscaler.zpa.posture.miss:
+  description: The posture profiles that the Zscaler Client Connector failed to verify
+    for this device
+  name: zscaler.zpa.posture.miss
+  type: text
+
+zscaler.zpa.trusted_networks.ids:
+  description: The unique IDs for the trusted networks that the Zscaler Client Connector
+    has determined for this device
+  name: zscaler.zpa.trusted_networks.ids
+  type: text
+
+zscaler.zpa.trusted_networks.names:
+  description: The names for the trusted networks that the Zscaler Client Connector
+    has determined for this device
+  name: zscaler.zpa.trusted_networks.names
   type: text


### PR DESCRIPTION
## Summary by Sourcery

Reorder and reformat Zscaler ZPA field definitions to satisfy linting and YAML style requirements without changing their semantics.

Enhancements:
- Normalize YAML description quoting and line wrapping for Zscaler ZPA audit fields.
- Reposition several Zscaler ZPA field definitions to align with the expected field order and linting rules.