### PR TITLE
Hotfix: Netskope Events

### DIFF
--- a/Netskope/netskope_events/_meta/manifest.yml
+++ b/Netskope/netskope_events/_meta/manifest.yml
@@ -1,5 +1,4 @@
 uuid: de9ca004-991e-4f5c-89c5-e075f3fb3216
-automation_connector_uuid: 97edba63-7643-4232-91b9-2e7aafa232c8
 automation_module_uuid: 1e3f2e33-fb9c-4387-bcf7-8d7ece37f913
 name: Netskope
 slug: netskope-events


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Clean up Netskope events manifest by dropping the automation connector UUID field.