### PR TITLE
fix(Ubika): deprecate old formats

### DIFF
--- a/Ubika/ubika-cloud-protector-alerts/_meta/manifest.yml
+++ b/Ubika/ubika-cloud-protector-alerts/_meta/manifest.yml
@@ -1,9 +1,10 @@
 uuid: d0383e87-e054-4a21-8a2c-6a89635d8615
-name: Ubika Cloud Protector Alerts
+name: Ubika Cloud Protector Alerts [DEPRECATED]
 slug: ubika-cloud-protector-alerts
 automation_connector_uuid: 9a92d17c-6740-476f-8cec-621de2e853c5
 automation_module_uuid: 0c82ee9b-f645-47f9-8e16-a689cfc246c4
 description: >-
   Ubika Cloud Protector is a cloud-native security solution, providing advanced threat detection and data protection to secure cloud environments, enabling real-time monitoring and mitigation of risks in cloud-based infrastructures.
+  This integration is now deprecated. Please use Ubika Cloud Protector Next Generation Alerts instead.
 data_sources:
   Web application firewall logs: Ubika detects and mitigates threats against web applications and APIs

--- a/Ubika/ubika-cloud-protector-traffic/_meta/manifest.yml
+++ b/Ubika/ubika-cloud-protector-traffic/_meta/manifest.yml
@@ -1,9 +1,10 @@
 uuid: 8d024a2b-3627-4909-818d-26e1e3b2409c
-name: Ubika Cloud Protector Traffic
+name: Ubika Cloud Protector Traffic [DEPRECATED]
 slug: ubika-cloud-protector-traffic
 automation_connector_uuid: 60b3ed59-e7e4-45fa-84e8-5a52695116c1
 automation_module_uuid: 0c82ee9b-f645-47f9-8e16-a689cfc246c4
 description: >-
   Ubika Cloud Protector is a cloud-native security solution, providing advanced threat detection and data protection to secure cloud environments, enabling real-time monitoring and mitigation of risks in cloud-based infrastructures.
+  This integration is now deprecated. Please use Ubika Cloud Protector Next Generation Traffic logs instead.
 data_sources:
   Web proxy: Ubika detects and mitigates threats against web applications and APIs.


### PR DESCRIPTION
Deprecate the old formats

## Summary by Sourcery

Documentation:
- Update Ubika Cloud Protector Alerts and Traffic integration metadata to mark them as deprecated and point users to the Next Generation integrations.