### PR TITLE
feature/cisco_ios_add_fields

### DIFF
--- a/Cisco/cisco-ios/CHANGELOG.md
+++ b/Cisco/cisco-ios/CHANGELOG.md
@@ -6,3 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [Unreleased] - 2026-06-16
+
+### Added
+
+- Parse ECS dynamic fields for HTTPS connection logs without Cisco header:
+    - destination.ip
+    - event.action
+    - event.category
+    - event.code
+    - event.outcome
+    - event.reason
+    - event.type
+    - network.protocol
+    - source.ip
+    - user.name
+- Add smart descriptions for HTTPS connection accepted and terminated events
+
+### Changed
+
+- Update parser fallback to handle description-only messages and to map HTTPS connection states to ECS

--- a/Cisco/cisco-ios/_meta/smart-descriptions.json
+++ b/Cisco/cisco-ios/_meta/smart-descriptions.json
@@ -363,6 +363,50 @@
     ]
   },
   {
+    "value": "HTTPS connection accepted for user {user.name} from {source.address} to {destination.address}",
+    "conditions": [
+      {
+        "field": "event.code",
+        "value": "HTTPS_CONNECTION"
+      },
+      {
+        "field": "event.action",
+        "value": "accepted"
+      },
+      {
+        "field": "user.name"
+      },
+      {
+        "field": "source.address"
+      },
+      {
+        "field": "destination.address"
+      }
+    ]
+  },
+  {
+    "value": "HTTPS connection terminated for user {user.name} from {source.address} to {destination.address}",
+    "conditions": [
+      {
+        "field": "event.code",
+        "value": "HTTPS_CONNECTION"
+      },
+      {
+        "field": "event.action",
+        "value": "terminated"
+      },
+      {
+        "field": "user.name"
+      },
+      {
+        "field": "source.address"
+      },
+      {
+        "field": "destination.address"
+      }
+    ]
+  },
+  {
     "value": "{event.reason}",
     "conditions": [{ "field": "event.reason" }]
   }

--- a/Cisco/cisco-ios/ingest/parser.yml
+++ b/Cisco/cisco-ios/ingest/parser.yml
@@ -4,7 +4,7 @@ pipeline:
     external:
       name: grok.match
       properties:
-        pattern: "(?:%{CUSTOM_HOSTNAME:hostname}: )?%{CISCO_HEADER}: %{DATA:description}"
+        pattern: "(?:(?:%{CUSTOM_HOSTNAME:hostname}: )?%{CISCO_HEADER}: %{DATA:description}|%{DATA:raw_description})"
         custom_patterns:
           CUSTOM_HOSTNAME: '[0-9a-zA-Z_\-\.]+'
           CISCO_HEADER: "%{CISCO_DATESTAMP}: %{MSG_CODE}"
@@ -17,8 +17,8 @@ pipeline:
       name: grok.match
       properties:
         raise_errors: false
