### PR TITLE
feature/microsoft_365_defender_add_verdict_fields

### DIFF
--- a/Microsoft/microsoft-365-defender/CHANGELOG.md
+++ b/Microsoft/microsoft-365-defender/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2026-07-15
+## [Unreleased]
+
+## 2026-07-20 - 1.0.6
 
 ### Added
 

--- a/Microsoft/microsoft-365-defender/CHANGELOG.md
+++ b/Microsoft/microsoft-365-defender/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased] - 2026-07-15
+
+### Added
+
+- Parse custom fields:
+    - `microsoft.defender.threat.last_verdict`
+    - `microsoft.defender.threat.verdict`
 
 ## 2025-09-01 - 1.0.5
 

--- a/Microsoft/microsoft-365-defender/_meta/fields.yml
+++ b/Microsoft/microsoft-365-defender/_meta/fields.yml
@@ -1221,6 +1221,11 @@ microsoft.defender.threat.last_remediation_state:
   name: microsoft.defender.threat.last_remediation_state
   type: keyword
 
+microsoft.defender.threat.last_verdict:
+  description: The final consolidated threat verdict for the evidence
+  name: microsoft.defender.threat.last_verdict
+  type: keyword
+
 microsoft.defender.threat.names:
   description: Detection name for malware or other threats found
   name: microsoft.defender.threat.names
@@ -1257,6 +1262,11 @@ microsoft.defender.threat.types:
 microsoft.defender.threat.urls:
   description: URLs
   name: microsoft.defender.threat.urls
+  type: keyword
+
+microsoft.defender.threat.verdict:
+  description: Threat verdict from the last ThreatAnalysisSummary entry for the evidence
+  name: microsoft.defender.threat.verdict
   type: keyword
 
 microsoft.defender.url_location:

--- a/Microsoft/microsoft-365-defender/_meta/smart-descriptions.json
+++ b/Microsoft/microsoft-365-defender/_meta/smart-descriptions.json
@@ -818,5 +818,23 @@
         "field": "action.properties.FailedOperationsCount"
       }
     ]
+  },
+  {
+    "value": "Alert evidence verdict: {microsoft.defender.threat.last_verdict} for {microsoft.defender.entity.type} ({microsoft.defender.alert.title})",
+    "conditions": [
+      {
+        "field": "event.dataset",
+        "value": "alert_evidence"
+      },
+      {
+        "field": "microsoft.defender.threat.last_verdict"
+      },
+      {
+        "field": "microsoft.defender.entity.type"
+      },
+      {
+        "field": "microsoft.defender.alert.title"
+      }
+    ]
   }
 ]

--- a/Microsoft/microsoft-365-defender/ingest/parser.yml
+++ b/Microsoft/microsoft-365-defender/ingest/parser.yml
@@ -472,6 +472,7 @@ stages:
           microsoft.defender.threat.severity: "{{json_event.message.properties.Severity}}"
           microsoft.defender.threat.detection_status: "{{parse_additional_fields.fields.DetectionStatus}}"
           microsoft.defender.threat.suspicion_level: "{{parse_additional_fields.fields.SuspicionLevel}}"
+          microsoft.defender.threat.last_verdict: "{{parse_additional_fields.fields.LastVerdict}}"
 
           microsoft.defender.threat.host.remediation_providers: "{{parse_additional_fields.fields.Host.RemediationProviders}}"
           microsoft.defender.threat.host.last_remediation_state: "{{parse_additional_fields.fields.Host.LastRemediationState}}"
@@ -510,6 +511,10 @@ stages:
       - set:
           microsoft.defender.threat.intelligence: "{{parse_additional_fields.fields.ThreatIntelligence}}"
         filter: '{{parse_additional_fields.fields.get("ThreatIntelligence") != None}}'
+
+      - set:
+          microsoft.defender.threat.verdict: "{{parse_additional_fields.fields.ThreatAnalysisSummary[-1].Verdict}}"
+        filter: '{{parse_additional_fields.fields.get("ThreatAnalysisSummary") | length > 0}}'
 
       - set:
           threat.technique.name: "{{parse_attack_techniques.techniques}}"

