### PR TITLE
Azure: fix the way to parse the date and add a default event.type

### DIFF
--- a/Azure/azure-ad/ingest/parser.yml
+++ b/Azure/azure-ad/ingest/parser.yml
@@ -167,6 +167,8 @@ stages:
           http.request.method: "{{parsed_event.message.properties.requestMethod}}"
           http.response.status_code: "{{parsed_event.message.properties.responseStatusCode}}"
           url.original: "{{parsed_event.message.properties.requestUri}}"
+          event.category: ["iam"]
+          event.type: ["info"]
 
       - set:
           azuread.properties.scopes: >

--- a/Azure/azure-ad/ingest/parser.yml
+++ b/Azure/azure-ad/ingest/parser.yml
@@ -17,7 +17,7 @@ pipeline:
       properties:
         input_field: "{{parsed_event.message.properties.createdDateTime}}"
         output_field: date
-    filter: '{{parsed_event.message.properties.get("createdDateTime") != null}}'
+    filter: '{{parsed_event.message.get("properties", {}).get("createdDateTime", "") != ""}}'
 
   - name: parsed_additional_info
     external:

--- a/Azure/azure-ad/ingest/parser.yml
+++ b/Azure/azure-ad/ingest/parser.yml
@@ -8,8 +8,16 @@ pipeline:
     external:
       name: date.parse
       properties:
-        input_field: "{{parsed_event.message.properties.createdDateTime or parsed_event.message.time}}"
+        input_field: "{{parsed_event.message.time}}"
         output_field: date
+
+  - name: parsed_date
+    external:
+      name: date.parse
+      properties:
+        input_field: "{{parsed_event.message.properties.createdDateTime}}"
+        output_field: date
+    filter: '{{parsed_event.message.properties.get("createdDateTime") != null}}'
 
   - name: parsed_additional_info
     external:

--- a/Azure/azure-ad/tests/add_domain.json
+++ b/Azure/azure-ad/tests/add_domain.json
@@ -9,7 +9,10 @@
       "category": [
         "iam"
       ],
-      "outcome": "success"
+      "outcome": "success",
+      "type": [
+        "info"
+      ]
     },
     "@timestamp": "2019-06-24T09:21:27.369418Z",
     "action": {

--- a/Azure/azure-ad/tests/add_member_to_group.json
+++ b/Azure/azure-ad/tests/add_member_to_group.json
@@ -9,7 +9,10 @@
       "category": [
         "iam"
       ],
-      "outcome": "success"
+      "outcome": "success",
+      "type": [
+        "info"
+      ]
     },
     "@timestamp": "2020-01-02T13:36:37.951568Z",
     "action": {

--- a/Azure/azure-ad/tests/add_member_to_group_2.json
+++ b/Azure/azure-ad/tests/add_member_to_group_2.json
@@ -15,7 +15,10 @@
       "category": [
         "iam"
       ],
-      "outcome": "success"
+      "outcome": "success",
+      "type": [
+        "info"
+      ]
     },
     "@timestamp": "2025-01-29T17:07:02.586395Z",
     "action": {

--- a/Azure/azure-ad/tests/add_service_principal_failure.json
+++ b/Azure/azure-ad/tests/add_service_principal_failure.json
@@ -10,7 +10,10 @@
         "iam"
       ],
       "outcome": "failure",
-      "reason": "Microsoft.Online.Workflows.SpnValidationException"
+      "reason": "Microsoft.Online.Workflows.SpnValidationException",
+      "type": [
+        "info"
+      ]
     },
     "@timestamp": "2019-06-24T09:18:23.586020Z",
     "action": {

--- a/Azure/azure-ad/tests/add_user.json
+++ b/Azure/azure-ad/tests/add_user.json
@@ -9,7 +9,10 @@
       "category": [
         "iam"
       ],
-      "outcome": "success"
+      "outcome": "success",
+      "type": [
+        "info"
+      ]
     },
     "@timestamp": "2019-06-24T09:29:28.624272Z",
     "action": {

--- a/Azure/azure-ad/tests/app_role.json
+++ b/Azure/azure-ad/tests/app_role.json
@@ -9,7 +9,10 @@
       "category": [
         "iam"
       ],
-      "outcome": "success"
+      "outcome": "success",
+      "type": [
+        "info"
+      ]
     },
     "@timestamp": "2025-10-27T10:15:15.844264Z",
     "action": {

--- a/Azure/azure-ad/tests/change_password.json
+++ b/Azure/azure-ad/tests/change_password.json
@@ -16,7 +16,10 @@
         "iam"
       ],
       "outcome": "failure",