-        input_field: parsed_event.message.description
-        pattern: "%{ACCTLOCAL}|%{AUTHMGR_START}|%{BLOCK_BPDUGUARD}|%{CFGLOG_LOGGEDCMD}|%{CONFIG_I}|%{CONFIG_P}|%{CONFIG_RESOLVE_FAILURE}|%{DHCP_SNOOPING}|%{DHCP_SNOOPING_MATCH_MAC_FAIL}|%{DMI_AUTH_FAILED}|%{DMI_AUTH_PASSED}|%{DUPADDR}|%{ERR_DISABLE}|%{IPACCESSLOGP}|%{IPACCESSLOGS}|%{LINEPROTO}|%{LINK}|%{LOOPGUARD_BLOCK}|%{MAB}|%{MODEL_RPC_I}|%{PORT_SECURITY}|%{PRIV_AUTH_FAIL}|%{PRIV_AUTH_PASS}|%{QUIET_MODE_ON}|%{ROOTCHANGE}|%{SEC_LOGIN}|%{SEC_VIOLATION}|%{SSH2_CLOSE}|%{SSH2_SESSION}|%{SSH2_USERAUTH}|%{STCKYARPOVR}|%{SW_MATM_MACFLAP}|%{SYS_LOGIN_FAILURE}|%{SYS_LOGOUT}|%{SYS_TTY_EXPIRE_TIMER}|%{USERNAME_CONFIGURATION}|%{USER_RESET}|%{WEAK_PASSWORD_TYPE}"
+        input_field: "{{parsed_event.message.description or parsed_event.message.raw_description}}"
+        pattern: "%{ACCTLOCAL}|%{AUTHMGR_START}|%{BLOCK_BPDUGUARD}|%{CFGLOG_LOGGEDCMD}|%{CONFIG_I}|%{CONFIG_P}|%{CONFIG_RESOLVE_FAILURE}|%{DHCP_SNOOPING}|%{DHCP_SNOOPING_MATCH_MAC_FAIL}|%{DMI_AUTH_FAILED}|%{DMI_AUTH_PASSED}|%{DUPADDR}|%{ERR_DISABLE}|%{HTTPS_CONNECTION}|%{IPACCESSLOGP}|%{IPACCESSLOGS}|%{LINEPROTO}|%{LINK}|%{LOOPGUARD_BLOCK}|%{MAB}|%{MODEL_RPC_I}|%{PORT_SECURITY}|%{PRIV_AUTH_FAIL}|%{PRIV_AUTH_PASS}|%{QUIET_MODE_ON}|%{ROOTCHANGE}|%{SEC_LOGIN}|%{SEC_VIOLATION}|%{SSH2_CLOSE}|%{SSH2_SESSION}|%{SSH2_USERAUTH}|%{STCKYARPOVR}|%{SW_MATM_MACFLAP}|%{SYS_LOGIN_FAILURE}|%{SYS_LOGOUT}|%{SYS_TTY_EXPIRE_TIMER}|%{USERNAME_CONFIGURATION}|%{USER_RESET}|%{WEAK_PASSWORD_TYPE}"
         custom_patterns:
           ACCTLOCAL: "Username: %{USERNAME:username} Privilege level: %{NUMBER:priv_level} Command: %{GREEDYDATA:command_line}"
           AUTHMGR_START: "Starting '%{DATA}' for client \\(%{DATA:source_mac_addr}\\) on Interface %{NOTSPACE:ifname} AuditSessionID %{DATA:session_id}"
@@ -33,6 +33,7 @@ pipeline:
           DMI_AUTH_PASSED: "%{DATA:switch}: %{DATA:process_name}: User '%{DATA:username}' authenticated successfully from %{IP:source_ip}:%{NUMBER:source_port}\\s+(and was authorized\\s+)?for %{DATA:proto}. External groups: %{DATA:ext_groups}"
           DUPADDR: "Duplicate address %{IP:source_ip} on %{IFNAME_AND_VLAN:ifname}, sourced by %{DATA:source_mac_addr}"
           ERR_DISABLE: "%{DATA:error_type} error detected on %{NOTSPACE:ifname}, putting %{DATA} in %{DATA:ifstate} state"
+          HTTPS_CONNECTION: "(New )?https connection for user %{DATA:username}, source %{IP:source_ip} destination %{IP:destination_ip} %{WORD:https_connection_state}"
           IPACCESSLOGP: 'list %{DATA} permitted tcp %{IP:source_ip}\(%{NUMBER:source_port}\) -> %{IP:destination_ip}\(%{NUMBER:destination_port}\), %{NUMBER:packets} packet(s?)'
           IPACCESSLOGS: "list %{DATA} denied %{IP:source_ip} %{NUMBER:packets} packet(s?)"
           LINEPROTO: "Line protocol on Interface %{NOTSPACE:ifname}, changed state to %{WORD:ifstate}"
@@ -83,7 +84,7 @@ stages:
           observer.product: "ios"
           event.severity: "{{parsed_event.message.severity}}"
           event.code: "{{parsed_event.message.mnemonic}}"