--- a/Microsoft/microsoft-365-defender/tests/test_alert_evidence.json
+++ b/Microsoft/microsoft-365-defender/tests/test_alert_evidence.json
@@ -46,6 +46,7 @@
         "threat": {
           "detection_status": "Detected",
           "last_remediation_state": "Active",
+          "last_verdict": "Suspicious",
           "remediation_providers": [
             {
               "RemediationDate": "2023-09-28T16:16:56.6015218Z",
@@ -54,7 +55,8 @@
             }
           ],
           "severity": "Low",
-          "suspicion_level": "Suspicious"
+          "suspicion_level": "Suspicious",
+          "verdict": "Suspicious"
         }
       }
     },

--- a/Microsoft/microsoft-365-defender/tests/test_alert_evidence_5.json
+++ b/Microsoft/microsoft-365-defender/tests/test_alert_evidence_5.json
@@ -56,6 +56,7 @@
             ]
           },
           "last_remediation_state": "Active",
+          "last_verdict": "Suspicious",
           "remediation_providers": [
             {
               "RemediationDate": "2026-01-13T09:40:15.4348077Z",
@@ -64,7 +65,8 @@
             }
           ],
           "severity": "Low",
-          "suspicion_level": "Suspicious"
+          "suspicion_level": "Suspicious",
+          "verdict": "Suspicious"
         }
       }
     },

--- a/Microsoft/microsoft-365-defender/tests/test_alert_evidence_machine_remediation.json
+++ b/Microsoft/microsoft-365-defender/tests/test_alert_evidence_machine_remediation.json
@@ -50,6 +50,7 @@
         "threat": {
           "detection_status": "Detected",
           "last_remediation_state": "Active",
+          "last_verdict": "Suspicious",
           "remediation_providers": [
             {
               "RemediationDate": "2026-01-13T09:40:40.9701986Z",
@@ -58,7 +59,8 @@
             }
           ],
           "severity": "Low",
-          "suspicion_level": "Suspicious"
+          "suspicion_level": "Suspicious",
+          "verdict": "Suspicious"
         }
       }
     },

--- a/Microsoft/microsoft-365-defender/tests/test_alert_evidence_machine_suspicious_behavior.json
+++ b/Microsoft/microsoft-365-defender/tests/test_alert_evidence_machine_suspicious_behavior.json
@@ -50,6 +50,7 @@
         "threat": {
           "detection_status": "Detected",
           "last_remediation_state": "Active",
+          "last_verdict": "Suspicious",
           "remediation_providers": [
             {
               "RemediationDate": "2026-01-13T09:30:47.7219848Z",
@@ -58,7 +59,8 @@
             }
           ],
           "severity": "Low",
-          "suspicion_level": "Suspicious"
+          "suspicion_level": "Suspicious",
+          "verdict": "Suspicious"
         }
       }
     },

