### PR TITLE
Fix: Aws Include Necessary Events (1844)

### DIFF
--- a/AWS/aws-cloudtrail/ingest/parser.yml
+++ b/AWS/aws-cloudtrail/ingest/parser.yml
@@ -58,6 +58,11 @@ stages:
         filter: "{{parsed_source.source.ip | is_ipaddress}}"
 
       - set:
+          event.outcome: "failure"
+          action.outcome: "failure"
+        filter: '{{json_event.message.get("errorCode") != None}}'
+
+      - set:
           event.category: ["iam"]
           event.type: ["change"]
         filter: '{{json_event.message.eventName in ("PasswordUpdated", "EnableMFADevice")}}'

--- a/AWS/aws-cloudtrail/tests/event_ec2-error.json
+++ b/AWS/aws-cloudtrail/tests/event_ec2-error.json
@@ -10,7 +10,7 @@
         "network"
       ],
       "code": "Client.AuthFailure",
-      "outcome": "success",
+      "outcome": "failure",
       "provider": "ec2.amazonaws.com",
       "reason": "vm-import-export@amazon.com must have WRITE and READ_ACL permission on the S3 bucket.",
       "type": [
@@ -20,7 +20,7 @@
     "@timestamp": "2020-09-22T15:05:22Z",
     "action": {
       "name": "CreateInstanceExportTask",
-      "outcome": "success",
+      "outcome": "failure",
       "properties": {
         "errorCode": "Client.AuthFailure",
         "errorMessage": "vm-import-export@amazon.com must have WRITE and READ_ACL permission on the S3 bucket.",

--- a/AWS/aws-cloudtrail/tests/event_ec2_describe_instances.json
+++ b/AWS/aws-cloudtrail/tests/event_ec2_describe_instances.json
@@ -1,0 +1,103 @@
+{
+  "input": {
+    "message": "{\"eventVersion\":\"1.09\",\"userIdentity\":{\"type\":\"AssumedRole\",\"principalId\":\"ABCDEFGHIJKLMN1234567\",\"arn\":\"arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser\",\"accountId\":\"111111111111\",\"accessKeyId\":\"ASIA1111111111111111\",\"sessionContext\":{\"sessionIssuer\":{\"type\":\"Role\",\"principalId\":\"ABCDEFGHIJKLMN1234567\",\"arn\":\"arn:aws:iam::111111111111:role/example-ec2-role\",\"accountId\":\"111111111111\",\"userName\":\"example-ec2-role\"},\"attributes\":{\"creationDate\":\"2026-07-30T09:12:33Z\",\"mfaAuthenticated\":\"false\"},\"ec2RoleDelivery\":\"2.0\"}},\"eventTime\":\"2026-07-30T09:14:02Z\",\"eventSource\":\"ec2.amazonaws.com\",\"eventName\":\"DescribeInstances\",\"awsRegion\":\"eu-west-1\",\"sourceIPAddress\":\"1.2.3.4\",\"userAgent\":\"aws-cli/2.15.30 Python/3.11.8 Linux/6.1.0 exec-env/AWS_EC2 botocore/2.4.5\",\"requestParameters\":{\"instancesSet\":{},\"filterSet\":{}},\"responseElements\":null,\"requestID\":\"9f2f4d5c-1b3a-4a7e-9d1f-1a1a1a1a1a1a\",\"eventID\":\"b1e9a6f4-52a1-4d8e-9c3b-1a1a1a1a1a1a\",\"readOnly\":true,\"eventType\":\"AwsApiCall\",\"managementEvent\":true,\"recipientAccountId\":\"111111111111\",\"eventCategory\":\"Management\",\"tlsDetails\":{\"tlsVersion\":\"TLSv1.3\",\"cipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"clientProvidedHostHeader\":\"ec2.eu-west-1.amazonaws.com\"}}"
+  },
+  "expected": {
+    "message": "{\"eventVersion\":\"1.09\",\"userIdentity\":{\"type\":\"AssumedRole\",\"principalId\":\"ABCDEFGHIJKLMN1234567\",\"arn\":\"arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser\",\"accountId\":\"111111111111\",\"accessKeyId\":\"ASIA1111111111111111\",\"sessionContext\":{\"sessionIssuer\":{\"type\":\"Role\",\"principalId\":\"ABCDEFGHIJKLMN1234567\",\"arn\":\"arn:aws:iam::111111111111:role/example-ec2-role\",\"accountId\":\"111111111111\",\"userName\":\"example-ec2-role\"},\"attributes\":{\"creationDate\":\"2026-07-30T09:12:33Z\",\"mfaAuthenticated\":\"false\"},\"ec2RoleDelivery\":\"2.0\"}},\"eventTime\":\"2026-07-30T09:14:02Z\",\"eventSource\":\"ec2.amazonaws.com\",\"eventName\":\"DescribeInstances\",\"awsRegion\":\"eu-west-1\",\"sourceIPAddress\":\"1.2.3.4\",\"userAgent\":\"aws-cli/2.15.30 Python/3.11.8 Linux/6.1.0 exec-env/AWS_EC2 botocore/2.4.5\",\"requestParameters\":{\"instancesSet\":{},\"filterSet\":{}},\"responseElements\":null,\"requestID\":\"9f2f4d5c-1b3a-4a7e-9d1f-1a1a1a1a1a1a\",\"eventID\":\"b1e9a6f4-52a1-4d8e-9c3b-1a1a1a1a1a1a\",\"readOnly\":true,\"eventType\":\"AwsApiCall\",\"managementEvent\":true,\"recipientAccountId\":\"111111111111\",\"eventCategory\":\"Management\",\"tlsDetails\":{\"tlsVersion\":\"TLSv1.3\",\"cipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"clientProvidedHostHeader\":\"ec2.eu-west-1.amazonaws.com\"}}",
+    "event": {
+      "action": "DescribeInstances",
+      "category": [
+        "network"
+      ],
+      "outcome": "success",
+      "provider": "ec2.amazonaws.com",
+      "type": [
+        "access"
+      ]
+    },
+    "@timestamp": "2026-07-30T09:14:02Z",
+    "action": {
+      "name": "DescribeInstances",
+      "outcome": "success",
+      "properties": {
+        "recipientAccountId": "111111111111",
+        "userIdentity": {
+          "accountId": "111111111111",
+          "arn": "arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser",
+          "principalId": "ABCDEFGHIJKLMN1234567",
+          "sessionContext": {
+            "attributes": {
+              "mfaAuthenticated": "false"
+            },
+            "sessionIssuer": {
+              "arn": "arn:aws:iam::111111111111:role/example-ec2-role",
+              "type": "Role",
+              "userName": "example-ec2-role"
+            }
+          },
+          "type": "AssumedRole"
+        }
+      },
+      "target": "network-traffic",
+      "type": "AwsApiCall"
+    },
+    "aws": {
+      "cloudtrail": {
+        "flattened": {
+          "request_parameters": "{\"filterSet\":{},\"instancesSet\":{}}"
+        },
+        "user_identity": {
+          "accessKeyId": "ASIA1111111111111111",
+          "accountId": "111111111111",
+          "arn": "arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser",
+          "principalId": "ABCDEFGHIJKLMN1234567",
+          "sessionContext": {
+            "sessionIssuer": {
+              "arn": "arn:aws:iam::111111111111:role/example-ec2-role",
+              "userName": "example-ec2-role"
+            }
+          },
+          "type": "AssumedRole"
+        }
+      }
+    },
+    "cloud": {
+      "account": {
+        "id": "111111111111"
+      },
+      "provider": "aws",
+      "region": "eu-west-1",
+      "service": {
+        "name": "cloudtrail"
+      }
+    },
+    "related": {
+      "ip": [
+        "1.2.3.4"
+      ]
+    },
+    "source": {
+      "address": "1.2.3.4",
+      "ip": "1.2.3.4"
+    },
+    "tls": {
+      "cipher": "TLS_AES_128_GCM_SHA256",
+      "version": "TLSv1.3"
+    },
+    "user": {
+      "id": "111111111111"
+    },
+    "user_agent": {
+      "device": {
+        "name": "Spider"
+      },
+      "name": "aws-cli",
+      "original": "aws-cli/2.15.30 Python/3.11.8 Linux/6.1.0 exec-env/AWS_EC2 botocore/2.4.5",
+      "os": {
+        "name": "Linux",
+        "version": "6.1.0"
+      },
+      "version": "2.15.30"
+    }
+  }
+}

--- a/AWS/aws-cloudtrail/tests/event_iam_list_access_keys.json
+++ b/AWS/aws-cloudtrail/tests/event_iam_list_access_keys.json
@@ -1,0 +1,103 @@
+{
+  "input": {
+    "message": "{\"eventVersion\":\"1.09\",\"userIdentity\":{\"type\":\"AssumedRole\",\"principalId\":\"ABCDEFGHIJKLMN1234567\",\"arn\":\"arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser\",\"accountId\":\"111111111111\",\"accessKeyId\":\"ASIA1111111111111111\",\"sessionContext\":{\"sessionIssuer\":{\"type\":\"Role\",\"principalId\":\"ABCDEFGHIJKLMN1234567\",\"arn\":\"arn:aws:iam::111111111111:role/example-ec2-role\",\"accountId\":\"111111111111\",\"userName\":\"example-ec2-role\"},\"attributes\":{\"creationDate\":\"2026-07-30T09:12:33Z\",\"mfaAuthenticated\":\"false\"},\"ec2RoleDelivery\":\"2.0\"}},\"eventTime\":\"2026-07-30T09:14:31Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"ListAccessKeys\",\"awsRegion\":\"eu-west-1\",\"sourceIPAddress\":\"1.2.3.4\",\"userAgent\":\"aws-cli/2.15.30 Python/3.11.8 Linux/6.1.0 exec-env/AWS_EC2 botocore/2.4.5\",\"requestParameters\":{\"userName\":\"user1\"},\"responseElements\":null,\"requestID\":\"9f2f4d5c-1b3a-4a7e-9d1f-4d4d4d4d4d4d\",\"eventID\":\"b1e9a6f4-52a1-4d8e-9c3b-4d4d4d4d4d4d\",\"readOnly\":true,\"eventType\":\"AwsApiCall\",\"managementEvent\":true,\"recipientAccountId\":\"111111111111\",\"eventCategory\":\"Management\",\"tlsDetails\":{\"tlsVersion\":\"TLSv1.3\",\"cipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"clientProvidedHostHeader\":\"iam.amazonaws.com\"}}"
+  },
+  "expected": {
+    "message": "{\"eventVersion\":\"1.09\",\"userIdentity\":{\"type\":\"AssumedRole\",\"principalId\":\"ABCDEFGHIJKLMN1234567\",\"arn\":\"arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser\",\"accountId\":\"111111111111\",\"accessKeyId\":\"ASIA1111111111111111\",\"sessionContext\":{\"sessionIssuer\":{\"type\":\"Role\",\"principalId\":\"ABCDEFGHIJKLMN1234567\",\"arn\":\"arn:aws:iam::111111111111:role/example-ec2-role\",\"accountId\":\"111111111111\",\"userName\":\"example-ec2-role\"},\"attributes\":{\"creationDate\":\"2026-07-30T09:12:33Z\",\"mfaAuthenticated\":\"false\"},\"ec2RoleDelivery\":\"2.0\"}},\"eventTime\":\"2026-07-30T09:14:31Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"ListAccessKeys\",\"awsRegion\":\"eu-west-1\",\"sourceIPAddress\":\"1.2.3.4\",\"userAgent\":\"aws-cli/2.15.30 Python/3.11.8 Linux/6.1.0 exec-env/AWS_EC2 botocore/2.4.5\",\"requestParameters\":{\"userName\":\"user1\"},\"responseElements\":null,\"requestID\":\"9f2f4d5c-1b3a-4a7e-9d1f-4d4d4d4d4d4d\",\"eventID\":\"b1e9a6f4-52a1-4d8e-9c3b-4d4d4d4d4d4d\",\"readOnly\":true,\"eventType\":\"AwsApiCall\",\"managementEvent\":true,\"recipientAccountId\":\"111111111111\",\"eventCategory\":\"Management\",\"tlsDetails\":{\"tlsVersion\":\"TLSv1.3\",\"cipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"clientProvidedHostHeader\":\"iam.amazonaws.com\"}}",
+    "event": {
+      "action": "ListAccessKeys",
+      "category": [
+        "network"
+      ],
+      "outcome": "success",
+      "provider": "iam.amazonaws.com",
+      "type": [
+        "access"
+      ]
+    },
+    "@timestamp": "2026-07-30T09:14:31Z",
+    "action": {
+      "name": "ListAccessKeys",
+      "outcome": "success",
+      "properties": {
+        "recipientAccountId": "111111111111",
+        "userIdentity": {
+          "accountId": "111111111111",
+          "arn": "arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser",
+          "principalId": "ABCDEFGHIJKLMN1234567",
+          "sessionContext": {
+            "attributes": {
+              "mfaAuthenticated": "false"
+            },
+            "sessionIssuer": {
+              "arn": "arn:aws:iam::111111111111:role/example-ec2-role",
+              "type": "Role",
+              "userName": "example-ec2-role"
+            }
+          },
+          "type": "AssumedRole"
+        }
+      },
+      "target": "network-traffic",
+      "type": "AwsApiCall"
+    },
+    "aws": {
+      "cloudtrail": {
+        "flattened": {
+          "request_parameters": "{\"userName\":\"user1\"}"
+        },
+        "user_identity": {
+          "accessKeyId": "ASIA1111111111111111",
+          "accountId": "111111111111",
+          "arn": "arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser",
+          "principalId": "ABCDEFGHIJKLMN1234567",
+          "sessionContext": {
+            "sessionIssuer": {
+              "arn": "arn:aws:iam::111111111111:role/example-ec2-role",
+              "userName": "example-ec2-role"
+            }
+          },
+          "type": "AssumedRole"
+        }
+      }
+    },
+    "cloud": {
+      "account": {
+        "id": "111111111111"
+      },
+      "provider": "aws",
+      "region": "eu-west-1",
+      "service": {
+        "name": "cloudtrail"
+      }
+    },
+    "related": {
+      "ip": [
+        "1.2.3.4"
+      ]
+    },
+    "source": {
+      "address": "1.2.3.4",
+      "ip": "1.2.3.4"
+    },
+    "tls": {
+      "cipher": "TLS_AES_128_GCM_SHA256",
+      "version": "TLSv1.3"
+    },
+    "user": {
+      "id": "111111111111"
+    },
+    "user_agent": {
+      "device": {
+        "name": "Spider"
+      },
+      "name": "aws-cli",
+      "original": "aws-cli/2.15.30 Python/3.11.8 Linux/6.1.0 exec-env/AWS_EC2 botocore/2.4.5",
+      "os": {
+        "name": "Linux",
+        "version": "6.1.0"
+      },
+      "version": "2.15.30"
+    }
+  }
+}

--- a/AWS/aws-cloudtrail/tests/event_iam_list_roles.json
+++ b/AWS/aws-cloudtrail/tests/event_iam_list_roles.json
@@ -1,0 +1,100 @@
+{
+  "input": {
+    "message": "{\"eventVersion\":\"1.09\",\"userIdentity\":{\"type\":\"AssumedRole\",\"principalId\":\"ABCDEFGHIJKLMN1234567\",\"arn\":\"arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser\",\"accountId\":\"111111111111\",\"accessKeyId\":\"ASIA1111111111111111\",\"sessionContext\":{\"sessionIssuer\":{\"type\":\"Role\",\"principalId\":\"ABCDEFGHIJKLMN1234567\",\"arn\":\"arn:aws:iam::111111111111:role/example-ec2-role\",\"accountId\":\"111111111111\",\"userName\":\"example-ec2-role\"},\"attributes\":{\"creationDate\":\"2026-07-30T09:12:33Z\",\"mfaAuthenticated\":\"false\"},\"ec2RoleDelivery\":\"2.0\"}},\"eventTime\":\"2026-07-30T09:14:18Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"ListRoles\",\"awsRegion\":\"eu-west-1\",\"sourceIPAddress\":\"1.2.3.4\",\"userAgent\":\"aws-cli/2.15.30 Python/3.11.8 Linux/6.1.0 exec-env/AWS_EC2 botocore/2.4.5\",\"requestParameters\":null,\"responseElements\":null,\"requestID\":\"9f2f4d5c-1b3a-4a7e-9d1f-2b2b2b2b2b2b\",\"eventID\":\"b1e9a6f4-52a1-4d8e-9c3b-2b2b2b2b2b2b\",\"readOnly\":true,\"eventType\":\"AwsApiCall\",\"managementEvent\":true,\"recipientAccountId\":\"111111111111\",\"eventCategory\":\"Management\",\"tlsDetails\":{\"tlsVersion\":\"TLSv1.3\",\"cipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"clientProvidedHostHeader\":\"iam.amazonaws.com\"}}"
+  },
+  "expected": {
+    "message": "{\"eventVersion\":\"1.09\",\"userIdentity\":{\"type\":\"AssumedRole\",\"principalId\":\"ABCDEFGHIJKLMN1234567\",\"arn\":\"arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser\",\"accountId\":\"111111111111\",\"accessKeyId\":\"ASIA1111111111111111\",\"sessionContext\":{\"sessionIssuer\":{\"type\":\"Role\",\"principalId\":\"ABCDEFGHIJKLMN1234567\",\"arn\":\"arn:aws:iam::111111111111:role/example-ec2-role\",\"accountId\":\"111111111111\",\"userName\":\"example-ec2-role\"},\"attributes\":{\"creationDate\":\"2026-07-30T09:12:33Z\",\"mfaAuthenticated\":\"false\"},\"ec2RoleDelivery\":\"2.0\"}},\"eventTime\":\"2026-07-30T09:14:18Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"ListRoles\",\"awsRegion\":\"eu-west-1\",\"sourceIPAddress\":\"1.2.3.4\",\"userAgent\":\"aws-cli/2.15.30 Python/3.11.8 Linux/6.1.0 exec-env/AWS_EC2 botocore/2.4.5\",\"requestParameters\":null,\"responseElements\":null,\"requestID\":\"9f2f4d5c-1b3a-4a7e-9d1f-2b2b2b2b2b2b\",\"eventID\":\"b1e9a6f4-52a1-4d8e-9c3b-2b2b2b2b2b2b\",\"readOnly\":true,\"eventType\":\"AwsApiCall\",\"managementEvent\":true,\"recipientAccountId\":\"111111111111\",\"eventCategory\":\"Management\",\"tlsDetails\":{\"tlsVersion\":\"TLSv1.3\",\"cipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"clientProvidedHostHeader\":\"iam.amazonaws.com\"}}",
+    "event": {
+      "action": "ListRoles",
+      "category": [
+        "network"
+      ],
+      "outcome": "success",
+      "provider": "iam.amazonaws.com",
+      "type": [
+        "access"
+      ]
+    },
+    "@timestamp": "2026-07-30T09:14:18Z",
+    "action": {
+      "name": "ListRoles",
+      "outcome": "success",
+      "properties": {
+        "recipientAccountId": "111111111111",
+        "userIdentity": {
+          "accountId": "111111111111",
+          "arn": "arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser",
+          "principalId": "ABCDEFGHIJKLMN1234567",
+          "sessionContext": {
+            "attributes": {
+              "mfaAuthenticated": "false"
+            },
+            "sessionIssuer": {
+              "arn": "arn:aws:iam::111111111111:role/example-ec2-role",
+              "type": "Role",
+              "userName": "example-ec2-role"
+            }
+          },
+          "type": "AssumedRole"
+        }
+      },
+      "target": "network-traffic",
+      "type": "AwsApiCall"
+    },
+    "aws": {
+      "cloudtrail": {
+        "user_identity": {
+          "accessKeyId": "ASIA1111111111111111",
+          "accountId": "111111111111",
+          "arn": "arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser",
+          "principalId": "ABCDEFGHIJKLMN1234567",
+          "sessionContext": {
+            "sessionIssuer": {
+              "arn": "arn:aws:iam::111111111111:role/example-ec2-role",
+              "userName": "example-ec2-role"
+            }
+          },
+          "type": "AssumedRole"
+        }
+      }
+    },
+    "cloud": {
+      "account": {
+        "id": "111111111111"
+      },
+      "provider": "aws",
+      "region": "eu-west-1",
+      "service": {
+        "name": "cloudtrail"
+      }
+    },
+    "related": {
+      "ip": [
+        "1.2.3.4"
+      ]
+    },
+    "source": {
+      "address": "1.2.3.4",
+      "ip": "1.2.3.4"
+    },
+    "tls": {
+      "cipher": "TLS_AES_128_GCM_SHA256",
+      "version": "TLSv1.3"
+    },
+    "user": {
+      "id": "111111111111"
+    },
+    "user_agent": {
+      "device": {
+        "name": "Spider"
+      },
+      "name": "aws-cli",
+      "original": "aws-cli/2.15.30 Python/3.11.8 Linux/6.1.0 exec-env/AWS_EC2 botocore/2.4.5",
+      "os": {
+        "name": "Linux",
+        "version": "6.1.0"
+      },
+      "version": "2.15.30"
+    }
+  }
+}

--- a/AWS/aws-cloudtrail/tests/event_iam_list_users.json
+++ b/AWS/aws-cloudtrail/tests/event_iam_list_users.json
@@ -1,0 +1,100 @@
+{
+  "input": {
+    "message": "{\"eventVersion\":\"1.09\",\"userIdentity\":{\"type\":\"AssumedRole\",\"principalId\":\"ABCDEFGHIJKLMN1234567\",\"arn\":\"arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser\",\"accountId\":\"111111111111\",\"accessKeyId\":\"ASIA1111111111111111\",\"sessionContext\":{\"sessionIssuer\":{\"type\":\"Role\",\"principalId\":\"ABCDEFGHIJKLMN1234567\",\"arn\":\"arn:aws:iam::111111111111:role/example-ec2-role\",\"accountId\":\"111111111111\",\"userName\":\"example-ec2-role\"},\"attributes\":{\"creationDate\":\"2026-07-30T09:12:33Z\",\"mfaAuthenticated\":\"false\"},\"ec2RoleDelivery\":\"2.0\"}},\"eventTime\":\"2026-07-30T09:14:25Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"ListUsers\",\"awsRegion\":\"eu-west-1\",\"sourceIPAddress\":\"1.2.3.4\",\"userAgent\":\"aws-cli/2.15.30 Python/3.11.8 Linux/6.1.0 exec-env/AWS_EC2 botocore/2.4.5\",\"requestParameters\":null,\"responseElements\":null,\"requestID\":\"9f2f4d5c-1b3a-4a7e-9d1f-3c3c3c3c3c3c\",\"eventID\":\"b1e9a6f4-52a1-4d8e-9c3b-3c3c3c3c3c3c\",\"readOnly\":true,\"eventType\":\"AwsApiCall\",\"managementEvent\":true,\"recipientAccountId\":\"111111111111\",\"eventCategory\":\"Management\",\"tlsDetails\":{\"tlsVersion\":\"TLSv1.3\",\"cipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"clientProvidedHostHeader\":\"iam.amazonaws.com\"}}"
+  },
+  "expected": {
+    "message": "{\"eventVersion\":\"1.09\",\"userIdentity\":{\"type\":\"AssumedRole\",\"principalId\":\"ABCDEFGHIJKLMN1234567\",\"arn\":\"arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser\",\"accountId\":\"111111111111\",\"accessKeyId\":\"ASIA1111111111111111\",\"sessionContext\":{\"sessionIssuer\":{\"type\":\"Role\",\"principalId\":\"ABCDEFGHIJKLMN1234567\",\"arn\":\"arn:aws:iam::111111111111:role/example-ec2-role\",\"accountId\":\"111111111111\",\"userName\":\"example-ec2-role\"},\"attributes\":{\"creationDate\":\"2026-07-30T09:12:33Z\",\"mfaAuthenticated\":\"false\"},\"ec2RoleDelivery\":\"2.0\"}},\"eventTime\":\"2026-07-30T09:14:25Z\",\"eventSource\":\"iam.amazonaws.com\",\"eventName\":\"ListUsers\",\"awsRegion\":\"eu-west-1\",\"sourceIPAddress\":\"1.2.3.4\",\"userAgent\":\"aws-cli/2.15.30 Python/3.11.8 Linux/6.1.0 exec-env/AWS_EC2 botocore/2.4.5\",\"requestParameters\":null,\"responseElements\":null,\"requestID\":\"9f2f4d5c-1b3a-4a7e-9d1f-3c3c3c3c3c3c\",\"eventID\":\"b1e9a6f4-52a1-4d8e-9c3b-3c3c3c3c3c3c\",\"readOnly\":true,\"eventType\":\"AwsApiCall\",\"managementEvent\":true,\"recipientAccountId\":\"111111111111\",\"eventCategory\":\"Management\",\"tlsDetails\":{\"tlsVersion\":\"TLSv1.3\",\"cipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"clientProvidedHostHeader\":\"iam.amazonaws.com\"}}",
+    "event": {
+      "action": "ListUsers",
+      "category": [
+        "network"
+      ],
+      "outcome": "success",
+      "provider": "iam.amazonaws.com",
+      "type": [
+        "access"
+      ]
+    },
+    "@timestamp": "2026-07-30T09:14:25Z",
+    "action": {
+      "name": "ListUsers",
+      "outcome": "success",
+      "properties": {
+        "recipientAccountId": "111111111111",
+        "userIdentity": {
+          "accountId": "111111111111",
+          "arn": "arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser",
+          "principalId": "ABCDEFGHIJKLMN1234567",
+          "sessionContext": {
+            "attributes": {
+              "mfaAuthenticated": "false"
+            },
+            "sessionIssuer": {
+              "arn": "arn:aws:iam::111111111111:role/example-ec2-role",
+              "type": "Role",
+              "userName": "example-ec2-role"
+            }
+          },
+          "type": "AssumedRole"
+        }
+      },
+      "target": "network-traffic",
+      "type": "AwsApiCall"
+    },
+    "aws": {
+      "cloudtrail": {
+        "user_identity": {
+          "accessKeyId": "ASIA1111111111111111",
+          "accountId": "111111111111",
+          "arn": "arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser",
+          "principalId": "ABCDEFGHIJKLMN1234567",
+          "sessionContext": {
+            "sessionIssuer": {
+              "arn": "arn:aws:iam::111111111111:role/example-ec2-role",
+              "userName": "example-ec2-role"
+            }
+          },
+          "type": "AssumedRole"
+        }
+      }
+    },
+    "cloud": {
+      "account": {
+        "id": "111111111111"
+      },
+      "provider": "aws",
+      "region": "eu-west-1",
+      "service": {
+        "name": "cloudtrail"
+      }
+    },
+    "related": {
+      "ip": [
+        "1.2.3.4"
+      ]
+    },
+    "source": {
+      "address": "1.2.3.4",
+      "ip": "1.2.3.4"
+    },
+    "tls": {
+      "cipher": "TLS_AES_128_GCM_SHA256",
+      "version": "TLSv1.3"
+    },
+    "user": {
+      "id": "111111111111"
+    },
+    "user_agent": {
+      "device": {
+        "name": "Spider"
+      },
+      "name": "aws-cli",
+      "original": "aws-cli/2.15.30 Python/3.11.8 Linux/6.1.0 exec-env/AWS_EC2 botocore/2.4.5",
+      "os": {
+        "name": "Linux",
+        "version": "6.1.0"
+      },
+      "version": "2.15.30"
+    }
+  }
+}

--- a/AWS/aws-cloudtrail/tests/event_secretsmanager_list_secrets.json
+++ b/AWS/aws-cloudtrail/tests/event_secretsmanager_list_secrets.json
@@ -1,0 +1,103 @@
+{
+  "input": {
+    "message": "{\"eventVersion\":\"1.09\",\"userIdentity\":{\"type\":\"AssumedRole\",\"principalId\":\"ABCDEFGHIJKLMN1234567\",\"arn\":\"arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser\",\"accountId\":\"111111111111\",\"accessKeyId\":\"ASIA1111111111111111\",\"sessionContext\":{\"sessionIssuer\":{\"type\":\"Role\",\"principalId\":\"ABCDEFGHIJKLMN1234567\",\"arn\":\"arn:aws:iam::111111111111:role/example-ec2-role\",\"accountId\":\"111111111111\",\"userName\":\"example-ec2-role\"},\"attributes\":{\"creationDate\":\"2026-07-30T09:12:33Z\",\"mfaAuthenticated\":\"false\"},\"ec2RoleDelivery\":\"2.0\"}},\"eventTime\":\"2026-07-30T09:14:44Z\",\"eventSource\":\"secretsmanager.amazonaws.com\",\"eventName\":\"ListSecrets\",\"awsRegion\":\"eu-west-1\",\"sourceIPAddress\":\"1.2.3.4\",\"userAgent\":\"aws-cli/2.15.30 Python/3.11.8 Linux/6.1.0 exec-env/AWS_EC2 botocore/2.4.5\",\"requestParameters\":{\"maxResults\":100,\"includePlannedDeletion\":false},\"responseElements\":null,\"requestID\":\"9f2f4d5c-1b3a-4a7e-9d1f-5e5e5e5e5e5e\",\"eventID\":\"b1e9a6f4-52a1-4d8e-9c3b-5e5e5e5e5e5e\",\"readOnly\":true,\"eventType\":\"AwsApiCall\",\"managementEvent\":true,\"recipientAccountId\":\"111111111111\",\"eventCategory\":\"Management\",\"tlsDetails\":{\"tlsVersion\":\"TLSv1.3\",\"cipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"clientProvidedHostHeader\":\"secretsmanager.eu-west-1.amazonaws.com\"}}"
+  },
+  "expected": {
+    "message": "{\"eventVersion\":\"1.09\",\"userIdentity\":{\"type\":\"AssumedRole\",\"principalId\":\"ABCDEFGHIJKLMN1234567\",\"arn\":\"arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser\",\"accountId\":\"111111111111\",\"accessKeyId\":\"ASIA1111111111111111\",\"sessionContext\":{\"sessionIssuer\":{\"type\":\"Role\",\"principalId\":\"ABCDEFGHIJKLMN1234567\",\"arn\":\"arn:aws:iam::111111111111:role/example-ec2-role\",\"accountId\":\"111111111111\",\"userName\":\"example-ec2-role\"},\"attributes\":{\"creationDate\":\"2026-07-30T09:12:33Z\",\"mfaAuthenticated\":\"false\"},\"ec2RoleDelivery\":\"2.0\"}},\"eventTime\":\"2026-07-30T09:14:44Z\",\"eventSource\":\"secretsmanager.amazonaws.com\",\"eventName\":\"ListSecrets\",\"awsRegion\":\"eu-west-1\",\"sourceIPAddress\":\"1.2.3.4\",\"userAgent\":\"aws-cli/2.15.30 Python/3.11.8 Linux/6.1.0 exec-env/AWS_EC2 botocore/2.4.5\",\"requestParameters\":{\"maxResults\":100,\"includePlannedDeletion\":false},\"responseElements\":null,\"requestID\":\"9f2f4d5c-1b3a-4a7e-9d1f-5e5e5e5e5e5e\",\"eventID\":\"b1e9a6f4-52a1-4d8e-9c3b-5e5e5e5e5e5e\",\"readOnly\":true,\"eventType\":\"AwsApiCall\",\"managementEvent\":true,\"recipientAccountId\":\"111111111111\",\"eventCategory\":\"Management\",\"tlsDetails\":{\"tlsVersion\":\"TLSv1.3\",\"cipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"clientProvidedHostHeader\":\"secretsmanager.eu-west-1.amazonaws.com\"}}",
+    "event": {
+      "action": "ListSecrets",
+      "category": [
+        "network"
+      ],
+      "outcome": "success",
+      "provider": "secretsmanager.amazonaws.com",
+      "type": [
+        "access"
+      ]
+    },
+    "@timestamp": "2026-07-30T09:14:44Z",
+    "action": {
+      "name": "ListSecrets",
+      "outcome": "success",
+      "properties": {
+        "recipientAccountId": "111111111111",
+        "userIdentity": {
+          "accountId": "111111111111",
+          "arn": "arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser",
+          "principalId": "ABCDEFGHIJKLMN1234567",
+          "sessionContext": {
+            "attributes": {
+              "mfaAuthenticated": "false"
+            },
+            "sessionIssuer": {
+              "arn": "arn:aws:iam::111111111111:role/example-ec2-role",
+              "type": "Role",
+              "userName": "example-ec2-role"
+            }
+          },
+          "type": "AssumedRole"
+        }
+      },
+      "target": "network-traffic",
+      "type": "AwsApiCall"
+    },
+    "aws": {
+      "cloudtrail": {
+        "flattened": {
+          "request_parameters": "{\"maxResults\":100,\"includePlannedDeletion\":false}"
+        },
+        "user_identity": {
+          "accessKeyId": "ASIA1111111111111111",
+          "accountId": "111111111111",
+          "arn": "arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser",
+          "principalId": "ABCDEFGHIJKLMN1234567",
+          "sessionContext": {
+            "sessionIssuer": {
+              "arn": "arn:aws:iam::111111111111:role/example-ec2-role",
+              "userName": "example-ec2-role"
+            }
+          },
+          "type": "AssumedRole"
+        }
+      }
+    },
+    "cloud": {
+      "account": {
+        "id": "111111111111"
+      },
+      "provider": "aws",
+      "region": "eu-west-1",
+      "service": {
+        "name": "cloudtrail"
+      }
+    },
+    "related": {
+      "ip": [
+        "1.2.3.4"
+      ]
+    },
+    "source": {
+      "address": "1.2.3.4",
+      "ip": "1.2.3.4"
+    },
+    "tls": {
+      "cipher": "TLS_AES_128_GCM_SHA256",
+      "version": "TLSv1.3"
+    },
+    "user": {
+      "id": "111111111111"
+    },
+    "user_agent": {
+      "device": {
+        "name": "Spider"
+      },
+      "name": "aws-cli",
+      "original": "aws-cli/2.15.30 Python/3.11.8 Linux/6.1.0 exec-env/AWS_EC2 botocore/2.4.5",
+      "os": {
+        "name": "Linux",
+        "version": "6.1.0"
+      },
+      "version": "2.15.30"
+    }
+  }
+}

--- a/AWS/aws-cloudtrail/tests/event_secretsmanager_list_secrets_denied.json
+++ b/AWS/aws-cloudtrail/tests/event_secretsmanager_list_secrets_denied.json
@@ -1,0 +1,107 @@
+{
+  "input": {
+    "message": "{\"eventVersion\":\"1.09\",\"userIdentity\":{\"type\":\"AssumedRole\",\"principalId\":\"ABCDEFGHIJKLMN1234567\",\"arn\":\"arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser\",\"accountId\":\"111111111111\",\"accessKeyId\":\"ASIA1111111111111111\",\"sessionContext\":{\"sessionIssuer\":{\"type\":\"Role\",\"principalId\":\"ABCDEFGHIJKLMN1234567\",\"arn\":\"arn:aws:iam::111111111111:role/example-ec2-role\",\"accountId\":\"111111111111\",\"userName\":\"example-ec2-role\"},\"attributes\":{\"creationDate\":\"2026-07-30T09:12:33Z\",\"mfaAuthenticated\":\"false\"},\"ec2RoleDelivery\":\"2.0\"}},\"eventTime\":\"2026-07-30T09:14:51Z\",\"eventSource\":\"secretsmanager.amazonaws.com\",\"eventName\":\"ListSecrets\",\"awsRegion\":\"eu-west-1\",\"sourceIPAddress\":\"1.2.3.4\",\"userAgent\":\"aws-cli/2.15.30 Python/3.11.8 Linux/6.1.0 exec-env/AWS_EC2 botocore/2.4.5\",\"requestParameters\":{\"maxResults\":100,\"includePlannedDeletion\":false},\"responseElements\":null,\"requestID\":\"9f2f4d5c-1b3a-4a7e-9d1f-6f6f6f6f6f6f\",\"eventID\":\"b1e9a6f4-52a1-4d8e-9c3b-6f6f6f6f6f6f\",\"readOnly\":true,\"eventType\":\"AwsApiCall\",\"managementEvent\":true,\"recipientAccountId\":\"111111111111\",\"eventCategory\":\"Management\",\"tlsDetails\":{\"tlsVersion\":\"TLSv1.3\",\"cipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"clientProvidedHostHeader\":\"secretsmanager.eu-west-1.amazonaws.com\"},\"errorCode\":\"AccessDenied\",\"errorMessage\":\"User: arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser is not authorized to perform: secretsmanager:ListSecrets because no identity-based policy allows the secretsmanager:ListSecrets action\"}"
+  },
+  "expected": {
+    "message": "{\"eventVersion\":\"1.09\",\"userIdentity\":{\"type\":\"AssumedRole\",\"principalId\":\"ABCDEFGHIJKLMN1234567\",\"arn\":\"arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser\",\"accountId\":\"111111111111\",\"accessKeyId\":\"ASIA1111111111111111\",\"sessionContext\":{\"sessionIssuer\":{\"type\":\"Role\",\"principalId\":\"ABCDEFGHIJKLMN1234567\",\"arn\":\"arn:aws:iam::111111111111:role/example-ec2-role\",\"accountId\":\"111111111111\",\"userName\":\"example-ec2-role\"},\"attributes\":{\"creationDate\":\"2026-07-30T09:12:33Z\",\"mfaAuthenticated\":\"false\"},\"ec2RoleDelivery\":\"2.0\"}},\"eventTime\":\"2026-07-30T09:14:51Z\",\"eventSource\":\"secretsmanager.amazonaws.com\",\"eventName\":\"ListSecrets\",\"awsRegion\":\"eu-west-1\",\"sourceIPAddress\":\"1.2.3.4\",\"userAgent\":\"aws-cli/2.15.30 Python/3.11.8 Linux/6.1.0 exec-env/AWS_EC2 botocore/2.4.5\",\"requestParameters\":{\"maxResults\":100,\"includePlannedDeletion\":false},\"responseElements\":null,\"requestID\":\"9f2f4d5c-1b3a-4a7e-9d1f-6f6f6f6f6f6f\",\"eventID\":\"b1e9a6f4-52a1-4d8e-9c3b-6f6f6f6f6f6f\",\"readOnly\":true,\"eventType\":\"AwsApiCall\",\"managementEvent\":true,\"recipientAccountId\":\"111111111111\",\"eventCategory\":\"Management\",\"tlsDetails\":{\"tlsVersion\":\"TLSv1.3\",\"cipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"clientProvidedHostHeader\":\"secretsmanager.eu-west-1.amazonaws.com\"},\"errorCode\":\"AccessDenied\",\"errorMessage\":\"User: arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser is not authorized to perform: secretsmanager:ListSecrets because no identity-based policy allows the secretsmanager:ListSecrets action\"}",
+    "event": {
+      "action": "ListSecrets",
+      "category": [
+        "network"
+      ],
+      "code": "AccessDenied",
+      "outcome": "failure",
+      "provider": "secretsmanager.amazonaws.com",
+      "reason": "User: arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser is not authorized to perform: secretsmanager:ListSecrets because no identity-based policy allows the secretsmanager:ListSecrets action",
+      "type": [
+        "access"
+      ]
+    },
+    "@timestamp": "2026-07-30T09:14:51Z",
+    "action": {
+      "name": "ListSecrets",
+      "outcome": "failure",
+      "properties": {
+        "errorCode": "AccessDenied",
+        "errorMessage": "User: arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser is not authorized to perform: secretsmanager:ListSecrets because no identity-based policy allows the secretsmanager:ListSecrets action",
+        "recipientAccountId": "111111111111",
+        "userIdentity": {
+          "accountId": "111111111111",
+          "arn": "arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser",
+          "principalId": "ABCDEFGHIJKLMN1234567",
+          "sessionContext": {
+            "attributes": {
+              "mfaAuthenticated": "false"
+            },
+            "sessionIssuer": {
+              "arn": "arn:aws:iam::111111111111:role/example-ec2-role",
+              "type": "Role",
+              "userName": "example-ec2-role"
+            }
+          },
+          "type": "AssumedRole"
+        }
+      },
+      "target": "network-traffic",
+      "type": "AwsApiCall"
+    },
+    "aws": {
+      "cloudtrail": {
+        "flattened": {
+          "request_parameters": "{\"maxResults\":100,\"includePlannedDeletion\":false}"
+        },
+        "user_identity": {
+          "accessKeyId": "ASIA1111111111111111",
+          "accountId": "111111111111",
+          "arn": "arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser",
+          "principalId": "ABCDEFGHIJKLMN1234567",
+          "sessionContext": {
+            "sessionIssuer": {
+              "arn": "arn:aws:iam::111111111111:role/example-ec2-role",
+              "userName": "example-ec2-role"
+            }
+          },
+          "type": "AssumedRole"
+        }
+      }
+    },
+    "cloud": {
+      "account": {
+        "id": "111111111111"
+      },
+      "provider": "aws",
+      "region": "eu-west-1",
+      "service": {
+        "name": "cloudtrail"
+      }
+    },
+    "related": {
+      "ip": [
+        "1.2.3.4"
+      ]
+    },
+    "source": {
+      "address": "1.2.3.4",
+      "ip": "1.2.3.4"
+    },
+    "tls": {
+      "cipher": "TLS_AES_128_GCM_SHA256",
+      "version": "TLSv1.3"
+    },
+    "user": {
+      "id": "111111111111"
+    },
+    "user_agent": {
+      "device": {
+        "name": "Spider"
+      },
+      "name": "aws-cli",
+      "original": "aws-cli/2.15.30 Python/3.11.8 Linux/6.1.0 exec-env/AWS_EC2 botocore/2.4.5",
+      "os": {
+        "name": "Linux",
+        "version": "6.1.0"
+      },
+      "version": "2.15.30"
+    }
+  }
+}

--- a/AWS/aws-cloudtrail/tests/event_ssm_describe_parameters.json
+++ b/AWS/aws-cloudtrail/tests/event_ssm_describe_parameters.json
@@ -1,0 +1,103 @@
+{
+  "input": {
+    "message": "{\"eventVersion\":\"1.09\",\"userIdentity\":{\"type\":\"AssumedRole\",\"principalId\":\"ABCDEFGHIJKLMN1234567\",\"arn\":\"arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser\",\"accountId\":\"111111111111\",\"accessKeyId\":\"ASIA1111111111111111\",\"sessionContext\":{\"sessionIssuer\":{\"type\":\"Role\",\"principalId\":\"ABCDEFGHIJKLMN1234567\",\"arn\":\"arn:aws:iam::111111111111:role/example-ec2-role\",\"accountId\":\"111111111111\",\"userName\":\"example-ec2-role\"},\"attributes\":{\"creationDate\":\"2026-07-30T09:12:33Z\",\"mfaAuthenticated\":\"false\"},\"ec2RoleDelivery\":\"2.0\"}},\"eventTime\":\"2026-07-30T09:15:07Z\",\"eventSource\":\"ssm.amazonaws.com\",\"eventName\":\"DescribeParameters\",\"awsRegion\":\"eu-west-1\",\"sourceIPAddress\":\"1.2.3.4\",\"userAgent\":\"aws-cli/2.15.30 Python/3.11.8 Linux/6.1.0 exec-env/AWS_EC2 botocore/2.4.5\",\"requestParameters\":{\"maxResults\":50},\"responseElements\":null,\"requestID\":\"9f2f4d5c-1b3a-4a7e-9d1f-7a7a7a7a7a7a\",\"eventID\":\"b1e9a6f4-52a1-4d8e-9c3b-7a7a7a7a7a7a\",\"readOnly\":true,\"eventType\":\"AwsApiCall\",\"managementEvent\":true,\"recipientAccountId\":\"111111111111\",\"eventCategory\":\"Management\",\"tlsDetails\":{\"tlsVersion\":\"TLSv1.3\",\"cipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"clientProvidedHostHeader\":\"ssm.eu-west-1.amazonaws.com\"}}"
+  },
+  "expected": {
+    "message": "{\"eventVersion\":\"1.09\",\"userIdentity\":{\"type\":\"AssumedRole\",\"principalId\":\"ABCDEFGHIJKLMN1234567\",\"arn\":\"arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser\",\"accountId\":\"111111111111\",\"accessKeyId\":\"ASIA1111111111111111\",\"sessionContext\":{\"sessionIssuer\":{\"type\":\"Role\",\"principalId\":\"ABCDEFGHIJKLMN1234567\",\"arn\":\"arn:aws:iam::111111111111:role/example-ec2-role\",\"accountId\":\"111111111111\",\"userName\":\"example-ec2-role\"},\"attributes\":{\"creationDate\":\"2026-07-30T09:12:33Z\",\"mfaAuthenticated\":\"false\"},\"ec2RoleDelivery\":\"2.0\"}},\"eventTime\":\"2026-07-30T09:15:07Z\",\"eventSource\":\"ssm.amazonaws.com\",\"eventName\":\"DescribeParameters\",\"awsRegion\":\"eu-west-1\",\"sourceIPAddress\":\"1.2.3.4\",\"userAgent\":\"aws-cli/2.15.30 Python/3.11.8 Linux/6.1.0 exec-env/AWS_EC2 botocore/2.4.5\",\"requestParameters\":{\"maxResults\":50},\"responseElements\":null,\"requestID\":\"9f2f4d5c-1b3a-4a7e-9d1f-7a7a7a7a7a7a\",\"eventID\":\"b1e9a6f4-52a1-4d8e-9c3b-7a7a7a7a7a7a\",\"readOnly\":true,\"eventType\":\"AwsApiCall\",\"managementEvent\":true,\"recipientAccountId\":\"111111111111\",\"eventCategory\":\"Management\",\"tlsDetails\":{\"tlsVersion\":\"TLSv1.3\",\"cipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"clientProvidedHostHeader\":\"ssm.eu-west-1.amazonaws.com\"}}",
+    "event": {
+      "action": "DescribeParameters",
+      "category": [
+        "network"
+      ],
+      "outcome": "success",
+      "provider": "ssm.amazonaws.com",
+      "type": [
+        "access"
+      ]
+    },
+    "@timestamp": "2026-07-30T09:15:07Z",
+    "action": {
+      "name": "DescribeParameters",
+      "outcome": "success",
+      "properties": {
+        "recipientAccountId": "111111111111",
+        "userIdentity": {
+          "accountId": "111111111111",
+          "arn": "arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser",
+          "principalId": "ABCDEFGHIJKLMN1234567",
+          "sessionContext": {
+            "attributes": {
+              "mfaAuthenticated": "false"
+            },
+            "sessionIssuer": {
+              "arn": "arn:aws:iam::111111111111:role/example-ec2-role",
+              "type": "Role",
+              "userName": "example-ec2-role"
+            }
+          },
+          "type": "AssumedRole"
+        }
+      },
+      "target": "network-traffic",
+      "type": "AwsApiCall"
+    },
+    "aws": {
+      "cloudtrail": {
+        "flattened": {
+          "request_parameters": "{\"maxResults\":50}"
+        },
+        "user_identity": {
+          "accessKeyId": "ASIA1111111111111111",
+          "accountId": "111111111111",
+          "arn": "arn:aws:sts::111111111111:assumed-role/example-ec2-role/TestUser",
+          "principalId": "ABCDEFGHIJKLMN1234567",
+          "sessionContext": {
+            "sessionIssuer": {
+              "arn": "arn:aws:iam::111111111111:role/example-ec2-role",
+              "userName": "example-ec2-role"
+            }
+          },
+          "type": "AssumedRole"
+        }
+      }
+    },
+    "cloud": {
+      "account": {
+        "id": "111111111111"
+      },
+      "provider": "aws",
+      "region": "eu-west-1",
+      "service": {
+        "name": "cloudtrail"
+      }
+    },
+    "related": {
+      "ip": [
+        "1.2.3.4"
+      ]
+    },
+    "source": {
+      "address": "1.2.3.4",
+      "ip": "1.2.3.4"
+    },
+    "tls": {
+      "cipher": "TLS_AES_128_GCM_SHA256",
+      "version": "TLSv1.3"
+    },
+    "user": {
+      "id": "111111111111"
+    },
+    "user_agent": {
+      "device": {
+        "name": "Spider"
+      },
+      "name": "aws-cli",
+      "original": "aws-cli/2.15.30 Python/3.11.8 Linux/6.1.0 exec-env/AWS_EC2 botocore/2.4.5",
+      "os": {
+        "name": "Linux",
+        "version": "6.1.0"
+      },
+      "version": "2.15.30"
+    }
+  }
+}


### PR DESCRIPTION
Relates to [1844](https://github.com/SekoiaLab/integration/issues/1844)

## Summary by Sourcery

Classify AWS CloudTrail events with an error code as failed and extend test coverage for additional AWS service events.

Bug Fixes:
- Mark CloudTrail events as failed when an errorCode is present in the message payload.

Tests:
- Add sample CloudTrail events for EC2, IAM, Secrets Manager, and SSM operations, including an access-denied scenario, to improve parsing coverage.