-          event.reason: "{{parsed_event.message.description}}"
+          event.reason: "{{parsed_event.message.description or parsed_event.message.raw_description}}"
           event.action: "{{parsed_description.message.ifstate}}"
           host.name: "{{parsed_event.message.hostname}}"
       - set:
@@ -161,12 +162,28 @@ stages:
           event.category: ["authentication"]
           event.type: ["start"]
           event.outcome: "failure"
-        filter: "{{'Authentication failed' in parsed_event.message.description}}"
+        filter: "{{'Authentication failed' in (parsed_event.message.description or parsed_event.message.raw_description or '')}}"
 
       - set:
           event.outcome: "success"
           event.type: ["start"]
-        filter: "{{parsed_event.message.mnemonic == 'SSH2_USERAUTH' and 'Succeeded' in parsed_event.message.description}}"
+        filter: "{{parsed_event.message.mnemonic == 'SSH2_USERAUTH' and 'Succeeded' in (parsed_event.message.description or parsed_event.message.raw_description or '')}}"
+
+      - set:
+          event.code: "HTTPS_CONNECTION"
+          event.action: "{{parsed_description.message.https_connection_state | lower}}"
+          event.category: ["network"]
+          network.protocol: "https"
+        filter: '{{parsed_description.message.get("https_connection_state") != None}}'
+
+      - set:
+          event.type: ["start"]
+          event.outcome: "success"
+        filter: '{{parsed_description.message.https_connection_state == "ACCEPTED"}}'
+
+      - set:
+          event.type: ["end"]
+        filter: '{{parsed_description.message.https_connection_state == "TERMINATED"}}'
 
   set_cisco_fields:
     actions:

--- a/Cisco/cisco-ios/tests/test_https_connection_accepted.json
+++ b/Cisco/cisco-ios/tests/test_https_connection_accepted.json
@@ -1,0 +1,47 @@
+{
+  "input": {
+    "message": "New https connection for user user1, source 198.51.100.10 destination 203.0.113.50 ACCEPTED"
+  },
+  "expected": {
+    "message": "New https connection for user user1, source 198.51.100.10 destination 203.0.113.50 ACCEPTED",
+    "event": {
+      "action": "accepted",
+      "category": [
+        "network"
+      ],
+      "code": "HTTPS_CONNECTION",
+      "outcome": "success",
+      "reason": "New https connection for user user1, source 198.51.100.10 destination 203.0.113.50 ACCEPTED",
+      "type": [
+        "start"
+      ]
+    },
+    "destination": {
+      "address": "203.0.113.50",
+      "ip": "203.0.113.50"
+    },
+    "network": {
+      "protocol": "https"
+    },
+    "observer": {
+      "product": "ios",
+      "vendor": "Cisco"
+    },
+    "related": {
+      "ip": [
+        "198.51.100.10",
+        "203.0.113.50"
+      ],
+      "user": [
+        "user1"
+      ]
+    },
+    "source": {
+      "address": "198.51.100.10",
+      "ip": "198.51.100.10"
+    },
+    "user": {
+      "name": "user1"
+    }
+  }
+}

--- a/Cisco/cisco-ios/tests/test_https_connection_terminated.json
+++ b/Cisco/cisco-ios/tests/test_https_connection_terminated.json
@@ -1,0 +1,46 @@
+{
+  "input": {
+    "message": "https connection for user user1, source 198.51.100.10 destination 203.0.113.50 TERMINATED"
+  },
+  "expected": {
+    "message": "https connection for user user1, source 198.51.100.10 destination 203.0.113.50 TERMINATED",
+    "event": {
+      "action": "terminated",
+      "category": [
+        "network"
+      ],
+      "code": "HTTPS_CONNECTION",
+      "reason": "https connection for user user1, source 198.51.100.10 destination 203.0.113.50 TERMINATED",
+      "type": [
+        "end"
+      ]
+    },
+    "destination": {
+      "address": "203.0.113.50",
+      "ip": "203.0.113.50"
+    },
+    "network": {
+      "protocol": "https"
+    },
+    "observer": {
+      "product": "ios",
+      "vendor": "Cisco"
+    },
+    "related": {
+      "ip": [
+        "198.51.100.10",
+        "203.0.113.50"
+      ],
+      "user": [
+        "user1"
+      ]
+    },
+    "source": {
+      "address": "198.51.100.10",
+      "ip": "198.51.100.10"
+    },
+    "user": {
+      "name": "user1"
+    }
+  }
+}