--- a/Microsoft/microsoft-365-defender/tests/test_alert_evidence_mail_cluster_verdict.json
+++ b/Microsoft/microsoft-365-defender/tests/test_alert_evidence_mail_cluster_verdict.json
@@ -1,0 +1,63 @@
+{
+  "input": {
+    "message": "{\"time\": \"2026-07-06T07:03:33.9221162Z\", \"tenantId\": \"11111111-1111-1111-1111-111111111111\", \"operationName\": \"Publish\", \"category\": \"AdvancedHunting-AlertEvidence\", \"_TimeReceivedBySvc\": \"2026-07-06T07:03:33.8890000Z\", \"properties\": {\"Timestamp\": \"2026-07-06T06:56:18.2047135Z\", \"AlertId\": \"da33333333-3333-3333-3333-333333333333\", \"EntityType\": \"MailCluster\", \"EvidenceRole\": \"Related\", \"SHA1\": null, \"SHA256\": null, \"RemoteIP\": null, \"LocalIP\": null, \"RemoteUrl\": null, \"AccountName\": null, \"AccountDomain\": null, \"AccountSid\": null, \"AccountObjectId\": null, \"DeviceId\": null, \"ThreatFamily\": null, \"EvidenceDirection\": null, \"AdditionalFields\": \"{\\\"CountByThreatType\\\": {\\\"Spam\\\": 0, \\\"Phish\\\": 0, \\\"HighConfPhish\\\": 0, \\\"Malware\\\": 0}, \\\"CountByProtectionStatus\\\": {\\\"Delivered\\\": 44}, \\\"CountByDeliveryLocation\\\": {\\\"Inbox\\\": 43, \\\"External\\\": 1}, \\\"Query\\\": \\\"((BodyFingerprintBin1:\\\\\\\"1234567890\\\\\\\") AND (SenderIp:\\\\\\\"198.51.100.72\\\\\\\")) AND (ContentType:\\\\\\\"1\\\\\\\") AND NOT(XmiInfoTenantPolicyFinalVerdictSource:PhishEdu) AND NOT(XmiInfoTenantPolicyFinalVerdictSource:SecOps)\\\", \\\"QueryTime\\\": \\\"2026-07-06T07:00:00Z\\\", \\\"MailCount\\\": 44, \\\"IsVolumeAnomaly\\\": true, \\\"Source\\\": \\\"OATP\\\", \\\"ClusterSourceIdentifier\\\": \\\"BodyFingerprintBin1 == 1234567890 and SenderIp == \\\\\\\"198.51.100.72\\\\\\\"\\\", \\\"ClusterSourceType\\\": \\\"MailSimilarity\\\", \\\"ClusterQueryStartTime\\\": \\\"2026-06-16T00:00:00Z\\\", \\\"ClusterQueryEndTime\\\": \\\"2026-07-06T07:00:00Z\\\", \\\"ClusterGroup\\\": \\\"BodyFingerprintBin1,SenderIp\\\", \\\"ThreatIntelligence\\\": [{\\\"ProviderName\\\": \\\"OATP\\\", \\\"ThreatType\\\": \\\"EmailVolumeAnomaly\\\", \\\"ThreatName\\\": \\\"EmailVolumeAnomaly\\\"}], \\\"ThreatAnalysisSummary\\\": [{\\\"AnalyzersResult\\\": [{\\\"ThreatIntelligence\\\": {\\\"ProviderName\\\": \\\"OATP\\\", \\\"ThreatType\\\": \\\"EmailVolumeAnomaly\\\", \\\"ThreatName\\\": \\\"EmailVolumeAnomaly\\\"}, \\\"EngineReport\\\": \\\"\\\", \\\"Verdict\\\": \\\"NoThreatsFound\\\", \\\"AnalysisDate\\\": \\\"0001-01-01T00:00:00\\\"}], \\\"Verdict\\\": \\\"NoThreatsFound\\\", \\\"AnalysisDate\\\": \\\"2026-07-06T07:03:30.6394902Z\\\"}], \\\"LastVerdict\\\": \\\"NoThreatsFound\\\", \\\"EntitySources\\\": [\\\"Automation\\\"], \\\"Type\\\": \\\"mailCluster\\\", \\\"ClusterBy\\\": \\\"BodyFingerprintBin1;SenderIp;ContentType;XmiInfoTenantPolicyFinalVerdictSource\\\", \\\"ClusterByValue\\\": \\\"1234567890;198.51.100.72;1;PhishEdu,SecOps\\\", \\\"QueryStartTime\\\": \\\"2026-07-06T07:00:00Z\\\", \\\"Urn\\\": \\\"urn:MailClusterEntityModel:00000000000000000000000000000000\\\", \\\"FirstSeen\\\": \\\"0001-01-01T00:00:00\\\", \\\"Role\\\": 1, \\\"MergeByKey\\\": \\\"AAAAAAAAAAAAAAAAAAAAAAAAAAAA=\\\", \\\"MergeByKeyHex\\\": \\\"0000000000000000000000000000000000000000\\\"}\", \"MachineGroup\": null, \"NetworkMessageId\": null, \"ServiceSource\": \"Microsoft Defender for Office 365\", \"FileName\": null, \"FolderPath\": null, \"ProcessCommandLine\": null, \"EmailSubject\": null, \"ApplicationId\": null, \"Application\": null, \"DeviceName\": null, \"FileSize\": null, \"RegistryKey\": null, \"RegistryValueName\": null, \"RegistryValueData\": null, \"AccountUpn\": null, \"OAuthApplicationId\": null, \"Categories\": \"[\\\"InitialAccess\\\"]\", \"Title\": \"Email reported by user as malware or phish\", \"AttackTechniques\": \"[\\\"Phishing (T1566)\\\"]\", \"DetectionSource\": \"Microsoft Defender for Office 365\", \"Severity\": \"Low\", \"CloudResource\": null, \"CloudPlatform\": \"\", \"ResourceType\": null, \"ResourceID\": null, \"SubscriptionId\": \"\"}, \"Tenant\": \"DefaultTenant\"}"
+  },
+  "expected": {
+    "message": "{\"time\": \"2026-07-06T07:03:33.9221162Z\", \"tenantId\": \"11111111-1111-1111-1111-111111111111\", \"operationName\": \"Publish\", \"category\": \"AdvancedHunting-AlertEvidence\", \"_TimeReceivedBySvc\": \"2026-07-06T07:03:33.8890000Z\", \"properties\": {\"Timestamp\": \"2026-07-06T06:56:18.2047135Z\", \"AlertId\": \"da33333333-3333-3333-3333-333333333333\", \"EntityType\": \"MailCluster\", \"EvidenceRole\": \"Related\", \"SHA1\": null, \"SHA256\": null, \"RemoteIP\": null, \"LocalIP\": null, \"RemoteUrl\": null, \"AccountName\": null, \"AccountDomain\": null, \"AccountSid\": null, \"AccountObjectId\": null, \"DeviceId\": null, \"ThreatFamily\": null, \"EvidenceDirection\": null, \"AdditionalFields\": \"{\\\"CountByThreatType\\\": {\\\"Spam\\\": 0, \\\"Phish\\\": 0, \\\"HighConfPhish\\\": 0, \\\"Malware\\\": 0}, \\\"CountByProtectionStatus\\\": {\\\"Delivered\\\": 44}, \\\"CountByDeliveryLocation\\\": {\\\"Inbox\\\": 43, \\\"External\\\": 1}, \\\"Query\\\": \\\"((BodyFingerprintBin1:\\\\\\\"1234567890\\\\\\\") AND (SenderIp:\\\\\\\"198.51.100.72\\\\\\\")) AND (ContentType:\\\\\\\"1\\\\\\\") AND NOT(XmiInfoTenantPolicyFinalVerdictSource:PhishEdu) AND NOT(XmiInfoTenantPolicyFinalVerdictSource:SecOps)\\\", \\\"QueryTime\\\": \\\"2026-07-06T07:00:00Z\\\", \\\"MailCount\\\": 44, \\\"IsVolumeAnomaly\\\": true, \\\"Source\\\": \\\"OATP\\\", \\\"ClusterSourceIdentifier\\\": \\\"BodyFingerprintBin1 == 1234567890 and SenderIp == \\\\\\\"198.51.100.72\\\\\\\"\\\", \\\"ClusterSourceType\\\": \\\"MailSimilarity\\\", \\\"ClusterQueryStartTime\\\": \\\"2026-06-16T00:00:00Z\\\", \\\"ClusterQueryEndTime\\\": \\\"2026-07-06T07:00:00Z\\\", \\\"ClusterGroup\\\": \\\"BodyFingerprintBin1,SenderIp\\\", \\\"ThreatIntelligence\\\": [{\\\"ProviderName\\\": \\\"OATP\\\", \\\"ThreatType\\\": \\\"EmailVolumeAnomaly\\\", \\\"ThreatName\\\": \\\"EmailVolumeAnomaly\\\"}], \\\"ThreatAnalysisSummary\\\": [{\\\"AnalyzersResult\\\": [{\\\"ThreatIntelligence\\\": {\\\"ProviderName\\\": \\\"OATP\\\", \\\"ThreatType\\\": \\\"EmailVolumeAnomaly\\\", \\\"ThreatName\\\": \\\"EmailVolumeAnomaly\\\"}, \\\"EngineReport\\\": \\\"\\\", \\\"Verdict\\\": \\\"NoThreatsFound\\\", \\\"AnalysisDate\\\": \\\"0001-01-01T00:00:00\\\"}], \\\"Verdict\\\": \\\"NoThreatsFound\\\", \\\"AnalysisDate\\\": \\\"2026-07-06T07:03:30.6394902Z\\\"}], \\\"LastVerdict\\\": \\\"NoThreatsFound\\\", \\\"EntitySources\\\": [\\\"Automation\\\"], \\\"Type\\\": \\\"mailCluster\\\", \\\"ClusterBy\\\": \\\"BodyFingerprintBin1;SenderIp;ContentType;XmiInfoTenantPolicyFinalVerdictSource\\\", \\\"ClusterByValue\\\": \\\"1234567890;198.51.100.72;1;PhishEdu,SecOps\\\", \\\"QueryStartTime\\\": \\\"2026-07-06T07:00:00Z\\\", \\\"Urn\\\": \\\"urn:MailClusterEntityModel:00000000000000000000000000000000\\\", \\\"FirstSeen\\\": \\\"0001-01-01T00:00:00\\\", \\\"Role\\\": 1, \\\"MergeByKey\\\": \\\"AAAAAAAAAAAAAAAAAAAAAAAAAAAA=\\\", \\\"MergeByKeyHex\\\": \\\"0000000000000000000000000000000000000000\\\"}\", \"MachineGroup\": null, \"NetworkMessageId\": null, \"ServiceSource\": \"Microsoft Defender for Office 365\", \"FileName\": null, \"FolderPath\": null, \"ProcessCommandLine\": null, \"EmailSubject\": null, \"ApplicationId\": null, \"Application\": null, \"DeviceName\": null, \"FileSize\": null, \"RegistryKey\": null, \"RegistryValueName\": null, \"RegistryValueData\": null, \"AccountUpn\": null, \"OAuthApplicationId\": null, \"Categories\": \"[\\\"InitialAccess\\\"]\", \"Title\": \"Email reported by user as malware or phish\", \"AttackTechniques\": \"[\\\"Phishing (T1566)\\\"]\", \"DetectionSource\": \"Microsoft Defender for Office 365\", \"Severity\": \"Low\", \"CloudResource\": null, \"CloudPlatform\": \"\", \"ResourceType\": null, \"ResourceID\": null, \"SubscriptionId\": \"\"}, \"Tenant\": \"DefaultTenant\"}",
+    "event": {
+      "category": [
+        "threat"
+      ],
+      "dataset": "alert_evidence",
+      "kind": "enrichment",
+      "type": [
+        "indicator"
+      ]
+    },
+    "@timestamp": "2026-07-06T06:56:18.204713Z",
+    "action": {
+      "name": "Publish",
+      "properties": {
+        "ServiceSource": "Microsoft Defender for Office 365"
+      }
+    },
+    "microsoft": {
+      "defender": {
+        "alert": {
+          "id": "da33333333-3333-3333-3333-333333333333",
+          "severity": "Low",
+          "title": "Email reported by user as malware or phish"
+        },
+        "entity": {
+          "type": "MailCluster"
+        },
+        "evidence": {
+          "role": "Related"
+        },
+        "threat": {
+          "intelligence": [
+            {
+              "ProviderName": "OATP",
+              "ThreatName": "EmailVolumeAnomaly",
+              "ThreatType": "EmailVolumeAnomaly"
+            }
+          ],
+          "last_verdict": "NoThreatsFound",
+          "severity": "Low",
+          "verdict": "NoThreatsFound"
+        }
+      }
+    },
+    "service": {
+      "name": "Microsoft Defender for Office 365",
+      "type": "Microsoft Defender for Office 365"
+    },
+    "threat": {
+      "technique": {
+        "name": [
+          "Phishing (T1566)"
+        ]
+      }
+    }
+  }
+}

