### PR TITLE
Out of Beta April

### DIFF
--- a/Azure/azure-activity-logs/_meta/manifest.yml
+++ b/Azure/azure-activity-logs/_meta/manifest.yml
@@ -1,5 +1,5 @@
 uuid: 39280bac-34d7-4fa2-a6b5-c43791eed1bc
-name: Azure Activity Logs [BETA]
+name: Azure Activity Logs
 slug: azure-activity-logs
 automation_connector_uuid: 66627aa0-6800-4f54-9550-85463cb622cc
 automation_module_uuid: 28d53bf5-738a-42a4-8ce4-67e00195590e

--- a/Juniper/juniper-ngfw/_meta/manifest.yml
+++ b/Juniper/juniper-ngfw/_meta/manifest.yml
@@ -1,5 +1,5 @@
 uuid: f5f05e2a-32fc-432d-9f00-11f490ae15f4
-name: Juniper NGFW [BETA]
+name: Juniper NGFW
 slug: juniper-ngfw
 automation_module_uuid: 759bcde6-01eb-4d3c-a5ed-0944e69760b6
 description: >-

--- a/Keycloak/keycloak-events/_meta/manifest.yml
+++ b/Keycloak/keycloak-events/_meta/manifest.yml
@@ -1,5 +1,5 @@
 uuid: cc1b212e-80c2-4dde-8446-2e194c6d4e80
-name: Keycloak Events [BETA]
+name: Keycloak Events
 slug: keycloak-events
 automation_module_uuid: 3111e77c-36b5-420a-a13d-52bc99a32f6d
 

--- a/NewRelic/newrelic-alerts/_meta/manifest.yml
+++ b/NewRelic/newrelic-alerts/_meta/manifest.yml
@@ -1,5 +1,5 @@
 uuid: 9df06db1-01f1-46ef-97e4-a269e24ff417
-name: New Relic Alerts [BETA]
+name: New Relic Alerts
 slug: newrelic-alerts
 automation_module_uuid: e44114c6-4c81-47b9-9298-3fe268b30f84
 


### PR DESCRIPTION
- remove Beta flag from new release

## Summary by Sourcery

Enhancements:
- Update display names of Azure Activity Logs, Juniper NGFW, Keycloak Events, and New Relic Alerts integrations to remove the [BETA] suffix.