### PR DESCRIPTION
## Description

Relates to https://github.com/SekoiaLab/integration/issues/1685

### Added

- Parse ECS dynamic fields for HTTPS connection logs without Cisco header:
    - destination.ip
    - event.action
    - event.category
    - event.code
    - event.outcome
    - event.reason
    - event.type
    - network.protocol
    - source.ip
    - user.name
- Add smart descriptions for HTTPS connection accepted and terminated events

### Changed

- Update parser fallback to handle description-only messages and to map HTTPS connection states to ECS

## Type of Change

- [ ] New intake format
- [x] Update to existing intake format
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (please describe):

## Affected Intake Formats

- Vendor/product: Cisco/cisco-ios

## Checklist

<!-- Ensure all requirements are met before submitting -->

### 🔒 CRITICAL - Security Requirements (MUST BE VERIFIED FIRST)

- [ ] **No real email addresses** in test files (use: user@example.com, test@example.org)
- [ ] **No real passwords or API keys** (use: "P@ssw0rd!", "xxxxxxxxxxxx", "FAKE_TOKEN_123")
- [ ] **No real IP addresses** (use TEST-NET ranges: 192.0.2.x, 198.51.100.x, 203.0.113.x)
- [ ] **No real phone numbers** (use: +1-555-0100 or similar test numbers)
- [ ] **No real names or PII** (use: "John Doe", "Jane Smith", "User123")
- [ ] **No real company/organization names** in test data (unless public vendors)
- [ ] **No real usernames, hostnames, or domain names** (use: user1, host.example.com, test.corp)
- [ ] All test data has been anonymized and verified

### Required for All PRs

- [ ] Code has been linted
    - [ ] with the linter for manifest, smart-descriptions, and test files (`uv run python linter.py check --changes` in utils/)
    - [ ] with Prettier for the parser code files (`npx prettier --write <module>/<format>/ingest/parser.yml`)
- [ ] All CI/CD checks pass
- [ ] Changes follow the contribution guidelines in `CONTRIBUTING.md`

### Required for New/Updated Intake Formats

- [ ] Clear descriptions provided for modules and formats
- [ ] Logo files included for new modules/formats
- [ ] Parser test coverage is at least 75%
- [ ] At least one smart-description is provided
- [ ] README.md updated (if applicable)
- [ ] Taxonomy mappings are correct and documented
- [ ] Test cases cover edge cases and error handling

### Testing

- [ ] Local tests pass (`uv run pytest` in utils/)
- [ ] Sample data is representative and **completely anonymized**
- [ ] **No sensitive information** (PII, credentials, real IPs, real emails) in test files
- [ ] Test data uses example.com/example.org domains and TEST-NET IP ranges
- [ ] Parser handles malformed data gracefully

### Documentation

- [ ] Code changes are documented
- [ ] Smart-descriptions are clear and informative
- [ ] Field mappings are explained

## Additional Notes

<!-- Add any additional context, screenshots, or information that would help reviewers -->

## Related Issues

<!-- Link any related issues using #issue_number -->

Closes #

## Summary by Sourcery

Extend Cisco IOS parser to handle HTTPS connection logs without Cisco headers and map them to appropriate ECS network event fields.

New Features:
- Extract ECS fields such as source and destination IPs, user name, protocol, action, type, outcome, and code from HTTPS connection messages, including those without Cisco headers.
- Provide smart descriptions for HTTPS connection accepted and terminated events.

Enhancements:
- Update parser fallback logic to use either structured description or raw description and to derive ECS fields from HTTPS connection state.
- Document the new HTTPS connection handling in the Cisco IOS changelog.

Tests:
- Add tests covering HTTPS connection accepted and terminated events to validate the new parsing and smart descriptions.