--- a/Microsoft/microsoft-365-defender/tests/test_alert_evidence_mail_phish.json
+++ b/Microsoft/microsoft-365-defender/tests/test_alert_evidence_mail_phish.json
@@ -71,6 +71,7 @@
             }
           ],
           "last_remediation_state": "Active",
+          "last_verdict": "Malicious",
           "names": [
             "EmailVolumeAnomaly",
             "EmailVolumeAnomaly",
@@ -90,7 +91,8 @@
             "https://example.com/malicious1",
             "https://example.com/malicious2",
             "https://example.com/redir"
-          ]
+          ],
+          "verdict": "Malicious"
         }
       }
     },

--- a/Microsoft/microsoft-365-defender/tests/test_alert_evidence_process_blocked.json
+++ b/Microsoft/microsoft-365-defender/tests/test_alert_evidence_process_blocked.json
@@ -52,6 +52,7 @@
         "threat": {
           "detection_status": "Blocked",
           "last_remediation_state": "Blocked",
+          "last_verdict": "Malicious",
           "remediation_providers": [
             {
               "RemediationDate": "2026-01-13T09:28:16.3142113Z",
@@ -60,7 +61,8 @@
             }
           ],
           "severity": "Low",
-          "suspicion_level": "Suspicious"
+          "suspicion_level": "Suspicious",
+          "verdict": "Malicious"
         }
       }
     },

