### PR TITLE
Ngnix: fix the automation module uuid in the NGINX format to a valid one

### DIFF
--- a/NGINX/nginx/_meta/manifest.yml
+++ b/NGINX/nginx/_meta/manifest.yml
@@ -4,4 +4,4 @@ slug: nginx
 description: "NGINX is an HTTP and reverse proxy server.\nSending NGINX logs will help detect suspicious connections and intrusion attempts."
 data_sources:
   Web logs: Nginx logs provide many information like the connected client, the requested resource, the user agent or the response status.
-automation_module_uuid: 4fe0c00-78e9-4fa9-a6d8-38ca190d9dad
+automation_module_uuid: 04fe0c00-78e9-4fa9-a6d8-38ca190d9dad


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix invalid automation_module_uuid in the NGINX manifest by replacing it with a valid UUID.