### PR TITLE
fix(sekoiaio-activity-logs): do not set user.full_name for apikey profiles

### DIFF
--- a/.anonymization-exceptions.json
+++ b/.anonymization-exceptions.json
@@ -1,0 +1,6 @@
+{
+  "allowed_values": {
+    "user.domain": ["SEKOIA.IO"],
+    "url.query": ["extended=true", "auto_merge=1"]
+  }
+}

--- a/SekoiaIO/activity_log/CHANGELOG.md
+++ b/SekoiaIO/activity_log/CHANGELOG.md
@@ -6,3 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+
+- Do not populate `user.full_name` for API key profiles, since the value is the internal API key label rather than a real user name

--- a/SekoiaIO/activity_log/ingest/parser.yml
+++ b/SekoiaIO/activity_log/ingest/parser.yml
@@ -42,7 +42,6 @@ stages:
           url.path: "{{json_event.message.action.path}}"
           user.id: "{{json_event.message.identity.user_uuid}}"
           user.domain: "SEKOIA.IO"
-          user.full_name: "{{json_event.message.identity.profile_name}}"
           user_agent.original: "{{json_event.message.visit.user_agent}}"
           sekoiaio.activity.client.id: "{{json_event.message.identity.profile_identity}}"
           sekoiaio.activity.client.type: "{{json_event.message.identity.profile_type}}"
@@ -105,6 +104,9 @@ stages:
           sekoiaio.activity.user.lastname: "{{json_event.message.action.parameters.user.lastname}}"
           sekoiaio.activity.user.name: "{{json_event.message.action.parameters.user.name}}"
           sekoiaio.activity.user.uuid: "{{json_event.message.action.parameters.user.uuid}}"
+      - set:
+          user.full_name: "{{json_event.message.identity.profile_name}}"
+        filter: '{{json_event.message.identity.profile_type != "apikey"}}'
       - set:
           sekoiaio.activity.archive.short_id: "{{json_event.message.action.results.archive.short_id}}"
           sekoiaio.activity.archive_view.uuid: "{{json_event.message.action.results.archive_view.uuid}}"

--- a/SekoiaIO/activity_log/ingest/parser.yml
+++ b/SekoiaIO/activity_log/ingest/parser.yml
@@ -106,7 +106,7 @@ stages:
           sekoiaio.activity.user.uuid: "{{json_event.message.action.parameters.user.uuid}}"
       - set:
           user.full_name: "{{json_event.message.identity.profile_name}}"
-        filter: '{{json_event.message.identity.profile_type != "apikey"}}'
+        filter: '{{json_event.message.identity.get("profile_type") not in [None, "apikey"]}}'
       - set:
           sekoiaio.activity.archive.short_id: "{{json_event.message.action.results.archive.short_id}}"
           sekoiaio.activity.archive_view.uuid: "{{json_event.message.action.results.archive_view.uuid}}"

