### PR TITLE
VMWare vCenter - parse service name

### DIFF
--- a/VMWare/vmware-vcenter/CHANGELOG.md
+++ b/VMWare/vmware-vcenter/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2026-08-14 - 1.0.1
+
+### Added
+
+- Parse new ECS fields:
+  - `service.name`
+
 ## 2023-10-02 - 1.0.0
 
 ### Changed

--- a/VMWare/vmware-vcenter/_meta/smart-descriptions.json
+++ b/VMWare/vmware-vcenter/_meta/smart-descriptions.json
@@ -1,5 +1,13 @@
 [
   {
+    "value": "Core service registration detected for {service.name}",
+    "conditions": [
+      {
+        "field": "service.name"
+      }
+    ]
+  },
+  {
     "value": "User {user.name} failed to log from {source.address}",
     "conditions": [
       {

--- a/VMWare/vmware-vcenter/ingest/parser.yml
+++ b/VMWare/vmware-vcenter/ingest/parser.yml
@@ -6,7 +6,7 @@ pipeline:
       properties:
         input_field: "{{original.message}}"
         output_field: message
-        pattern: "%{SESSION_TYPE_1}|%{SESSION_TYPE_2}|%{SESSION_TYPE_3}|%{SESSION_TYPE_4}|%{SESSION_TYPE_6}|%{CONNECTIONS}|%{FAULT}|%{FAULT_TYPE_2}|%{HTTP_LOGS_1}|%{HTTP_LOGS_4}|%{HTTP_LOGS_2}|%{HTTP_LOGS_3}|%{LOGIN}|%{OTHERS_EVENTS_TYPE_6}|%{OTHERS_EVENTS}|%{OTHERS_EVENTS_TYPE_2}|%{OTHERS_EVENTS_TYPE_3}|%{OTHERS_EVENTS_TYPE_5}|%{OTHERS_EVENTS_TYPE_7}|%{OTHERS_EVENTS_TYPE_7_1}|%{OTHERS_EVENTS_TYPE_8}|%{OTHERS_EVENTS_TYPE_9}|%{OTHERS_EVENTS_TYPE_10}|%{VLSI_API}|%{VIDM_HTTP}|%{VIDM_LOG}|%{VMCAD}|%{PERMISSION_TYPE_1}|%{PERMISSION_TYPE_2}|%{SESSION_COUNT}|%{OTHERS_EVENTS_TYPE_12}|%{TOMCAT_ACCESS}|%{DNSMASQ_QUERY}"
+        pattern: "%{SESSION_TYPE_1}|%{SESSION_TYPE_2}|%{SESSION_TYPE_3}|%{SESSION_TYPE_4}|%{SESSION_TYPE_6}|%{CONNECTIONS}|%{FAULT}|%{FAULT_TYPE_2}|%{HTTP_LOGS_1}|%{HTTP_LOGS_4}|%{HTTP_LOGS_2}|%{HTTP_LOGS_3}|%{LOGIN}|%{OTHERS_EVENTS_TYPE_6}|%{OTHERS_EVENTS}|%{OTHERS_EVENTS_TYPE_2}|%{OTHERS_EVENTS_TYPE_3}|%{OTHERS_EVENTS_TYPE_5}|%{OTHERS_EVENTS_TYPE_7}|%{OTHERS_EVENTS_TYPE_7_1}|%{OTHERS_EVENTS_TYPE_8}|%{OTHERS_EVENTS_TYPE_9}|%{OTHERS_EVENTS_TYPE_10}|%{VLSI_API}|%{VIDM_HTTP}|%{VIDM_LOG}|%{VMCAD}|%{PERMISSION_TYPE_1}|%{PERMISSION_TYPE_2}|%{SESSION_COUNT}|%{OTHERS_EVENTS_TYPE_12}|%{TOMCAT_ACCESS}|%{DNSMASQ_QUERY}|%{WCP_SERVICE}"
         custom_patterns:
           SESSION_TYPE_1: 'Event \[%{INT:id}\] \[1-1\] \[%{TIMESTAMP_ISO8601:timestamp}\] \[%{DATA:event_code}\] \[%{DATA:log_level}\] \[%{DATA:source_user_name}\] \[%{HOSTNAME:hostname}\] \[%{INT}] \[(?P<reason>Cannot login %{USERNAME:username}@%{IP:ip_address})\]'
           SESSION_TYPE_2: 'Event \[%{INT:id}\] \[1-1\] \[%{TIMESTAMP_ISO8601:timestamp}\] \[%{DATA:event_code}\] \[%{DATA:log_level}\] \[%{DATA}\] \[%{DATA}\] \[%{INT}\] \[(?P<reason>User %{USERNAME_WITH_DOMAIN} logged in as %{DATA})\]'
@@ -72,6 +72,9 @@ pipeline:
           # May 12 15:33:29 dnsmasq[2110]: query[A] example.com from 127.0.0.1
           DNSMASQ_QUERY: '%{SYSLOGTIMESTAMP:timestamp} dnsmasq\[%{DATA}\]: query\[%{DATA:dns_query_type}\] %{DATA:dns_requested_domain} from %{IP:source_ip}'
 
+          # 2026-07-10T12:55:22.446Z info wcp [controller/core_service_controller.go:689] [opID=CoreServiceController] Registering core service 'tkg.vsphere.vmware.com'
+          WCP_SERVICE: '%{TIMESTAMP_ISO8601:timestamp} %{DATA:log_level} wcp \[%{DATA}\] \[%{DATA:originator_info}\] (?<reason>%{DATA} service ''%{DATA:service_name}''%{DATA})'
+
   - name: parsed_json
     filter: '{{parsed_event.message.LOGIN != None and parsed_event.message.reason | re_match("^\\s*\\{.*\\}\\s*$")}}'
     external:
@@ -128,6 +131,7 @@ stages:
           file.path: "{{parsed_event.message.vmx_path}}"
           dns.question.name: "{{parsed_event.message.dns_requested_domain}}"
           dns.question.type: "{{parsed_event.message.dns_query_type}}"
+          service.name: "{{parsed_event.message.service_name}}"
           vmware_vcenter.network.port: "{{parsed_event.message.local_port1}}"
           vmware_vcenter.login_time: "{{parsed_event.message.login_time}}"
           vmware_vcenter.api_invocations: "{{parsed_event.message.api_invocations}}"

--- a/VMWare/vmware-vcenter/ingest/parser.yml
+++ b/VMWare/vmware-vcenter/ingest/parser.yml
@@ -73,7 +73,7 @@ pipeline:
           DNSMASQ_QUERY: '%{SYSLOGTIMESTAMP:timestamp} dnsmasq\[%{DATA}\]: query\[%{DATA:dns_query_type}\] %{DATA:dns_requested_domain} from %{IP:source_ip}'
 
           # 2026-07-10T12:55:22.446Z info wcp [controller/core_service_controller.go:689] [opID=CoreServiceController] Registering core service 'tkg.vsphere.vmware.com'
-          WCP_SERVICE: '%{TIMESTAMP_ISO8601:timestamp} %{DATA:log_level} wcp \[%{DATA}\] \[%{DATA:originator_info}\] (?<reason>%{DATA} service ''%{DATA:service_name}''%{DATA})'
+          WCP_SERVICE: '%{TIMESTAMP_ISO8601:timestamp} %{DATA:log_level} wcp \[%{DATA}\] \[%{DATA:originator_info}\] (?P<reason>%{DATA} service ''%{DATA:service_name}''%{DATA})'
 
   - name: parsed_json
     filter: '{{parsed_event.message.LOGIN != None and parsed_event.message.reason | re_match("^\\s*\\{.*\\}\\s*$")}}'

--- a/VMWare/vmware-vcenter/tests/test_task_event_with_domain.json
+++ b/VMWare/vmware-vcenter/tests/test_task_event_with_domain.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "Event [11111111] [1-1] [2026-05-26T12:44:30.423669Z] [vim.event.TaskEvent] [info] [EXAMPLE\\user1] [host1 - example] [11111111] [Task: Create virtual machine snapshot]"
+    "message": "Event [11111111] [1-1] [2026-05-26T12:44:30.423669Z] [vim.event.TaskEvent] [info] [EXAMPLE\\user1] [HOSTNAME] [11111111] [Task: Create virtual machine snapshot]"
   },
   "expected": {
-    "message": "Event [11111111] [1-1] [2026-05-26T12:44:30.423669Z] [vim.event.TaskEvent] [info] [EXAMPLE\\user1] [host1 - example] [11111111] [Task: Create virtual machine snapshot]",
+    "message": "Event [11111111] [1-1] [2026-05-26T12:44:30.423669Z] [vim.event.TaskEvent] [info] [EXAMPLE\\user1] [HOSTNAME] [11111111] [Task: Create virtual machine snapshot]",
     "event": {
       "category": [
         "network"
@@ -16,7 +16,7 @@
     },
     "@timestamp": "2026-05-26T12:44:30.423669Z",
     "host": {
-      "name": "host1 - example"
+      "name": "HOSTNAME"
     },
     "log": {
       "level": "info"

--- a/VMWare/vmware-vcenter/tests/wcp_service_registering.json
+++ b/VMWare/vmware-vcenter/tests/wcp_service_registering.json
@@ -1,0 +1,28 @@
+{
+  "input": {
+    "message": "2026-07-10T12:55:22.446Z info wcp [controller/core_service_controller.go:689] [opID=CoreServiceController] Registering core service 'tkg.vsphere.vmware.com'"
+  },
+  "expected": {
+    "message": "2026-07-10T12:55:22.446Z info wcp [controller/core_service_controller.go:689] [opID=CoreServiceController] Registering core service 'tkg.vsphere.vmware.com'",
+    "event": {
+      "category": [
+        "network"
+      ],
+      "reason": "Registering core service 'tkg.vsphere.vmware.com'",
+      "type": [
+        "connection"
+      ]
+    },
+    "@timestamp": "2026-07-10T12:55:22.446000Z",
+    "log": {
+      "level": "info"
+    },
+    "observer": {
+      "product": "VCenter",
+      "vendor": "VMWare"
+    },
+    "service": {
+      "name": "tkg.vsphere.vmware.com"
+    }
+  }
+}


### PR DESCRIPTION
## Description

Relates to https://github.com/SekoiaLab/integration/issues/1788

### Added

- Parse new ECS fields:
  - `service.name`

## Description

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] New intake format
- [x] Update to existing intake format
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (please describe):

## Affected Intake Formats

<!-- List the vendor/product formats affected by this PR -->

- Vendor/product: VMWare/vmware-vcenter

## Checklist

<!-- Ensure all requirements are met before submitting -->

### 🔒 CRITICAL - Security Requirements (MUST BE VERIFIED FIRST)

- [ ] **No real email addresses** in test files (use: user@example.com, test@example.org)
- [ ] **No real passwords or API keys** (use: "P@ssw0rd!", "xxxxxxxxxxxx", "FAKE_TOKEN_123")
- [ ] **No real IP addresses** (use TEST-NET ranges: 192.0.2.x, 198.51.100.x, 203.0.113.x)
- [ ] **No real phone numbers** (use: +1-555-0100 or similar test numbers)
- [ ] **No real names or PII** (use: "John Doe", "Jane Smith", "User123")
- [ ] **No real company/organization names** in test data (unless public vendors)
- [ ] **No real usernames, hostnames, or domain names** (use: user1, host.example.com, test.corp)
- [ ] All test data has been anonymized and verified

### Required for All PRs

- [ ] Code has been linted
    - [ ] with the linter for manifest, smart-descriptions, and test files (`uv run python linter.py check --changes` in utils/)
    - [ ] with Prettier for the parser code files (`npx prettier --write <module>/<format>/ingest/parser.yml`)
- [ ] All CI/CD checks pass
- [ ] Changes follow the contribution guidelines in `CONTRIBUTING.md`

### Required for New/Updated Intake Formats

- [ ] Clear descriptions provided for modules and formats
- [ ] Logo files included for new modules/formats
- [ ] Parser test coverage is at least 75%
- [ ] At least one smart-description is provided
- [ ] README.md updated (if applicable)
- [ ] Taxonomy mappings are correct and documented
- [ ] Test cases cover edge cases and error handling

### Testing

- [ ] Local tests pass (`uv run pytest` in utils/)
- [ ] Sample data is representative and **completely anonymized**
- [ ] **No sensitive information** (PII, credentials, real IPs, real emails) in test files
- [ ] Test data uses example.com/example.org domains and TEST-NET IP ranges
- [ ] Parser handles malformed data gracefully

### Documentation

- [ ] Code changes are documented
- [ ] Smart-descriptions are clear and informative
- [ ] Field mappings are explained

## Additional Notes

<!-- Add any additional context, screenshots, or information that would help reviewers -->

## Related Issues

<!-- Link any related issues using #issue_number -->

Closes #

## Summary by Sourcery

Extend the VMware vCenter intake parser to handle WCP service registration logs and map the parsed service name into normalized fields.

Enhancements:
- Add a WCP service log pattern to parse core service registration events and extract service name metadata.

Tests:
- Add a test fixture for WCP service registration log parsing.

## Summary by Sourcery

Extend the VMware vCenter intake parser to normalize service names from WCP service registration logs.

New Features:
- Parse VMware vCenter WCP service registration events and extract the registered service name into ECS `service.name`.

Tests:
- Add coverage for WCP service registration log parsing.