-      "reason": "On-premises operation result: ChangeSuccess. Cloud operation result: Unknown"
+      "reason": "On-premises operation result: ChangeSuccess. Cloud operation result: Unknown",
+      "type": [
+        "info"
+      ]
     },
     "@timestamp": "2026-03-01T15:06:06.036330Z",
     "action": {

--- a/Azure/azure-ad/tests/change_user_password.json
+++ b/Azure/azure-ad/tests/change_user_password.json
@@ -9,7 +9,10 @@
       "category": [
         "iam"
       ],
-      "outcome": "success"
+      "outcome": "success",
+      "type": [
+        "info"
+      ]
     },
     "@timestamp": "2019-06-24T09:32:07.463722Z",
     "action": {

--- a/Azure/azure-ad/tests/graph_activity.json
+++ b/Azure/azure-ad/tests/graph_activity.json
@@ -8,6 +8,9 @@
       "action": "Microsoft Graph Activity",
       "category": [
         "iam"
+      ],
+      "type": [
+        "info"
       ]
     },
     "@timestamp": "2025-02-18T10:25:12.277914Z",

--- a/Azure/azure-ad/tests/graph_activity_1.json
+++ b/Azure/azure-ad/tests/graph_activity_1.json
@@ -8,6 +8,9 @@
       "action": "Microsoft Graph Activity",
       "category": [
         "iam"
+      ],
+      "type": [
+        "info"
       ]
     },
     "@timestamp": "2025-02-18T10:25:12.277914Z",

--- a/Azure/azure-ad/tests/graph_activity_2.json
+++ b/Azure/azure-ad/tests/graph_activity_2.json
@@ -14,6 +14,9 @@
       "action": "Microsoft Graph Activity",
       "category": [
         "iam"
+      ],
+      "type": [
+        "info"
       ]
     },
     "@timestamp": "2025-10-02T08:56:25.071773Z",

--- a/Azure/azure-ad/tests/graph_activity_3.json
+++ b/Azure/azure-ad/tests/graph_activity_3.json
@@ -14,6 +14,9 @@
       "action": "Microsoft Graph Activity",
       "category": [
         "iam"
+      ],
+      "type": [
+        "info"
       ]
     },
     "@timestamp": "2026-04-21T22:02:48.864439Z",

--- a/Azure/azure-ad/tests/graph_activity_4.json
+++ b/Azure/azure-ad/tests/graph_activity_4.json
@@ -14,6 +14,9 @@
       "action": "Microsoft Graph Activity",
       "category": [
         "iam"
+      ],
+      "type": [
+        "info"
       ]
     },
     "@timestamp": "2026-04-21T22:02:48.864439Z",

--- a/Azure/azure-ad/tests/recover_local_admin_password.json
+++ b/Azure/azure-ad/tests/recover_local_admin_password.json
@@ -9,7 +9,10 @@
       "category": [
         "iam"
       ],
-      "outcome": "success"
+      "outcome": "success",
+      "type": [
+        "info"
+      ]
     },
     "@timestamp": "2025-05-07T01:42:40.282820Z",
     "action": {

--- a/Azure/azure-ad/tests/remove_domain.json
+++ b/Azure/azure-ad/tests/remove_domain.json
@@ -9,7 +9,10 @@
       "category": [
         "iam"
       ],
-      "outcome": "success"
+      "outcome": "success",
+      "type": [
+        "info"
+      ]
     },
     "@timestamp": "2019-06-24T09:21:50.041890Z",
     "action": {

--- a/Azure/azure-ad/tests/remove_member_from_group.json
+++ b/Azure/azure-ad/tests/remove_member_from_group.json
@@ -15,7 +15,10 @@
       "category": [
         "iam"
       ],
-      "outcome": "success"
+      "outcome": "success",
+      "type": [
+        "info"
+      ]
     },
     "@timestamp": "2025-01-29T16:53:43.276443Z",
     "action": {

--- a/Azure/azure-ad/tests/sign-in_activity7.json
+++ b/Azure/azure-ad/tests/sign-in_activity7.json
@@ -8,6 +8,9 @@
       "action": "Sign-in activity",
       "category": [
         "iam"
+      ],
+      "type": [
+        "info"
       ]
     },
     "@timestamp": "2025-10-14T07:33:50.149897Z",