--- a/SekoiaIO/activity_log/tests/activity_log_alert_filter_creation.json
+++ b/SekoiaIO/activity_log/tests/activity_log_alert_filter_creation.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "{\"timestamp\": \"2026-01-02T09:17:44.652230Z\", \"observer\": {\"name\": \"sekoia.webapi\"}, \"visit\": {\"ip\": \"1.1.1.1\", \"user_agent\": \"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36\", \"referrer\": \"https://app.sekoia.io/rules-catalog?match%5Bname%5D=*Disabled%20Service*&indexPage=0&sizePage=100&rule-uuid=66666666-6666-6666-6666-666666666666\"}, \"action\": {\"name\": \"rule-alert-filter-creation\", \"path\": \"/v1/sic/conf/rules-catalog/multi-tenant/rules/66666666-6666-6666-6666-666666666666/alert-filters\", \"url\": \"http://api.sekoia.io/v1/sic/conf/rules-catalog/multi-tenant/rules/66666666-6666-6666-6666-666666666666/alert-filters\", \"method\": \"POST\", \"parameters\": {\"rule\": {\"definition_uuid\": \"66666666-6666-6666-6666-666666666666\", \"name\": \"Disabled Service\", \"alert_filter\": {\"uuid\": \"44444444-4444-4444-4444-444444444444\", \"name\": \"EXAMPLE - Update packages\"}}}, \"communities\": [\"66666666-6666-6666-6666-666666666666\"]}, \"identity\": {\"user_uuid\": \"66666666-6666-6666-6666-666666666666\", \"community_uuid\": \"44444444-4444-4444-4444-444444444444\", \"profile_type\": \"avatar\", \"profile_identity\": \"22222222-2222-2222-2222-222222222222\", \"profile_name\": \"J. Doe\"}}"
+    "message": "{\"timestamp\": \"2026-01-02T09:17:44.652230Z\", \"observer\": {\"name\": \"sekoia.webapi\"}, \"visit\": {\"ip\": \"1.1.1.1\", \"user_agent\": \"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36\", \"referrer\": \"https://app.example.com/rules-catalog?match%5Bname%5D=*Disabled%20Service*&indexPage=0&sizePage=100&rule-uuid=66666666-6666-6666-6666-666666666666\"}, \"action\": {\"name\": \"rule-alert-filter-creation\", \"path\": \"/v1/sic/conf/rules-catalog/multi-tenant/rules/66666666-6666-6666-6666-666666666666/alert-filters\", \"url\": \"http://api.example.com/v1/sic/conf/rules-catalog/multi-tenant/rules/66666666-6666-6666-6666-666666666666/alert-filters\", \"method\": \"POST\", \"parameters\": {\"rule\": {\"definition_uuid\": \"66666666-6666-6666-6666-666666666666\", \"name\": \"Disabled Service\", \"alert_filter\": {\"uuid\": \"44444444-4444-4444-4444-444444444444\", \"name\": \"EXAMPLE - Update packages\"}}}, \"communities\": [\"66666666-6666-6666-6666-666666666666\"]}, \"identity\": {\"user_uuid\": \"66666666-6666-6666-6666-666666666666\", \"community_uuid\": \"44444444-4444-4444-4444-444444444444\", \"profile_type\": \"avatar\", \"profile_identity\": \"22222222-2222-2222-2222-222222222222\", \"profile_name\": \"J. Doe\"}}"
   },
   "expected": {
-    "message": "{\"timestamp\": \"2026-01-02T09:17:44.652230Z\", \"observer\": {\"name\": \"sekoia.webapi\"}, \"visit\": {\"ip\": \"1.1.1.1\", \"user_agent\": \"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36\", \"referrer\": \"https://app.sekoia.io/rules-catalog?match%5Bname%5D=*Disabled%20Service*&indexPage=0&sizePage=100&rule-uuid=66666666-6666-6666-6666-666666666666\"}, \"action\": {\"name\": \"rule-alert-filter-creation\", \"path\": \"/v1/sic/conf/rules-catalog/multi-tenant/rules/66666666-6666-6666-6666-666666666666/alert-filters\", \"url\": \"http://api.sekoia.io/v1/sic/conf/rules-catalog/multi-tenant/rules/66666666-6666-6666-6666-666666666666/alert-filters\", \"method\": \"POST\", \"parameters\": {\"rule\": {\"definition_uuid\": \"66666666-6666-6666-6666-666666666666\", \"name\": \"Disabled Service\", \"alert_filter\": {\"uuid\": \"44444444-4444-4444-4444-444444444444\", \"name\": \"EXAMPLE - Update packages\"}}}, \"communities\": [\"66666666-6666-6666-6666-666666666666\"]}, \"identity\": {\"user_uuid\": \"66666666-6666-6666-6666-666666666666\", \"community_uuid\": \"44444444-4444-4444-4444-444444444444\", \"profile_type\": \"avatar\", \"profile_identity\": \"22222222-2222-2222-2222-222222222222\", \"profile_name\": \"J. Doe\"}}",
+    "message": "{\"timestamp\": \"2026-01-02T09:17:44.652230Z\", \"observer\": {\"name\": \"sekoia.webapi\"}, \"visit\": {\"ip\": \"1.1.1.1\", \"user_agent\": \"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36\", \"referrer\": \"https://app.example.com/rules-catalog?match%5Bname%5D=*Disabled%20Service*&indexPage=0&sizePage=100&rule-uuid=66666666-6666-6666-6666-666666666666\"}, \"action\": {\"name\": \"rule-alert-filter-creation\", \"path\": \"/v1/sic/conf/rules-catalog/multi-tenant/rules/66666666-6666-6666-6666-666666666666/alert-filters\", \"url\": \"http://api.example.com/v1/sic/conf/rules-catalog/multi-tenant/rules/66666666-6666-6666-6666-666666666666/alert-filters\", \"method\": \"POST\", \"parameters\": {\"rule\": {\"definition_uuid\": \"66666666-6666-6666-6666-666666666666\", \"name\": \"Disabled Service\", \"alert_filter\": {\"uuid\": \"44444444-4444-4444-4444-444444444444\", \"name\": \"EXAMPLE - Update packages\"}}}, \"communities\": [\"66666666-6666-6666-6666-666666666666\"]}, \"identity\": {\"user_uuid\": \"66666666-6666-6666-6666-666666666666\", \"community_uuid\": \"44444444-4444-4444-4444-444444444444\", \"profile_type\": \"avatar\", \"profile_identity\": \"22222222-2222-2222-2222-222222222222\", \"profile_name\": \"J. Doe\"}}",
     "event": {
       "action": "rule-alert-filter-creation"
     },
@@ -15,7 +15,7 @@
     "http": {
       "request": {
         "method": "POST",
-        "referrer": "https://app.sekoia.io/rules-catalog?match%5Bname%5D=*Disabled%20Service*&indexPage=0&sizePage=100&rule-uuid=66666666-6666-6666-6666-666666666666"
+        "referrer": "https://app.example.com/rules-catalog?match%5Bname%5D=*Disabled%20Service*&indexPage=0&sizePage=100&rule-uuid=66666666-6666-6666-6666-666666666666"
       }
     },
     "observer": {
@@ -46,15 +46,15 @@
       }
     },
     "url": {
-      "domain": "api.sekoia.io",
-      "full": "http://api.sekoia.io/v1/sic/conf/rules-catalog/multi-tenant/rules/66666666-6666-6666-6666-666666666666/alert-filters",
-      "original": "http://api.sekoia.io/v1/sic/conf/rules-catalog/multi-tenant/rules/66666666-6666-6666-6666-666666666666/alert-filters",
+      "domain": "api.example.com",
+      "full": "http://api.example.com/v1/sic/conf/rules-catalog/multi-tenant/rules/66666666-6666-6666-6666-666666666666/alert-filters",
+      "original": "http://api.example.com/v1/sic/conf/rules-catalog/multi-tenant/rules/66666666-6666-6666-6666-666666666666/alert-filters",
       "path": "/v1/sic/conf/rules-catalog/multi-tenant/rules/66666666-6666-6666-6666-666666666666/alert-filters",
       "port": 80,
-      "registered_domain": "sekoia.io",
+      "registered_domain": "example.com",
       "scheme": "http",
       "subdomain": "api",
-      "top_level_domain": "io"
+      "top_level_domain": "com"
     },
     "user": {
       "domain": "SEKOIA.IO",

--- a/SekoiaIO/activity_log/tests/activity_log_archive_creation.json
+++ b/SekoiaIO/activity_log/tests/activity_log_archive_creation.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "{\n    \"timestamp\": \"2023-05-23T16:04:17.327781\",\n    \"observer\": {\n        \"name\": \"sekoia.webapi\"\n    },\n    \"visit\": {\n        \"ip\": \"1.1.1.1\",\n        \"user_agent\": \"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36\",\n        \"referrer\": \"https://app.sekoia.io/operations/archives\"\n    },\n    \"action\": {\n        \"name\": \"archive-creation\",\n        \"path\": \"/v1/sic/conf/archives\",\n        \"url\": \"http://api.sekoia.io/v1/sic/conf/archives\",\n        \"method\": \"POST\",\n        \"parameters\": {\n            \"archive\": {\n                \"provider\": \"aws_s3\",\n                \"name\": \"Test Archive\"\n            }\n        },\n        \"results\": {\n            \"archive\": {\n                \"uuid\": \"33333333-3333-3333-3333-333333333333\",\n                \"short_id\": \"ARj5VFpxRTet\"\n            }\n        },\n        \"communities\": [\n            \"11111111-1111-1111-1111-111111111111\"\n        ]\n    },\n    \"identity\": {\n        \"user_uuid\": \"22222222-2222-2222-2222-222222222222\",\n        \"community_uuid\": \"11111111-1111-1111-1111-111111111111\",\n        \"profile_type\": \"avatar\",\n        \"profile_identity\": \"44444444-4444-4444-4444-444444444444\",\n        \"profile_name\": \"Michael S.\"\n    }\n}\n"
+    "message": "{\n    \"timestamp\": \"2023-05-23T16:04:17.327781\",\n    \"observer\": {\n        \"name\": \"sekoia.webapi\"\n    },\n    \"visit\": {\n        \"ip\": \"1.1.1.1\",\n        \"user_agent\": \"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36\",\n        \"referrer\": \"https://app.example.com/operations/archives\"\n    },\n    \"action\": {\n        \"name\": \"archive-creation\",\n        \"path\": \"/v1/sic/conf/archives\",\n        \"url\": \"http://api.example.com/v1/sic/conf/archives\",\n        \"method\": \"POST\",\n        \"parameters\": {\n            \"archive\": {\n                \"provider\": \"aws_s3\",\n                \"name\": \"Test Archive\"\n            }\n        },\n        \"results\": {\n            \"archive\": {\n                \"uuid\": \"33333333-3333-3333-3333-333333333333\",\n                \"short_id\": \"ARj5VFpxRTet\"\n            }\n        },\n        \"communities\": [\n            \"11111111-1111-1111-1111-111111111111\"\n        ]\n    },\n    \"identity\": {\n        \"user_uuid\": \"22222222-2222-2222-2222-222222222222\",\n        \"community_uuid\": \"11111111-1111-1111-1111-111111111111\",\n        \"profile_type\": \"avatar\",\n        \"profile_identity\": \"44444444-4444-4444-4444-444444444444\",\n        \"profile_name\": \"Michael S.\"\n    }\n}\n"
   },
   "expected": {
-    "message": "{\n    \"timestamp\": \"2023-05-23T16:04:17.327781\",\n    \"observer\": {\n        \"name\": \"sekoia.webapi\"\n    },\n    \"visit\": {\n        \"ip\": \"1.1.1.1\",\n        \"user_agent\": \"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36\",\n        \"referrer\": \"https://app.sekoia.io/operations/archives\"\n    },\n    \"action\": {\n        \"name\": \"archive-creation\",\n        \"path\": \"/v1/sic/conf/archives\",\n        \"url\": \"http://api.sekoia.io/v1/sic/conf/archives\",\n        \"method\": \"POST\",\n        \"parameters\": {\n            \"archive\": {\n                \"provider\": \"aws_s3\",\n                \"name\": \"Test Archive\"\n            }\n        },\n        \"results\": {\n            \"archive\": {\n                \"uuid\": \"33333333-3333-3333-3333-333333333333\",\n                \"short_id\": \"ARj5VFpxRTet\"\n            }\n        },\n        \"communities\": [\n            \"11111111-1111-1111-1111-111111111111\"\n        ]\n    },\n    \"identity\": {\n        \"user_uuid\": \"22222222-2222-2222-2222-222222222222\",\n        \"community_uuid\": \"11111111-1111-1111-1111-111111111111\",\n        \"profile_type\": \"avatar\",\n        \"profile_identity\": \"44444444-4444-4444-4444-444444444444\",\n        \"profile_name\": \"Michael S.\"\n    }\n}\n",
+    "message": "{\n    \"timestamp\": \"2023-05-23T16:04:17.327781\",\n    \"observer\": {\n        \"name\": \"sekoia.webapi\"\n    },\n    \"visit\": {\n        \"ip\": \"1.1.1.1\",\n        \"user_agent\": \"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36\",\n        \"referrer\": \"https://app.example.com/operations/archives\"\n    },\n    \"action\": {\n        \"name\": \"archive-creation\",\n        \"path\": \"/v1/sic/conf/archives\",\n        \"url\": \"http://api.example.com/v1/sic/conf/archives\",\n        \"method\": \"POST\",\n        \"parameters\": {\n            \"archive\": {\n                \"provider\": \"aws_s3\",\n                \"name\": \"Test Archive\"\n            }\n        },\n        \"results\": {\n            \"archive\": {\n                \"uuid\": \"33333333-3333-3333-3333-333333333333\",\n                \"short_id\": \"ARj5VFpxRTet\"\n            }\n        },\n        \"communities\": [\n            \"11111111-1111-1111-1111-111111111111\"\n        ]\n    },\n    \"identity\": {\n        \"user_uuid\": \"22222222-2222-2222-2222-222222222222\",\n        \"community_uuid\": \"11111111-1111-1111-1111-111111111111\",\n        \"profile_type\": \"avatar\",\n        \"profile_identity\": \"44444444-4444-4444-4444-444444444444\",\n        \"profile_name\": \"Michael S.\"\n    }\n}\n",
     "event": {
       "action": "archive-creation"
     },
@@ -15,7 +15,7 @@
     "http": {
       "request": {
         "method": "POST",
-        "referrer": "https://app.sekoia.io/operations/archives"
+        "referrer": "https://app.example.com/operations/archives"
       }
     },
     "observer": {
@@ -44,15 +44,15 @@
       }
     },
     "url": {
-      "domain": "api.sekoia.io",
-      "full": "http://api.sekoia.io/v1/sic/conf/archives",
-      "original": "http://api.sekoia.io/v1/sic/conf/archives",
+      "domain": "api.example.com",
+      "full": "http://api.example.com/v1/sic/conf/archives",
+      "original": "http://api.example.com/v1/sic/conf/archives",
       "path": "/v1/sic/conf/archives",
       "port": 80,
-      "registered_domain": "sekoia.io",
+      "registered_domain": "example.com",
       "scheme": "http",
       "subdomain": "api",
-      "top_level_domain": "io"
+      "top_level_domain": "com"
     },
     "user": {
       "domain": "SEKOIA.IO",

--- a/SekoiaIO/activity_log/tests/activity_log_asset_connector_apikey.json
+++ b/SekoiaIO/activity_log/tests/activity_log_asset_connector_apikey.json
@@ -1,0 +1,58 @@
+{
+  "input": {
+    "message": "{\"timestamp\":\"2026-06-03T23:28:51.372515Z\",\"observer\":{\"name\":\"Asset API\"},\"visit\":{\"ip\":\"1.1.1.1\",\"user_agent\":\"sekoiaio-asset-connector-33333333-3333-3333-3333-333333333333\",\"referrer\":\"\"},\"action\":{\"path\":\"/v2/asset-management/asset-connector/33333333-3333-3333-3333-333333333333\",\"url\":\"http://api.test.sekoia.io/v2/asset-management/asset-connector/33333333-3333-3333-3333-333333333333\",\"method\":\"POST\"},\"identity\":{\"community_uuid\":\"11111111-1111-1111-1111-111111111111\",\"profile_type\":\"apikey\",\"profile_identity\":\"22222222-2222-2222-2222-222222222222\",\"profile_name\":\"[11111111-1111-1111-1111-111111111111] internal API key for 33333333-3333-3333-3333-333333333333\"}}"
+  },
+  "expected": {
+    "message": "{\"timestamp\":\"2026-06-03T23:28:51.372515Z\",\"observer\":{\"name\":\"Asset API\"},\"visit\":{\"ip\":\"1.1.1.1\",\"user_agent\":\"sekoiaio-asset-connector-33333333-3333-3333-3333-333333333333\",\"referrer\":\"\"},\"action\":{\"path\":\"/v2/asset-management/asset-connector/33333333-3333-3333-3333-333333333333\",\"url\":\"http://api.test.sekoia.io/v2/asset-management/asset-connector/33333333-3333-3333-3333-333333333333\",\"method\":\"POST\"},\"identity\":{\"community_uuid\":\"11111111-1111-1111-1111-111111111111\",\"profile_type\":\"apikey\",\"profile_identity\":\"22222222-2222-2222-2222-222222222222\",\"profile_name\":\"[11111111-1111-1111-1111-111111111111] internal API key for 33333333-3333-3333-3333-333333333333\"}}",
+    "@timestamp": "2026-06-03T23:28:51.372515Z",
+    "client": {
+      "address": "1.1.1.1",
+      "ip": "1.1.1.1"
+    },
+    "http": {
+      "request": {
+        "method": "POST"
+      }
+    },
+    "observer": {
+      "name": "Asset API"
+    },
+    "related": {
+      "ip": [
+        "1.1.1.1"
+      ]
+    },
+    "sekoiaio": {
+      "activity": {
+        "client": {
+          "id": "22222222-2222-2222-2222-222222222222",
+          "type": "apikey"
+        }
+      }
+    },
+    "url": {
+      "domain": "api.test.sekoia.io",
+      "full": "http://api.test.sekoia.io/v2/asset-management/asset-connector/33333333-3333-3333-3333-333333333333",
+      "original": "http://api.test.sekoia.io/v2/asset-management/asset-connector/33333333-3333-3333-3333-333333333333",
+      "path": "/v2/asset-management/asset-connector/33333333-3333-3333-3333-333333333333",
+      "port": 80,
+      "registered_domain": "sekoia.io",
+      "scheme": "http",
+      "subdomain": "api.test",
+      "top_level_domain": "io"
+    },
+    "user": {
+      "domain": "SEKOIA.IO"
+    },
+    "user_agent": {
+      "device": {
+        "name": "Other"
+      },
+      "name": "Other",
+      "original": "sekoiaio-asset-connector-33333333-3333-3333-3333-333333333333",
+      "os": {
+        "name": "Other"
+      }
+    }
+  }
+}

--- a/SekoiaIO/activity_log/tests/activity_log_asset_connector_apikey.json
+++ b/SekoiaIO/activity_log/tests/activity_log_asset_connector_apikey.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "{\"timestamp\":\"2026-06-03T23:28:51.372515Z\",\"observer\":{\"name\":\"Asset API\"},\"visit\":{\"ip\":\"1.1.1.1\",\"user_agent\":\"sekoiaio-asset-connector-33333333-3333-3333-3333-333333333333\",\"referrer\":\"\"},\"action\":{\"path\":\"/v2/asset-management/asset-connector/33333333-3333-3333-3333-333333333333\",\"url\":\"http://api.test.sekoia.io/v2/asset-management/asset-connector/33333333-3333-3333-3333-333333333333\",\"method\":\"POST\"},\"identity\":{\"community_uuid\":\"11111111-1111-1111-1111-111111111111\",\"profile_type\":\"apikey\",\"profile_identity\":\"22222222-2222-2222-2222-222222222222\",\"profile_name\":\"[11111111-1111-1111-1111-111111111111] internal API key for 33333333-3333-3333-3333-333333333333\"}}"
+    "message": "{\"timestamp\":\"2026-06-03T23:28:51.372515Z\",\"observer\":{\"name\":\"Asset API\"},\"visit\":{\"ip\":\"1.1.1.1\",\"user_agent\":\"sekoiaio-asset-connector-33333333-3333-3333-3333-333333333333\",\"referrer\":\"\"},\"action\":{\"path\":\"/v2/asset-management/asset-connector/33333333-3333-3333-3333-333333333333\",\"url\":\"http://api.test.example.com/v2/asset-management/asset-connector/33333333-3333-3333-3333-333333333333\",\"method\":\"POST\"},\"identity\":{\"community_uuid\":\"11111111-1111-1111-1111-111111111111\",\"profile_type\":\"apikey\",\"profile_identity\":\"22222222-2222-2222-2222-222222222222\",\"profile_name\":\"[11111111-1111-1111-1111-111111111111] internal API key for 33333333-3333-3333-3333-333333333333\"}}"
   },
   "expected": {
-    "message": "{\"timestamp\":\"2026-06-03T23:28:51.372515Z\",\"observer\":{\"name\":\"Asset API\"},\"visit\":{\"ip\":\"1.1.1.1\",\"user_agent\":\"sekoiaio-asset-connector-33333333-3333-3333-3333-333333333333\",\"referrer\":\"\"},\"action\":{\"path\":\"/v2/asset-management/asset-connector/33333333-3333-3333-3333-333333333333\",\"url\":\"http://api.test.sekoia.io/v2/asset-management/asset-connector/33333333-3333-3333-3333-333333333333\",\"method\":\"POST\"},\"identity\":{\"community_uuid\":\"11111111-1111-1111-1111-111111111111\",\"profile_type\":\"apikey\",\"profile_identity\":\"22222222-2222-2222-2222-222222222222\",\"profile_name\":\"[11111111-1111-1111-1111-111111111111] internal API key for 33333333-3333-3333-3333-333333333333\"}}",
+    "message": "{\"timestamp\":\"2026-06-03T23:28:51.372515Z\",\"observer\":{\"name\":\"Asset API\"},\"visit\":{\"ip\":\"1.1.1.1\",\"user_agent\":\"sekoiaio-asset-connector-33333333-3333-3333-3333-333333333333\",\"referrer\":\"\"},\"action\":{\"path\":\"/v2/asset-management/asset-connector/33333333-3333-3333-3333-333333333333\",\"url\":\"http://api.test.example.com/v2/asset-management/asset-connector/33333333-3333-3333-3333-333333333333\",\"method\":\"POST\"},\"identity\":{\"community_uuid\":\"11111111-1111-1111-1111-111111111111\",\"profile_type\":\"apikey\",\"profile_identity\":\"22222222-2222-2222-2222-222222222222\",\"profile_name\":\"[11111111-1111-1111-1111-111111111111] internal API key for 33333333-3333-3333-3333-333333333333\"}}",
     "@timestamp": "2026-06-03T23:28:51.372515Z",
     "client": {
       "address": "1.1.1.1",
@@ -31,15 +31,15 @@
       }
     },
     "url": {
-      "domain": "api.test.sekoia.io",
-      "full": "http://api.test.sekoia.io/v2/asset-management/asset-connector/33333333-3333-3333-3333-333333333333",
-      "original": "http://api.test.sekoia.io/v2/asset-management/asset-connector/33333333-3333-3333-3333-333333333333",
+      "domain": "api.test.example.com",
+      "full": "http://api.test.example.com/v2/asset-management/asset-connector/33333333-3333-3333-3333-333333333333",
+      "original": "http://api.test.example.com/v2/asset-management/asset-connector/33333333-3333-3333-3333-333333333333",
       "path": "/v2/asset-management/asset-connector/33333333-3333-3333-3333-333333333333",
       "port": 80,
-      "registered_domain": "sekoia.io",
+      "registered_domain": "example.com",
       "scheme": "http",
       "subdomain": "api.test",
-      "top_level_domain": "io"
+      "top_level_domain": "com"
     },
     "user": {
       "domain": "SEKOIA.IO"

--- a/SekoiaIO/activity_log/tests/activity_log_event_search.json
+++ b/SekoiaIO/activity_log/tests/activity_log_event_search.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "{\"timestamp\":\"2022-11-22T16:03:33.617764\",\"observer\":{\"name\":\"sekoia.webapi\"},\"visit\":{\"ip\":\"1.1.1.1\",\"user_agent\":\"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36\",\"referrer\":\"https://app.sekoia.io/operations/events?jobId=55555555-5555-5555-5555-555555555555\"},\"action\":{\"name\":\"event-searchjob-start\",\"path\":\"/v1/sic/conf/events/search/jobs\",\"url\":\"http://api.sekoia.io/v1/sic/conf/events/search/jobs\",\"method\":\"POST\",\"parameters\":{\"events_search\":{\"earliest_time\":\"2022-11-22T15:58:33.027Z\",\"latest_time\":\"2022-11-22T16:03:33.027Z\",\"results_ttl\":1800,\"filters_json\":\"[{\\\"field\\\":\\\"http.request.method\\\",\\\"value\\\":\\\"GET\\\",\\\"operator\\\":\\\"=\\\",\\\"excluded\\\":true,\\\"disabled\\\":false}]\"},\"archive_view\":{\"uuid\":null}},\"results\":{\"events_search\":{\"uuid\":\"44444444-4444-4444-4444-444444444444\"}},\"communities\":[\"11111111-1111-1111-1111-111111111111\",\"33333333-3333-3333-3333-333333333333\",\"22222222-2222-2222-2222-222222222222\",\"88888888-8888-8888-8888-888888888888\",\"66666666-6666-6666-6666-666666666666\",\"77777777-7777-7777-7777-777777777777\"]},\"identity\":{\"user_uuid\":\"99999999-9999-9999-9999-999999999999\",\"community_uuid\":\"11111111-1111-1111-1111-111111111111\",\"profile_type\":\"avatar\",\"profile_identity\":\"11111111-1111-1111-1111-222222222222\",\"profile_name\":\"Michael S.\"}}"
+    "message": "{\"timestamp\":\"2022-11-22T16:03:33.617764\",\"observer\":{\"name\":\"sekoia.webapi\"},\"visit\":{\"ip\":\"1.1.1.1\",\"user_agent\":\"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36\",\"referrer\":\"https://app.example.com/operations/events?jobId=55555555-5555-5555-5555-555555555555\"},\"action\":{\"name\":\"event-searchjob-start\",\"path\":\"/v1/sic/conf/events/search/jobs\",\"url\":\"http://api.example.com/v1/sic/conf/events/search/jobs\",\"method\":\"POST\",\"parameters\":{\"events_search\":{\"earliest_time\":\"2022-11-22T15:58:33.027Z\",\"latest_time\":\"2022-11-22T16:03:33.027Z\",\"results_ttl\":1800,\"filters_json\":\"[{\\\"field\\\":\\\"http.request.method\\\",\\\"value\\\":\\\"GET\\\",\\\"operator\\\":\\\"=\\\",\\\"excluded\\\":true,\\\"disabled\\\":false}]\"},\"archive_view\":{\"uuid\":null}},\"results\":{\"events_search\":{\"uuid\":\"44444444-4444-4444-4444-444444444444\"}},\"communities\":[\"11111111-1111-1111-1111-111111111111\",\"33333333-3333-3333-3333-333333333333\",\"22222222-2222-2222-2222-222222222222\",\"88888888-8888-8888-8888-888888888888\",\"66666666-6666-6666-6666-666666666666\",\"77777777-7777-7777-7777-777777777777\"]},\"identity\":{\"user_uuid\":\"99999999-9999-9999-9999-999999999999\",\"community_uuid\":\"11111111-1111-1111-1111-111111111111\",\"profile_type\":\"avatar\",\"profile_identity\":\"11111111-1111-1111-1111-222222222222\",\"profile_name\":\"Michael S.\"}}"
   },
   "expected": {
-    "message": "{\"timestamp\":\"2022-11-22T16:03:33.617764\",\"observer\":{\"name\":\"sekoia.webapi\"},\"visit\":{\"ip\":\"1.1.1.1\",\"user_agent\":\"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36\",\"referrer\":\"https://app.sekoia.io/operations/events?jobId=55555555-5555-5555-5555-555555555555\"},\"action\":{\"name\":\"event-searchjob-start\",\"path\":\"/v1/sic/conf/events/search/jobs\",\"url\":\"http://api.sekoia.io/v1/sic/conf/events/search/jobs\",\"method\":\"POST\",\"parameters\":{\"events_search\":{\"earliest_time\":\"2022-11-22T15:58:33.027Z\",\"latest_time\":\"2022-11-22T16:03:33.027Z\",\"results_ttl\":1800,\"filters_json\":\"[{\\\"field\\\":\\\"http.request.method\\\",\\\"value\\\":\\\"GET\\\",\\\"operator\\\":\\\"=\\\",\\\"excluded\\\":true,\\\"disabled\\\":false}]\"},\"archive_view\":{\"uuid\":null}},\"results\":{\"events_search\":{\"uuid\":\"44444444-4444-4444-4444-444444444444\"}},\"communities\":[\"11111111-1111-1111-1111-111111111111\",\"33333333-3333-3333-3333-333333333333\",\"22222222-2222-2222-2222-222222222222\",\"88888888-8888-8888-8888-888888888888\",\"66666666-6666-6666-6666-666666666666\",\"77777777-7777-7777-7777-777777777777\"]},\"identity\":{\"user_uuid\":\"99999999-9999-9999-9999-999999999999\",\"community_uuid\":\"11111111-1111-1111-1111-111111111111\",\"profile_type\":\"avatar\",\"profile_identity\":\"11111111-1111-1111-1111-222222222222\",\"profile_name\":\"Michael S.\"}}",
+    "message": "{\"timestamp\":\"2022-11-22T16:03:33.617764\",\"observer\":{\"name\":\"sekoia.webapi\"},\"visit\":{\"ip\":\"1.1.1.1\",\"user_agent\":\"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36\",\"referrer\":\"https://app.example.com/operations/events?jobId=55555555-5555-5555-5555-555555555555\"},\"action\":{\"name\":\"event-searchjob-start\",\"path\":\"/v1/sic/conf/events/search/jobs\",\"url\":\"http://api.example.com/v1/sic/conf/events/search/jobs\",\"method\":\"POST\",\"parameters\":{\"events_search\":{\"earliest_time\":\"2022-11-22T15:58:33.027Z\",\"latest_time\":\"2022-11-22T16:03:33.027Z\",\"results_ttl\":1800,\"filters_json\":\"[{\\\"field\\\":\\\"http.request.method\\\",\\\"value\\\":\\\"GET\\\",\\\"operator\\\":\\\"=\\\",\\\"excluded\\\":true,\\\"disabled\\\":false}]\"},\"archive_view\":{\"uuid\":null}},\"results\":{\"events_search\":{\"uuid\":\"44444444-4444-4444-4444-444444444444\"}},\"communities\":[\"11111111-1111-1111-1111-111111111111\",\"33333333-3333-3333-3333-333333333333\",\"22222222-2222-2222-2222-222222222222\",\"88888888-8888-8888-8888-888888888888\",\"66666666-6666-6666-6666-666666666666\",\"77777777-7777-7777-7777-777777777777\"]},\"identity\":{\"user_uuid\":\"99999999-9999-9999-9999-999999999999\",\"community_uuid\":\"11111111-1111-1111-1111-111111111111\",\"profile_type\":\"avatar\",\"profile_identity\":\"11111111-1111-1111-1111-222222222222\",\"profile_name\":\"Michael S.\"}}",
     "event": {
       "action": "event-searchjob-start"
     },
@@ -15,7 +15,7 @@
     "http": {
       "request": {
         "method": "POST",
-        "referrer": "https://app.sekoia.io/operations/events?jobId=55555555-5555-5555-5555-555555555555"
+        "referrer": "https://app.example.com/operations/events?jobId=55555555-5555-5555-5555-555555555555"
       }
     },
     "observer": {
@@ -49,15 +49,15 @@
       }
     },
     "url": {
-      "domain": "api.sekoia.io",
-      "full": "http://api.sekoia.io/v1/sic/conf/events/search/jobs",
-      "original": "http://api.sekoia.io/v1/sic/conf/events/search/jobs",
+      "domain": "api.example.com",
+      "full": "http://api.example.com/v1/sic/conf/events/search/jobs",
+      "original": "http://api.example.com/v1/sic/conf/events/search/jobs",
       "path": "/v1/sic/conf/events/search/jobs",
       "port": 80,
-      "registered_domain": "sekoia.io",
+      "registered_domain": "example.com",
       "scheme": "http",
       "subdomain": "api",
-      "top_level_domain": "io"
+      "top_level_domain": "com"
     },
     "user": {
       "domain": "SEKOIA.IO",

--- a/SekoiaIO/activity_log/tests/activity_log_get_intake_format_picture.json
+++ b/SekoiaIO/activity_log/tests/activity_log_get_intake_format_picture.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "{\"timestamp\":\"2022-02-22T16:31:58.286485\",\"observer\":{\"name\":\"sekoia.webapi\",\"version\":null},\"visit\":{\"id\":null,\"ip\":\"1.1.1.1\",\"user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36\",\"referrer\":\"https://app.test.sekoia.io/operations/intakes/new\"},\"action\":{\"name\":\"intake-format-picture-retrieval\",\"path\":\"/v1/ingest/formats/11111111-1111-1111-1111-111111111111/picture\",\"url\":\"http://api.sekoia.io/v1/ingest/formats/11111111-1111-1111-1111-111111111111/picture\",\"method\":\"GET\"},\"identity\":{\"user_uuid\":\"33333333-3333-3333-3333-333333333333\",\"community_uuid\":\"22222222-2222-2222-2222-222222222222\",\"profile_type\":\"avatar\",\"profile_identity\":\"44444444-4444-4444-4444-444444444444\"}}"
+    "message": "{\"timestamp\":\"2022-02-22T16:31:58.286485\",\"observer\":{\"name\":\"sekoia.webapi\",\"version\":null},\"visit\":{\"id\":null,\"ip\":\"1.1.1.1\",\"user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36\",\"referrer\":\"https://app.test.example.com/operations/intakes/new\"},\"action\":{\"name\":\"intake-format-picture-retrieval\",\"path\":\"/v1/ingest/formats/11111111-1111-1111-1111-111111111111/picture\",\"url\":\"http://api.example.com/v1/ingest/formats/11111111-1111-1111-1111-111111111111/picture\",\"method\":\"GET\"},\"identity\":{\"user_uuid\":\"33333333-3333-3333-3333-333333333333\",\"community_uuid\":\"22222222-2222-2222-2222-222222222222\",\"profile_type\":\"avatar\",\"profile_identity\":\"44444444-4444-4444-4444-444444444444\"}}"
   },
   "expected": {
-    "message": "{\"timestamp\":\"2022-02-22T16:31:58.286485\",\"observer\":{\"name\":\"sekoia.webapi\",\"version\":null},\"visit\":{\"id\":null,\"ip\":\"1.1.1.1\",\"user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36\",\"referrer\":\"https://app.test.sekoia.io/operations/intakes/new\"},\"action\":{\"name\":\"intake-format-picture-retrieval\",\"path\":\"/v1/ingest/formats/11111111-1111-1111-1111-111111111111/picture\",\"url\":\"http://api.sekoia.io/v1/ingest/formats/11111111-1111-1111-1111-111111111111/picture\",\"method\":\"GET\"},\"identity\":{\"user_uuid\":\"33333333-3333-3333-3333-333333333333\",\"community_uuid\":\"22222222-2222-2222-2222-222222222222\",\"profile_type\":\"avatar\",\"profile_identity\":\"44444444-4444-4444-4444-444444444444\"}}",
+    "message": "{\"timestamp\":\"2022-02-22T16:31:58.286485\",\"observer\":{\"name\":\"sekoia.webapi\",\"version\":null},\"visit\":{\"id\":null,\"ip\":\"1.1.1.1\",\"user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36\",\"referrer\":\"https://app.test.example.com/operations/intakes/new\"},\"action\":{\"name\":\"intake-format-picture-retrieval\",\"path\":\"/v1/ingest/formats/11111111-1111-1111-1111-111111111111/picture\",\"url\":\"http://api.example.com/v1/ingest/formats/11111111-1111-1111-1111-111111111111/picture\",\"method\":\"GET\"},\"identity\":{\"user_uuid\":\"33333333-3333-3333-3333-333333333333\",\"community_uuid\":\"22222222-2222-2222-2222-222222222222\",\"profile_type\":\"avatar\",\"profile_identity\":\"44444444-4444-4444-4444-444444444444\"}}",
     "event": {
       "action": "intake-format-picture-retrieval"
     },
@@ -15,7 +15,7 @@
     "http": {
       "request": {
         "method": "GET",
-        "referrer": "https://app.test.sekoia.io/operations/intakes/new"
+        "referrer": "https://app.test.example.com/operations/intakes/new"
       }
     },
     "observer": {
@@ -35,15 +35,15 @@
       }
     },
     "url": {
-      "domain": "api.sekoia.io",
-      "full": "http://api.sekoia.io/v1/ingest/formats/11111111-1111-1111-1111-111111111111/picture",
-      "original": "http://api.sekoia.io/v1/ingest/formats/11111111-1111-1111-1111-111111111111/picture",
+      "domain": "api.example.com",
+      "full": "http://api.example.com/v1/ingest/formats/11111111-1111-1111-1111-111111111111/picture",
+      "original": "http://api.example.com/v1/ingest/formats/11111111-1111-1111-1111-111111111111/picture",
       "path": "/v1/ingest/formats/11111111-1111-1111-1111-111111111111/picture",
       "port": 80,
-      "registered_domain": "sekoia.io",
+      "registered_domain": "example.com",
       "scheme": "http",
       "subdomain": "api",
-      "top_level_domain": "io"
+      "top_level_domain": "com"
     },
     "user": {
       "domain": "SEKOIA.IO",

--- a/SekoiaIO/activity_log/tests/activity_log_get_me_extended.json
+++ b/SekoiaIO/activity_log/tests/activity_log_get_me_extended.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "{\"timestamp\":\"2021-10-29T11:34:23Z\",\"observer\":{\"name\":\"sekoia.webapi\",\"version\":null},\"visit\":{\"id\":null,\"ip\":\"1.1.1.1\",\"user_agent\":\"'Mozilla/5.0 (X11; Linux i686; rv:1.9.7.20) Gecko/2020-08-24 06:07:18 Firefox/3.8\",\"referrer\":\"https://api.sekoia.io/v1/user/profile/settings\"},\"action\":{\"name\":null,\"path\":\"/v1/me\",\"url\":\"http://api.sekoia.io/v1/me?extended=true\",\"method\":\"GET\"},\"identity\":{\"user_uuid\":\"22222222-2222-2222-2222-222222222222\",\"community_uuid\":\"33333333-3333-3333-3333-333333333333\",\"profile_type\":\"avatar\",\"profile_identity\":\"11111111-1111-1111-1111-111111111111\"}}"
+    "message": "{\"timestamp\":\"2021-10-29T11:34:23Z\",\"observer\":{\"name\":\"sekoia.webapi\",\"version\":null},\"visit\":{\"id\":null,\"ip\":\"1.1.1.1\",\"user_agent\":\"'Mozilla/5.0 (X11; Linux i686; rv:1.9.7.20) Gecko/2020-08-24 06:07:18 Firefox/3.8\",\"referrer\":\"https://api.example.com/v1/user/profile/settings\"},\"action\":{\"name\":null,\"path\":\"/v1/me\",\"url\":\"http://api.example.com/v1/me?extended=true\",\"method\":\"GET\"},\"identity\":{\"user_uuid\":\"22222222-2222-2222-2222-222222222222\",\"community_uuid\":\"33333333-3333-3333-3333-333333333333\",\"profile_type\":\"avatar\",\"profile_identity\":\"11111111-1111-1111-1111-111111111111\"}}"
   },
   "expected": {
-    "message": "{\"timestamp\":\"2021-10-29T11:34:23Z\",\"observer\":{\"name\":\"sekoia.webapi\",\"version\":null},\"visit\":{\"id\":null,\"ip\":\"1.1.1.1\",\"user_agent\":\"'Mozilla/5.0 (X11; Linux i686; rv:1.9.7.20) Gecko/2020-08-24 06:07:18 Firefox/3.8\",\"referrer\":\"https://api.sekoia.io/v1/user/profile/settings\"},\"action\":{\"name\":null,\"path\":\"/v1/me\",\"url\":\"http://api.sekoia.io/v1/me?extended=true\",\"method\":\"GET\"},\"identity\":{\"user_uuid\":\"22222222-2222-2222-2222-222222222222\",\"community_uuid\":\"33333333-3333-3333-3333-333333333333\",\"profile_type\":\"avatar\",\"profile_identity\":\"11111111-1111-1111-1111-111111111111\"}}",
+    "message": "{\"timestamp\":\"2021-10-29T11:34:23Z\",\"observer\":{\"name\":\"sekoia.webapi\",\"version\":null},\"visit\":{\"id\":null,\"ip\":\"1.1.1.1\",\"user_agent\":\"'Mozilla/5.0 (X11; Linux i686; rv:1.9.7.20) Gecko/2020-08-24 06:07:18 Firefox/3.8\",\"referrer\":\"https://api.example.com/v1/user/profile/settings\"},\"action\":{\"name\":null,\"path\":\"/v1/me\",\"url\":\"http://api.example.com/v1/me?extended=true\",\"method\":\"GET\"},\"identity\":{\"user_uuid\":\"22222222-2222-2222-2222-222222222222\",\"community_uuid\":\"33333333-3333-3333-3333-333333333333\",\"profile_type\":\"avatar\",\"profile_identity\":\"11111111-1111-1111-1111-111111111111\"}}",
     "@timestamp": "2021-10-29T11:34:23Z",
     "client": {
       "address": "1.1.1.1",
@@ -12,7 +12,7 @@
     "http": {
       "request": {
         "method": "GET",
-        "referrer": "https://api.sekoia.io/v1/user/profile/settings"
+        "referrer": "https://api.example.com/v1/user/profile/settings"
       }
     },
     "observer": {
@@ -32,16 +32,16 @@
       }
     },
     "url": {
-      "domain": "api.sekoia.io",
-      "full": "http://api.sekoia.io/v1/me?extended=true",
-      "original": "http://api.sekoia.io/v1/me?extended=true",
+      "domain": "api.example.com",
+      "full": "http://api.example.com/v1/me?extended=true",
+      "original": "http://api.example.com/v1/me?extended=true",
       "path": "/v1/me",
       "port": 80,
       "query": "extended=true",
-      "registered_domain": "sekoia.io",
+      "registered_domain": "example.com",
       "scheme": "http",
       "subdomain": "api",
-      "top_level_domain": "io"
+      "top_level_domain": "com"
     },
     "user": {
       "domain": "SEKOIA.IO",

--- a/SekoiaIO/activity_log/tests/activity_log_invitations_new.json
+++ b/SekoiaIO/activity_log/tests/activity_log_invitations_new.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "{\"timestamp\": \"2026-01-20T16:25:33.174256Z\", \"observer\": {\"name\": \"sekoia.webapi\"}, \"visit\": {\"ip\": \"1.1.1.1\", \"user_agent\": \"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0\", \"referrer\": \"https://app.sekoia.io/profile/communities/33333333-3333-3333-3333-333333333333/members\"}, \"action\": {\"name\": \"invitation\", \"path\": \"/v1/invitations\", \"url\": \"http://api.sekoia.io/v1/invitations\", \"method\": \"POST\", \"parameters\": {\"emails\": [\"john.doe@example.com\"]}, \"communities\": [\"22222222-2222-2222-2222-222222222222\"]}, \"identity\": {\"user_uuid\": \"11111111-1111-1111-1111-111111111111\", \"community_uuid\": \"33333333-3333-3333-3333-333333333333\", \"profile_type\": \"avatar\", \"profile_identity\": \"44444444-4444-4444-4444-444444444444\", \"profile_name\": \"John DOE\"}}"
+    "message": "{\"timestamp\": \"2026-01-20T16:25:33.174256Z\", \"observer\": {\"name\": \"sekoia.webapi\"}, \"visit\": {\"ip\": \"1.1.1.1\", \"user_agent\": \"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0\", \"referrer\": \"https://app.example.com/profile/communities/33333333-3333-3333-3333-333333333333/members\"}, \"action\": {\"name\": \"invitation\", \"path\": \"/v1/invitations\", \"url\": \"http://api.example.com/v1/invitations\", \"method\": \"POST\", \"parameters\": {\"emails\": [\"john.doe@example.com\"]}, \"communities\": [\"22222222-2222-2222-2222-222222222222\"]}, \"identity\": {\"user_uuid\": \"11111111-1111-1111-1111-111111111111\", \"community_uuid\": \"33333333-3333-3333-3333-333333333333\", \"profile_type\": \"avatar\", \"profile_identity\": \"44444444-4444-4444-4444-444444444444\", \"profile_name\": \"John DOE\"}}"
   },
   "expected": {
-    "message": "{\"timestamp\": \"2026-01-20T16:25:33.174256Z\", \"observer\": {\"name\": \"sekoia.webapi\"}, \"visit\": {\"ip\": \"1.1.1.1\", \"user_agent\": \"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0\", \"referrer\": \"https://app.sekoia.io/profile/communities/33333333-3333-3333-3333-333333333333/members\"}, \"action\": {\"name\": \"invitation\", \"path\": \"/v1/invitations\", \"url\": \"http://api.sekoia.io/v1/invitations\", \"method\": \"POST\", \"parameters\": {\"emails\": [\"john.doe@example.com\"]}, \"communities\": [\"22222222-2222-2222-2222-222222222222\"]}, \"identity\": {\"user_uuid\": \"11111111-1111-1111-1111-111111111111\", \"community_uuid\": \"33333333-3333-3333-3333-333333333333\", \"profile_type\": \"avatar\", \"profile_identity\": \"44444444-4444-4444-4444-444444444444\", \"profile_name\": \"John DOE\"}}",
+    "message": "{\"timestamp\": \"2026-01-20T16:25:33.174256Z\", \"observer\": {\"name\": \"sekoia.webapi\"}, \"visit\": {\"ip\": \"1.1.1.1\", \"user_agent\": \"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0\", \"referrer\": \"https://app.example.com/profile/communities/33333333-3333-3333-3333-333333333333/members\"}, \"action\": {\"name\": \"invitation\", \"path\": \"/v1/invitations\", \"url\": \"http://api.example.com/v1/invitations\", \"method\": \"POST\", \"parameters\": {\"emails\": [\"john.doe@example.com\"]}, \"communities\": [\"22222222-2222-2222-2222-222222222222\"]}, \"identity\": {\"user_uuid\": \"11111111-1111-1111-1111-111111111111\", \"community_uuid\": \"33333333-3333-3333-3333-333333333333\", \"profile_type\": \"avatar\", \"profile_identity\": \"44444444-4444-4444-4444-444444444444\", \"profile_name\": \"John DOE\"}}",
     "event": {
       "action": "invitation"
     },
@@ -22,7 +22,7 @@
     "http": {
       "request": {
         "method": "POST",
-        "referrer": "https://app.sekoia.io/profile/communities/33333333-3333-3333-3333-333333333333/members"
+        "referrer": "https://app.example.com/profile/communities/33333333-3333-3333-3333-333333333333/members"
       }
     },
     "observer": {
@@ -50,15 +50,15 @@
       }
     },
     "url": {
-      "domain": "api.sekoia.io",
-      "full": "http://api.sekoia.io/v1/invitations",
-      "original": "http://api.sekoia.io/v1/invitations",
+      "domain": "api.example.com",
+      "full": "http://api.example.com/v1/invitations",
+      "original": "http://api.example.com/v1/invitations",
       "path": "/v1/invitations",
       "port": 80,
-      "registered_domain": "sekoia.io",
+      "registered_domain": "example.com",
       "scheme": "http",
       "subdomain": "api",
-      "top_level_domain": "io"
+      "top_level_domain": "com"
     },
     "user": {
       "domain": "SEKOIA.IO",

--- a/SekoiaIO/activity_log/tests/activity_log_post_bundle.json
+++ b/SekoiaIO/activity_log/tests/activity_log_post_bundle.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "{\"timestamp\":\"2021-11-01T12:16:21.815546\",\"observer\":{\"name\":\"sekoia.webapi\",\"version\":null},\"visit\":{\"id\":null,\"ip\":\"1.1.1.1\",\"user_agent\":\"python-requests/2.26.0\",\"referrer\":\"None\"},\"action\":{\"name\":null,\"path\":\"/v2/inthreat/bundles\",\"url\":\"http://api.sekoia.io/v2/inthreat/bundles?auto_merge=1\",\"method\":\"POST\"},\"identity\":{\"user_uuid\":null,\"community_uuid\":\"11111111-1111-1111-1111-111111111111\",\"profile_type\":\"apikey\",\"profile_identity\":\"22222222-2222-2222-2222-222222222222\"}}"
+    "message": "{\"timestamp\":\"2021-11-01T12:16:21.815546\",\"observer\":{\"name\":\"sekoia.webapi\",\"version\":null},\"visit\":{\"id\":null,\"ip\":\"1.1.1.1\",\"user_agent\":\"python-requests/2.26.0\",\"referrer\":\"None\"},\"action\":{\"name\":null,\"path\":\"/v2/inthreat/bundles\",\"url\":\"http://api.example.com/v2/inthreat/bundles?auto_merge=1\",\"method\":\"POST\"},\"identity\":{\"user_uuid\":null,\"community_uuid\":\"11111111-1111-1111-1111-111111111111\",\"profile_type\":\"apikey\",\"profile_identity\":\"22222222-2222-2222-2222-222222222222\"}}"
   },
   "expected": {
-    "message": "{\"timestamp\":\"2021-11-01T12:16:21.815546\",\"observer\":{\"name\":\"sekoia.webapi\",\"version\":null},\"visit\":{\"id\":null,\"ip\":\"1.1.1.1\",\"user_agent\":\"python-requests/2.26.0\",\"referrer\":\"None\"},\"action\":{\"name\":null,\"path\":\"/v2/inthreat/bundles\",\"url\":\"http://api.sekoia.io/v2/inthreat/bundles?auto_merge=1\",\"method\":\"POST\"},\"identity\":{\"user_uuid\":null,\"community_uuid\":\"11111111-1111-1111-1111-111111111111\",\"profile_type\":\"apikey\",\"profile_identity\":\"22222222-2222-2222-2222-222222222222\"}}",
+    "message": "{\"timestamp\":\"2021-11-01T12:16:21.815546\",\"observer\":{\"name\":\"sekoia.webapi\",\"version\":null},\"visit\":{\"id\":null,\"ip\":\"1.1.1.1\",\"user_agent\":\"python-requests/2.26.0\",\"referrer\":\"None\"},\"action\":{\"name\":null,\"path\":\"/v2/inthreat/bundles\",\"url\":\"http://api.example.com/v2/inthreat/bundles?auto_merge=1\",\"method\":\"POST\"},\"identity\":{\"user_uuid\":null,\"community_uuid\":\"11111111-1111-1111-1111-111111111111\",\"profile_type\":\"apikey\",\"profile_identity\":\"22222222-2222-2222-2222-222222222222\"}}",
     "@timestamp": "2021-11-01T12:16:21.815546Z",
     "client": {
       "address": "1.1.1.1",
@@ -31,16 +31,16 @@
       }
     },
     "url": {
-      "domain": "api.sekoia.io",
-      "full": "http://api.sekoia.io/v2/inthreat/bundles?auto_merge=1",
-      "original": "http://api.sekoia.io/v2/inthreat/bundles?auto_merge=1",
+      "domain": "api.example.com",
+      "full": "http://api.example.com/v2/inthreat/bundles?auto_merge=1",
+      "original": "http://api.example.com/v2/inthreat/bundles?auto_merge=1",
       "path": "/v2/inthreat/bundles",
       "port": 80,
       "query": "auto_merge=1",
-      "registered_domain": "sekoia.io",
+      "registered_domain": "example.com",
       "scheme": "http",
       "subdomain": "api",
-      "top_level_domain": "io"
+      "top_level_domain": "com"
     },
     "user": {
       "domain": "SEKOIA.IO"

--- a/SekoiaIO/activity_log/tests/activity_log_role_assignment.json
+++ b/SekoiaIO/activity_log/tests/activity_log_role_assignment.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "{\"timestamp\":\"2022-11-22T17:51:17.134509\",\"observer\":{\"name\":\"sekoia.webapi\"},\"visit\":{\"ip\":\"1.1.1.1\",\"user_agent\":\"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36\",\"referrer\":\"https://app.sekoia.io/user/profile/communities/55555555-5555-5555-5555-555555555555/members/66666666-6666-6666-6666-666666666666\"},\"action\":{\"name\":\"role-assignment\",\"path\":\"/v1/communities/55555555-5555-5555-5555-555555555555/roles/11111111-1111-1111-1111-111111111111\",\"url\":\"http://api.sekoia.io/v1/communities/55555555-5555-5555-5555-555555555555/roles/11111111-1111-1111-1111-111111111111\",\"method\":\"POST\",\"parameters\":{\"role\":{\"uuid\":\"11111111-1111-1111-1111-111111111111\",\"name\":\"soar_operator\"},\"user\":{\"uuid\":\"22222222-2222-2222-2222-222222222222\",\"name\":\"Dwight S.\"}},\"communities\":[\"55555555-5555-5555-5555-555555555555\"]},\"identity\":{\"user_uuid\":\"33333333-3333-3333-3333-333333333333\",\"community_uuid\":\"55555555-5555-5555-5555-555555555555\",\"profile_type\":\"avatar\",\"profile_identity\":\"44444444-4444-4444-4444-444444444444\",\"profile_name\":\"Michael S.\"}}\n"
+    "message": "{\"timestamp\":\"2022-11-22T17:51:17.134509\",\"observer\":{\"name\":\"sekoia.webapi\"},\"visit\":{\"ip\":\"1.1.1.1\",\"user_agent\":\"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36\",\"referrer\":\"https://app.example.com/user/profile/communities/55555555-5555-5555-5555-555555555555/members/66666666-6666-6666-6666-666666666666\"},\"action\":{\"name\":\"role-assignment\",\"path\":\"/v1/communities/55555555-5555-5555-5555-555555555555/roles/11111111-1111-1111-1111-111111111111\",\"url\":\"http://api.example.com/v1/communities/55555555-5555-5555-5555-555555555555/roles/11111111-1111-1111-1111-111111111111\",\"method\":\"POST\",\"parameters\":{\"role\":{\"uuid\":\"11111111-1111-1111-1111-111111111111\",\"name\":\"soar_operator\"},\"user\":{\"uuid\":\"22222222-2222-2222-2222-222222222222\",\"name\":\"John Doe\"}},\"communities\":[\"55555555-5555-5555-5555-555555555555\"]},\"identity\":{\"user_uuid\":\"33333333-3333-3333-3333-333333333333\",\"community_uuid\":\"55555555-5555-5555-5555-555555555555\",\"profile_type\":\"avatar\",\"profile_identity\":\"44444444-4444-4444-4444-444444444444\",\"profile_name\":\"Michael S.\"}}\n"
   },
   "expected": {
-    "message": "{\"timestamp\":\"2022-11-22T17:51:17.134509\",\"observer\":{\"name\":\"sekoia.webapi\"},\"visit\":{\"ip\":\"1.1.1.1\",\"user_agent\":\"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36\",\"referrer\":\"https://app.sekoia.io/user/profile/communities/55555555-5555-5555-5555-555555555555/members/66666666-6666-6666-6666-666666666666\"},\"action\":{\"name\":\"role-assignment\",\"path\":\"/v1/communities/55555555-5555-5555-5555-555555555555/roles/11111111-1111-1111-1111-111111111111\",\"url\":\"http://api.sekoia.io/v1/communities/55555555-5555-5555-5555-555555555555/roles/11111111-1111-1111-1111-111111111111\",\"method\":\"POST\",\"parameters\":{\"role\":{\"uuid\":\"11111111-1111-1111-1111-111111111111\",\"name\":\"soar_operator\"},\"user\":{\"uuid\":\"22222222-2222-2222-2222-222222222222\",\"name\":\"Dwight S.\"}},\"communities\":[\"55555555-5555-5555-5555-555555555555\"]},\"identity\":{\"user_uuid\":\"33333333-3333-3333-3333-333333333333\",\"community_uuid\":\"55555555-5555-5555-5555-555555555555\",\"profile_type\":\"avatar\",\"profile_identity\":\"44444444-4444-4444-4444-444444444444\",\"profile_name\":\"Michael S.\"}}\n",
+    "message": "{\"timestamp\":\"2022-11-22T17:51:17.134509\",\"observer\":{\"name\":\"sekoia.webapi\"},\"visit\":{\"ip\":\"1.1.1.1\",\"user_agent\":\"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36\",\"referrer\":\"https://app.example.com/user/profile/communities/55555555-5555-5555-5555-555555555555/members/66666666-6666-6666-6666-666666666666\"},\"action\":{\"name\":\"role-assignment\",\"path\":\"/v1/communities/55555555-5555-5555-5555-555555555555/roles/11111111-1111-1111-1111-111111111111\",\"url\":\"http://api.example.com/v1/communities/55555555-5555-5555-5555-555555555555/roles/11111111-1111-1111-1111-111111111111\",\"method\":\"POST\",\"parameters\":{\"role\":{\"uuid\":\"11111111-1111-1111-1111-111111111111\",\"name\":\"soar_operator\"},\"user\":{\"uuid\":\"22222222-2222-2222-2222-222222222222\",\"name\":\"John Doe\"}},\"communities\":[\"55555555-5555-5555-5555-555555555555\"]},\"identity\":{\"user_uuid\":\"33333333-3333-3333-3333-333333333333\",\"community_uuid\":\"55555555-5555-5555-5555-555555555555\",\"profile_type\":\"avatar\",\"profile_identity\":\"44444444-4444-4444-4444-444444444444\",\"profile_name\":\"Michael S.\"}}\n",
     "event": {
       "action": "role-assignment"
     },
@@ -15,7 +15,7 @@
     "http": {
       "request": {
         "method": "POST",
-        "referrer": "https://app.sekoia.io/user/profile/communities/55555555-5555-5555-5555-555555555555/members/66666666-6666-6666-6666-666666666666"
+        "referrer": "https://app.example.com/user/profile/communities/55555555-5555-5555-5555-555555555555/members/66666666-6666-6666-6666-666666666666"
       }
     },
     "observer": {
@@ -40,28 +40,28 @@
           "uuid": "11111111-1111-1111-1111-111111111111"
         },
         "user": {
-          "name": "Dwight S.",
+          "name": "John Doe",
           "uuid": "22222222-2222-2222-2222-222222222222"
         }
       }
     },
     "url": {
-      "domain": "api.sekoia.io",
-      "full": "http://api.sekoia.io/v1/communities/55555555-5555-5555-5555-555555555555/roles/11111111-1111-1111-1111-111111111111",
-      "original": "http://api.sekoia.io/v1/communities/55555555-5555-5555-5555-555555555555/roles/11111111-1111-1111-1111-111111111111",
+      "domain": "api.example.com",
+      "full": "http://api.example.com/v1/communities/55555555-5555-5555-5555-555555555555/roles/11111111-1111-1111-1111-111111111111",
+      "original": "http://api.example.com/v1/communities/55555555-5555-5555-5555-555555555555/roles/11111111-1111-1111-1111-111111111111",
       "path": "/v1/communities/55555555-5555-5555-5555-555555555555/roles/11111111-1111-1111-1111-111111111111",
       "port": 80,
-      "registered_domain": "sekoia.io",
+      "registered_domain": "example.com",
       "scheme": "http",
       "subdomain": "api",
-      "top_level_domain": "io"
+      "top_level_domain": "com"
     },
     "user": {
       "domain": "SEKOIA.IO",
       "full_name": "Michael S.",
       "id": "33333333-3333-3333-3333-333333333333",
       "target": {
-        "full_name": "Dwight S.",
+        "full_name": "John Doe",
         "id": "22222222-2222-2222-2222-222222222222",
         "roles": "[soar_operator]"
       }


### PR DESCRIPTION
For apikey identities, identity.profile_name is the internal API key label (e.g. the asset connector internal key `[<community>] internal API key for <connector_uuid>`), not a real user name. It should not populate user.full_name. The parser now only sets user.full_name when profile_type is not apikey. Adds a test for an apikey activity log carrying a profile_name.

## Summary by Sourcery

Fix mapping of identity profile information in activity log parsing to avoid treating API key labels as user names.

Bug Fixes:
- Avoid populating user.full_name from identity.profile_name when the profile type is an API key to prevent incorrect user naming.

Documentation:
- Document the change in activity log behavior regarding user.full_name population for API key profiles in the changelog.

Tests:
- Add an activity log fixture for asset connector API key events to cover the updated user.full_name mapping behavior.