--- a/Microsoft/microsoft-365-defender/tests/test_alert_evidence_remediation.json
+++ b/Microsoft/microsoft-365-defender/tests/test_alert_evidence_remediation.json
@@ -52,6 +52,7 @@
         "threat": {
           "detection_status": "Detected",
           "last_remediation_state": "Active",
+          "last_verdict": "Suspicious",
           "remediation_providers": [
             {
               "RemediationDate": "2026-01-13T09:40:40.9701986Z",
@@ -60,7 +61,8 @@
             }
           ],
           "severity": "Low",
-          "suspicion_level": "Suspicious"
+          "suspicion_level": "Suspicious",
+          "verdict": "Suspicious"
         }
       }
     },

--- a/Microsoft/microsoft-365-defender/tests/test_alert_evidence_user_remediation.json
+++ b/Microsoft/microsoft-365-defender/tests/test_alert_evidence_user_remediation.json
@@ -55,6 +55,7 @@
             ]
           },
           "last_remediation_state": "Active",
+          "last_verdict": "Suspicious",
           "remediation_providers": [
             {
               "RemediationDate": "2026-01-13T09:40:40.9701986Z",
@@ -63,7 +64,8 @@
             }
           ],
           "severity": "Low",
-          "suspicion_level": "Suspicious"
+          "suspicion_level": "Suspicious",
+          "verdict": "Suspicious"
         }
       }
     },