--- a/Azure/azure-ad/tests/test_metric.json
+++ b/Azure/azure-ad/tests/test_metric.json
@@ -1,0 +1,22 @@
+{
+  "input": {
+    "message": "{\"count\":5,\"total\":599,\"minimum\":80,\"maximum\":131,\"average\":119.8,\"resourceId\":\"/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000000/RESOURCEGROUPS/MyRessourceGroup/PROVIDERS/MICROSOFT.EVENTHUB/NAMESPACES/Namespace\",\"time\":\"2026-07-07T07:25:00.0000000Z\",\"metricName\":\"IncomingRequests\",\"timeGrain\":\"PT1M\"}\n",
+    "sekoiaio": {
+      "intake": {
+        "dialect": "Microsoft Entra ID / Azure AD",
+        "dialect_uuid": "19cd2ed6-f90c-47f7-a46b-974354a107bb"
+      }
+    }
+  },
+  "expected": {
+    "message": "{\"count\":5,\"total\":599,\"minimum\":80,\"maximum\":131,\"average\":119.8,\"resourceId\":\"/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000000/RESOURCEGROUPS/MyRessourceGroup/PROVIDERS/MICROSOFT.EVENTHUB/NAMESPACES/Namespace\",\"time\":\"2026-07-07T07:25:00.0000000Z\",\"metricName\":\"IncomingRequests\",\"timeGrain\":\"PT1M\"}\n",
+    "@timestamp": "2026-07-07T07:25:00Z",
+    "azuread": {
+      "resourceId": "/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000000/RESOURCEGROUPS/MyRessourceGroup/PROVIDERS/MICROSOFT.EVENTHUB/NAMESPACES/Namespace"
+    },
+    "service": {
+      "name": "Azure Active Directory",
+      "type": "ldap"
+    }
+  }
+}

--- a/Azure/azure-ad/tests/test_metric.json
+++ b/Azure/azure-ad/tests/test_metric.json
@@ -10,6 +10,14 @@
   },
   "expected": {
     "message": "{\"count\":5,\"total\":599,\"minimum\":80,\"maximum\":131,\"average\":119.8,\"resourceId\":\"/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000000/RESOURCEGROUPS/MyRessourceGroup/PROVIDERS/MICROSOFT.EVENTHUB/NAMESPACES/Namespace\",\"time\":\"2026-07-07T07:25:00.0000000Z\",\"metricName\":\"IncomingRequests\",\"timeGrain\":\"PT1M\"}\n",
+    "event": {
+      "category": [
+        "iam"
+      ],
+      "type": [
+        "info"
+      ]
+    },
     "@timestamp": "2026-07-07T07:25:00Z",
     "azuread": {
       "resourceId": "/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000000/RESOURCEGROUPS/MyRessourceGroup/PROVIDERS/MICROSOFT.EVENTHUB/NAMESPACES/Namespace"

--- a/Azure/azure-ad/tests/update_policy.json
+++ b/Azure/azure-ad/tests/update_policy.json
@@ -15,7 +15,10 @@
       "category": [
         "iam"
       ],
-      "outcome": "success"
+      "outcome": "success",
+      "type": [
+        "info"
+      ]
     },
     "@timestamp": "2026-04-16T07:23:27.586150Z",
     "action": {

--- a/Azure/azure-ad/tests/update_ststoken.json
+++ b/Azure/azure-ad/tests/update_ststoken.json
@@ -9,7 +9,10 @@
       "category": [
         "iam"
       ],
-      "outcome": "success"
+      "outcome": "success",
+      "type": [
+        "info"
+      ]
     },
     "@timestamp": "2019-06-24T09:32:07.463722Z",
     "action": {


### PR DESCRIPTION
## Summary by Sourcery

Adjust Azure AD ingest parsing for event timestamps and default event metadata.

New Features:
- Set default event.category and event.type values for Azure AD events.

Bug Fixes:
- Correct date parsing by separating parsing of message.time and properties.createdDateTime fields.