### PR TITLE
PaloAlto Cortex XDR: refielding event.outcome into a custom field allowing its values

### DIFF
--- a/Palo Alto Networks/paloalto-cortex-xdr/_meta/fields.yml
+++ b/Palo Alto Networks/paloalto-cortex-xdr/_meta/fields.yml
@@ -23,6 +23,11 @@ paloalto.cortex.xdr.alert.is_whitelisted:
   name: paloalto.cortex.xdr.alert.is_whitelisted
   type: boolean
 
+paloalto.cortex.xdr.alert.matching_status:
+  description: Cortex alert matching status
+  name: paloalto.cortex.xdr.alert.matching_status
+  type: keyword
+
 paloalto.cortex.xdr.alert.name:
   description: Cortex alert name
   name: paloalto.cortex.xdr.alert.name

--- a/Palo Alto Networks/paloalto-cortex-xdr/_meta/smart-descriptions.json
+++ b/Palo Alto Networks/paloalto-cortex-xdr/_meta/smart-descriptions.json
@@ -1,6 +1,6 @@
 [
   {
-    "value": "{event.action} alert {event.outcome} {paloalto.cortex.xdr.alert.name} rule : {event.reason} ",
+    "value": "{event.action} alert {paloalto.cortex.xdr.alert.matching_status} {paloalto.cortex.xdr.alert.name} rule : {event.reason} ",
     "conditions": [
       {
         "field": "event.dataset",
@@ -10,7 +10,7 @@
         "field": "event.action"
       },
       {
-        "field": "event.outcome"
+        "field": "paloalto.cortex.xdr.alert.matching_status"
       },
       {
         "field": "paloalto.cortex.xdr.alert.name"
@@ -21,7 +21,7 @@
     ]
   },
   {
-    "value": "{event.action} alert {event.outcome} {paloalto.cortex.xdr.alert.name} rule",
+    "value": "{event.action} alert {paloalto.cortex.xdr.alert.matching_status} {paloalto.cortex.xdr.alert.name} rule",
     "conditions": [
       {
         "field": "event.dataset",
@@ -31,7 +31,7 @@
         "field": "event.action"
       },
       {
-        "field": "event.outcome"
+        "field": "paloalto.cortex.xdr.alert.matching_status"
       },
       {
         "field": "paloalto.cortex.xdr.alert.name"

--- a/Palo Alto Networks/paloalto-cortex-xdr/ingest/parser.yml
+++ b/Palo Alto Networks/paloalto-cortex-xdr/ingest/parser.yml
@@ -57,7 +57,6 @@ stages:
 
           event.action: "{{json_event.message.action}}"
           event.reason: "{{json_event.message.description}}"
-          event.outcome: "{{json_event.message.matching_status}}"
 
           agent.version: "{{json_event.message.agent_version}}"
           agent.name: "{{json_event.message.agent_fqdn}}"
@@ -73,6 +72,7 @@ stages:
           paloalto.cortex.xdr.alert.severity: "{{json_event.message.severity}}"
           paloalto.cortex.xdr.alert.id: "{{json_event.message.alert_id}}"
           paloalto.cortex.xdr.alert.externalID: "{{json_event.message.external_id}}"
+          paloalto.cortex.xdr.alert.matching_status: "{{json_event.message.matching_status}}"
           paloalto.cortex.xdr.alert.ruleID.matching_service: "{{json_event.message.matching_service_rule_id}}"
           paloalto.cortex.xdr.alert.ruleID.filter: "{{json_event.message.filter_rule_id}}"
           paloalto.cortex.xdr.alert.caseID: "{{json_event.message.case_id}}"

--- a/Palo Alto Networks/paloalto-cortex-xdr/tests/alerts_1.json
+++ b/Palo Alto Networks/paloalto-cortex-xdr/tests/alerts_1.json
@@ -11,7 +11,6 @@
       ],
       "dataset": "alert",
       "kind": "alert",
-      "outcome": "MATCHED",
       "reason": "great decription for this event",
       "type": [
         "info"
@@ -41,6 +40,7 @@
             "externalID": "c2c51d03-65db",
             "id": "555555555",
             "is_whitelisted": false,
+            "matching_status": "MATCHED",
             "name": "Large Upload (Generic)",
             "ruleID": {
               "matching_service": "03bb2cd4-a667-11ea-9d88-820e27035801"

--- a/Palo Alto Networks/paloalto-cortex-xdr/tests/alerts_2.json
+++ b/Palo Alto Networks/paloalto-cortex-xdr/tests/alerts_2.json
@@ -17,7 +17,6 @@
       ],
       "dataset": "alert",
       "kind": "alert",
-      "outcome": "MATCHED",
       "reason": "The scripting engine java.exe connected to 5.6.7.8. The address 5.6.7.8 was connected by 0 different endpoints across 0 unique days in the last 30 days. Command line: \"C:\\Program Files\\XDR\\jre\\bin\\java\" -XX:+UseParallelGC -Dfile.encoding=Cp1252 -Dsun.stdout.encoding=Cp1252 -Dsun.stderr.encoding=Cp1252 -Dwrapper.use_sun_encoding=true -Xms64m -Xmx128m -Djava.library.path=\"./19.484-1/bin/native/lib\" -classpath \"./19.484-1/lib/ant-1.10.14.jar;./19.484-1/lib/ant-launcher-1.10.14.jar;./19.484-1/lib/aopalliance-repackaged-2.6.1.jar;./19.484-1/lib/avro-1.11.3.jar;./19.484-1/lib/avro-fastserde-0.4.13.jar;./19.484-1/lib/avro-ipc-1.11.3.jar;./19.484-1/lib/avrox-19.484-1.jar;./19.484-1/lib/aws-java-sdk-core-1.12.269.jar;./19.484-1/lib/aws-java-sdk-kms-1.12.269.jar;./19.484-1/lib/aws-java-sdk-s3-1.12.269.jar;./19.484-1/lib/checker-qual-3.41.0.jar;./19.484-1/lib/classgraph-4.8.165.jar;./19.484-1/lib/codemodel-2.6.jar;./19.484-1/lib/collector-19.484-1-resources.jar;./19.484-1/lib/collector-19.484-1.jar;./19.484-1/lib/collector-base-19.484-1.jar;./19.484-1/lib/collector-interchange-19.484-1.jar;./19.484-1/lib/collector-util-19.484-1.jar;./19.484-1/lib/commons-beanutils-1.9.4.jar;./19.484-1/lib/commons-cli-1.6.0.jar;./19.484-1/lib/commons-codec-1.16.1.jar;./19.484-1/lib/commons-collections4-4.4.jar;./19.484-1/lib/commons-collections-3.2.2.jar;./19.484-1/lib/commons-compress-1.25.0.jar;./19.484-1/lib/commons-configuration2-2.9.0.jar;./19.484-1/lib/commons-configuration-1.10.jar;./19.484-1/lib/commons-digester-2.1.jar\" -Dwrapper.key=\"aaaaaaaaaaaaaaaaaaaaaaaaa\" -Dwrapper.port=32000 -Dwrapper.jvm.port.min=31000 -Dwrapper.jvm.port.max=31999 -Dwrapper.pid=5040 -Dwrapper.version=\"3.5.49-st\" -Dwrapper.native_library=\"wrapper\" -Dwrapper.arch=\"x86\" -Dwrapper.service=\"TRUE\" -Dwrapper.cpu.timeout=\"10\" -Dwrapper.jvmid=1 -Dwrapper.lang.domain=\"wrapper\" -Dwrapper.lang.folder=\"../lang\" org.tanukisoftware.wrapper.WrapperSimpleApp com.xdr.scala.collector.Collector",
       "type": [
         "info"
@@ -53,6 +52,7 @@
             "externalID": "d87d5e06-8119-4106-b4ab-0000eaf838b9",
             "id": "1111",
             "is_whitelisted": false,
+            "matching_status": "MATCHED",
             "name": "Scripting engine connected to a rare external host",
             "ruleID": {
               "matching_service": "d87d5e06-8119-4106-b4ab-0000eaf838b9"

--- a/Palo Alto Networks/paloalto-cortex-xdr/tests/alerts_3.json
+++ b/Palo Alto Networks/paloalto-cortex-xdr/tests/alerts_3.json
@@ -17,7 +17,6 @@
       ],
       "dataset": "alert",
       "kind": "alert",
-      "outcome": "MATCHED",
       "reason": "The host DESKTOP01 was seen communicating to the external entity sekoia.io. Communication between these entities was seen 12 times. This external entity is rare in the organization as only 2 hosts within the organization accessed it. This external entity is also rare globally. This external entity was accessed using 1 distinct ports. Based on our machine learning models, this connection was flagged as suspicious",
       "type": [
         "info"
@@ -49,6 +48,7 @@
             "externalID": "d87d5e06-8119-4106-b4ab-0000eaf838b9",
             "id": "1111",
             "is_whitelisted": false,
+            "matching_status": "MATCHED",
             "name": "Abnormal Recurring Communications to a Rare Domain to a Suspicious Autonomous System (AS)",
             "ruleID": {
               "matching_service": "d87d5e06-8119-4106-b4ab-0000eaf838b9"

--- a/Palo Alto Networks/paloalto-cortex-xdr/tests/alerts_4.json
+++ b/Palo Alto Networks/paloalto-cortex-xdr/tests/alerts_4.json
@@ -17,7 +17,6 @@
       ],
       "dataset": "alert",
       "kind": "alert",
-      "outcome": "MATCHED",
       "reason": "A service was disabled on the host DESKTOP01. The process GooglePlayGamesServicesInstaller.exe disabled the service GooglePlayGamesServices-25.1.40.0",
       "type": [
         "info"
@@ -49,6 +48,7 @@
             "externalID": "d16cf364-adb3-4c69-a588-bba7dc0a84d8",
             "id": "6404",
             "is_whitelisted": false,
+            "matching_status": "MATCHED",
             "name": "An unsigned process performed an uncommon service deactivation",
             "ruleID": {
               "matching_service": "d16cf364-adb3-4c69-a588-bba7dc0a84d8"

--- a/Palo Alto Networks/paloalto-cortex-xdr/tests/alerts_5.json
+++ b/Palo Alto Networks/paloalto-cortex-xdr/tests/alerts_5.json
@@ -11,7 +11,6 @@
       ],
       "dataset": "alert",
       "kind": "alert",
-      "outcome": "PENDING",
       "provider": "WildFire",
       "reason": "Suspicious executable detected",
       "type": [
@@ -42,6 +41,7 @@
             "externalID": "ttt",
             "id": "1111111",
             "is_whitelisted": false,
+            "matching_status": "PENDING",
             "name": "WildFire Malware",
             "severity": "medium"
           }

--- a/Palo Alto Networks/paloalto-cortex-xdr/tests/combined_alert.json
+++ b/Palo Alto Networks/paloalto-cortex-xdr/tests/combined_alert.json
@@ -11,7 +11,6 @@
       ],
       "dataset": "alert",
       "kind": "alert",
-      "outcome": "MATCHED",
       "reason": "great decription for this event",
       "type": [
         "info"
@@ -45,6 +44,7 @@
             "externalID": "c2c51d03-65db",
             "id": "555555555",
             "is_whitelisted": false,
+            "matching_status": "MATCHED",
             "name": "Large Upload (Generic)",
             "ruleID": {
               "matching_service": "03bb2cd4-a667-11ea-9d88-820e27035801"


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->
Related to [this issue](https://github.com/SekoiaLab/integration/issues/1677)

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] New intake format
- [ ] Update to existing intake format
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (please describe):

## Affected Intake Formats

<!-- List the vendor/product formats affected by this PR -->

- Vendor/product:

## Checklist

<!-- Ensure all requirements are met before submitting -->

### 🔒 CRITICAL - Security Requirements (MUST BE VERIFIED FIRST)

- [ ] **No real email addresses** in test files (use: user@example.com, test@example.org)
- [ ] **No real passwords or API keys** (use: "P@ssw0rd!", "xxxxxxxxxxxx", "FAKE_TOKEN_123")
- [ ] **No real IP addresses** (use TEST-NET ranges: 192.0.2.x, 198.51.100.x, 203.0.113.x)
- [ ] **No real phone numbers** (use: +1-555-0100 or similar test numbers)
- [ ] **No real names or PII** (use: "John Doe", "Jane Smith", "User123")
- [ ] **No real company/organization names** in test data (unless public vendors)
- [ ] **No real usernames, hostnames, or domain names** (use: user1, host.example.com, test.corp)
- [ ] All test data has been anonymized and verified

### Required for All PRs

- [ ] Code has been linted
    - [ ] with the linter for manifest, smart-descriptions, and test files (`uv run python linter.py check --changes` in utils/)
    - [ ] with Prettier for the parser code files (`npx prettier --write <module>/<format>/ingest/parser.yml`)
- [ ] All CI/CD checks pass
- [ ] Changes follow the contribution guidelines in `CONTRIBUTING.md`

### Required for New/Updated Intake Formats

- [ ] Clear descriptions provided for modules and formats
- [ ] Logo files included for new modules/formats
- [ ] Parser test coverage is at least 75%
- [ ] At least one smart-description is provided
- [ ] README.md updated (if applicable)
- [ ] Taxonomy mappings are correct and documented
- [ ] Test cases cover edge cases and error handling

### Testing

- [ ] Local tests pass (`uv run pytest` in utils/)
- [ ] Sample data is representative and **completely anonymized**
- [ ] **No sensitive information** (PII, credentials, real IPs, real emails) in test files
- [ ] Test data uses example.com/example.org domains and TEST-NET IP ranges
- [ ] Parser handles malformed data gracefully

### Documentation

- [ ] Code changes are documented
- [ ] Smart-descriptions are clear and informative
- [ ] Field mappings are explained

## Additional Notes

<!-- Add any additional context, screenshots, or information that would help reviewers -->

## Related Issues

<!-- Link any related issues using #issue_number -->

Closes #

## Summary by Sourcery

Refield Cortex XDR alert matching status from the generic event.outcome field into a dedicated vendor-specific field.

New Features:
- Add a paloalto.cortex.xdr.alert.matching_status custom field to store Cortex alert matching status.

Bug Fixes:
- Stop populating event.outcome with Cortex matching_status values, using the new custom field instead.

Tests:
- Update Palo Alto Cortex XDR alert test fixtures to cover the new matching_status field mapping.