--- a/Microsoft/microsoft-365-defender/tests/test_alert_evidence_user_suspicious_behavior.json
+++ b/Microsoft/microsoft-365-defender/tests/test_alert_evidence_user_suspicious_behavior.json
@@ -55,6 +55,7 @@
             ]
           },
           "last_remediation_state": "Active",
+          "last_verdict": "Suspicious",
           "remediation_providers": [
             {
               "RemediationDate": "2026-01-13T09:30:47.7219848Z",
@@ -63,7 +64,8 @@
             }
           ],
           "severity": "Low",
-          "suspicion_level": "Suspicious"
+          "suspicion_level": "Suspicious",
+          "verdict": "Suspicious"
         }
       }
     },

--- a/Microsoft/microsoft-365-defender/tests/test_alert_evidence_wscript_remediation.json
+++ b/Microsoft/microsoft-365-defender/tests/test_alert_evidence_wscript_remediation.json
@@ -52,6 +52,7 @@
         "threat": {
           "detection_status": "Detected",
           "last_remediation_state": "Active",
+          "last_verdict": "Suspicious",
           "remediation_providers": [
             {
               "RemediationDate": "2026-01-13T09:40:40.9701986Z",
@@ -60,7 +61,8 @@
             }
           ],
           "severity": "Low",
-          "suspicion_level": "Suspicious"
+          "suspicion_level": "Suspicious",
+          "verdict": "Suspicious"
         }
       }
     },


### PR DESCRIPTION
## Description

Fixes https://github.com/SekoiaLab/integration/issues/1782

### Added

- Parse custom fields:
    - `microsoft.defender.threat.last_verdict`
    - `microsoft.defender.threat.verdict`

## Type of Change

- [ ] New intake format
- [X] Update to existing intake format
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (please describe):

## Affected Intake Formats

- Vendor/product: Microsoft / Microsoft 365 Defender

## Checklist

<!-- Ensure all requirements are met before submitting -->

### 🔒 CRITICAL - Security Requirements (MUST BE VERIFIED FIRST)

- [ ] **No real email addresses** in test files (use: user@example.com, test@example.org)
- [ ] **No real passwords or API keys** (use: "P@ssw0rd!", "xxxxxxxxxxxx", "FAKE_TOKEN_123")
- [ ] **No real IP addresses** (use TEST-NET ranges: 192.0.2.x, 198.51.100.x, 203.0.113.x)
- [ ] **No real phone numbers** (use: +1-555-0100 or similar test numbers)
- [ ] **No real names or PII** (use: "John Doe", "Jane Smith", "User123")
- [ ] **No real company/organization names** in test data (unless public vendors)
- [ ] **No real usernames, hostnames, or domain names** (use: user1, host.example.com, test.corp)
- [ ] All test data has been anonymized and verified

### Required for All PRs

- [ ] Code has been linted
    - [ ] with the linter for manifest, smart-descriptions, and test files (`uv run python linter.py check --changes` in utils/)
    - [ ] with Prettier for the parser code files (`npx prettier --write <module>/<format>/ingest/parser.yml`)
- [ ] All CI/CD checks pass
- [ ] Changes follow the contribution guidelines in `CONTRIBUTING.md`

### Required for New/Updated Intake Formats

- [ ] Clear descriptions provided for modules and formats
- [ ] Logo files included for new modules/formats
- [ ] Parser test coverage is at least 75%
- [ ] At least one smart-description is provided
- [ ] README.md updated (if applicable)
- [ ] Taxonomy mappings are correct and documented
- [ ] Test cases cover edge cases and error handling

### Testing

- [ ] Local tests pass (`uv run pytest` in utils/)
- [ ] Sample data is representative and **completely anonymized**
- [ ] **No sensitive information** (PII, credentials, real IPs, real emails) in test files
- [ ] Test data uses example.com/example.org domains and TEST-NET IP ranges
- [ ] Parser handles malformed data gracefully

### Documentation

- [ ] Code changes are documented
- [ ] Smart-descriptions are clear and informative
- [ ] Field mappings are explained

## Additional Notes

<!-- Add any additional context, screenshots, or information that would help reviewers -->

## Related Issues

<!-- Link any related issues using #issue_number -->

Closes #

## Summary by Sourcery

Add verdict-related threat fields to the Microsoft 365 Defender intake format and update supporting metadata and tests.

New Features:
- Capture the final consolidated threat verdict in microsoft.defender.threat.last_verdict.
- Capture the latest threat verdict from ThreatAnalysisSummary in microsoft.defender.threat.verdict.

Enhancements:
- Document the new verdict fields and release date in the Microsoft 365 Defender changelog.
- Extend field metadata and smart descriptions to cover the new verdict fields.

Tests:
- Update existing alert evidence tests and add a new mail cluster verdict test case to validate parsing of the new verdict fields.