### PR TITLE
feature/kapersky_endpoint_security_add_new_fields

### DIFF
--- a/Kaspersky/kaspersky_endpoint_security/CHANGELOG.md
+++ b/Kaspersky/kaspersky_endpoint_security/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2026-08-03
+
+### Added
+
+- Add parsing support for `Result description: Processing error` events by extending `set_not_processed_fields` filter (shared stage)
+- Newly populated ECS fields for `Processing error` events (existing field names, no schema addition):
+	- `event.action`
+	- `event.category`
+	- `event.module`
+	- `event.reason`
+	- `event.type`
+	- `file.directory`
+	- `file.name`
+	- `process.executable`
+	- `process.pid`
+	- `user.domain`
+	- `user.name`
+
+### Changed
+
+- Modify parsing logic for existing ECS fields in `set_not_processed_fields`:
+    - `event.reason`
+    - `process.executable`
+    - `user.domain`
+    - `user.name`
+- Improve parsing for `Not processed` events when optional fields are missing
+- Improve user parsing robustness for identities with spaces in domain names (for example `NT AUTHORITY\\SYSTEM`)
+
+### Fixed
+
+- Fix `TypeError` in `set_not_processed_fields` when `Reason` is missing by making `event.reason` null-safe
+- Fix `TypeError` in `set_not_processed_fields` when `Application path` or `Name` is missing by making `process.executable` null-safe
+- Normalize `process.executable` path composition for `Not processed` events
+
 ## 2023-12-20
 
 ### Add

--- a/Kaspersky/kaspersky_endpoint_security/CHANGELOG.md
+++ b/Kaspersky/kaspersky_endpoint_security/CHANGELOG.md
@@ -13,17 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add parsing support for `Result description: Processing error` events by extending `set_not_processed_fields` filter (shared stage)
 - Newly populated ECS fields for `Processing error` events (existing field names, no schema addition):
-	- `event.action`
-	- `event.category`
-	- `event.module`
-	- `event.reason`
-	- `event.type`
-	- `file.directory`
-	- `file.name`
-	- `process.executable`
-	- `process.pid`
-	- `user.domain`
-	- `user.name`
+    - `event.action`
+    - `event.category`
+    - `event.module`
+    - `event.reason`
+    - `event.type`
+    - `file.directory`
+    - `file.name`
+    - `process.executable`
+    - `process.pid`
+    - `user.domain`
+    - `user.name`
 
 ### Changed
 

--- a/Kaspersky/kaspersky_endpoint_security/_meta/smart-descriptions.json
+++ b/Kaspersky/kaspersky_endpoint_security/_meta/smart-descriptions.json
@@ -52,7 +52,7 @@
     ]
   },
   {
-    "value": "{event.module}: {event.action} on {file.directory}\\{file.name} by {user.domain}\\{user.name}",
+    "value": "Kaspersky {event.module} reported that {file.directory}\\{file.name} was {event.action} by {user.domain}\\{user.name}.",
     "conditions": [
       {
         "field": "event.module"
@@ -79,7 +79,7 @@
     ]
   },
   {
-    "value": "{event.module}: {event.action} from {process.executable} (pid {process.pid}) - {event.reason}",
+    "value": "Kaspersky {event.module} reported {event.action} for process {process.executable} (PID {process.pid}). Reason: {event.reason}.",
     "conditions": [
       {
         "field": "event.module"
@@ -103,7 +103,7 @@
     ]
   },
   {
-    "value": "{event.category} event: {event.action} ({event.reason})",
+    "value": "Kaspersky reported a {event.category} event with action {event.action}. Reason: {event.reason}.",
     "conditions": [
       {
         "field": "event.category"

--- a/Kaspersky/kaspersky_endpoint_security/_meta/smart-descriptions.json
+++ b/Kaspersky/kaspersky_endpoint_security/_meta/smart-descriptions.json
@@ -50,5 +50,70 @@
         "value": "Error"
       }
     ]
+  },
+  {
+    "value": "{event.module}: {event.action} on {file.directory}\\{file.name} by {user.domain}\\{user.name}",
+    "conditions": [
+      {
+        "field": "event.module"
+      },
+      {
+        "field": "event.action"
+      },
+      {
+        "field": "file.directory"
+      },
+      {
+        "field": "file.name"
+      },
+      {
+        "field": "user.domain"
+      },
+      {
+        "field": "user.name"
+      },
+      {
+        "field": "event.category",
+        "value": "process"
+      }
+    ]
+  },
+  {
+    "value": "{event.module}: {event.action} from {process.executable} (pid {process.pid}) - {event.reason}",
+    "conditions": [
+      {
+        "field": "event.module"
+      },
+      {
+        "field": "event.action"
+      },
+      {
+        "field": "process.executable"
+      },
+      {
+        "field": "process.pid"
+      },
+      {
+        "field": "event.reason"
+      },
+      {
+        "field": "event.type",
+        "value": "info"
+      }
+    ]
+  },
+  {
+    "value": "{event.category} event: {event.action} ({event.reason})",
+    "conditions": [
+      {
+        "field": "event.category"
+      },
+      {
+        "field": "event.action"
+      },
+      {
+        "field": "event.reason"
+      }
+    ]
   }
 ]

--- a/Kaspersky/kaspersky_endpoint_security/ingest/parser.yml
+++ b/Kaspersky/kaspersky_endpoint_security/ingest/parser.yml
@@ -19,7 +19,7 @@ pipeline:
   - name: set_malware_fields
     filter: "{{ parsed_event.message.get('Type')=='Virus' }}"
   - name: set_not_processed_fields
-    filter: "{{ parsed_event.message.get('Type', '') == '' and  parsed_event.message.get('Result description') == 'Not processed'}}"
+    filter: "{{ parsed_event.message.get('Type', '') == '' and parsed_event.message.get('Result description') in ['Not processed', 'Processing error'] }}"
   - name: set_error_verifying_fields
     filter: "{{ parsed_event.message.get('Error') != None }}"
 stages:
@@ -52,15 +52,15 @@ stages:
       - set:
           event.type: ["info"]
           event.category: ["process"]
-          event.reason: "{{ parsed_event.message.get('Event type') +' because of '+ parsed_event.message.get('Reason')}}"
+          event.reason: "{{ (parsed_event.message.get('Event type') + ' because of ' + parsed_event.message.get('Reason')) if parsed_event.message.get('Reason') else parsed_event.message.get('Event type') }}"
           event.module: "{{ parsed_event.message.get('Component') }}"
           event.action: "{{ parsed_event.message.get('Result description') }}"
           file.directory: "{{ parsed_event.message.get('Path to object') }}"
           file.name: "{{ parsed_event.message.get('Object name') }}"
           process.pid: "{{ parsed_event.message.get('Process ID') }}"
-          process.executable: "{{ parsed_event.message.get('Application path') +'\"\\\\\"'+parsed_event.message.get('Name')}}"
-          user.name: "{{ parsed_event.message.get('User').split(' ')[0].split(\"\\\\\")[1][:-1] }}"
-          user.domain: "{{ parsed_event.message.get('User').split(' ')[0].split(\"\\\\\")[0] }}"
+          process.executable: "{{ (parsed_event.message.get('Application path') + '\\\\' + parsed_event.message.get('Name')) if (parsed_event.message.get('Application path') and parsed_event.message.get('Name')) else (parsed_event.message.get('Application path') or parsed_event.message.get('Name')) }}"
+          user.name: '{{ parsed_event.message.get("User", "").split(" (")[0].partition("\\")[2].rstrip("$") or None }}'
+          user.domain: '{{ parsed_event.message.get("User", "").split(" (")[0].partition("\\")[0] or None }}'
 
   set_error_verifying_fields:
     actions:

--- a/Kaspersky/kaspersky_endpoint_security/tests/test_not_processed.json
+++ b/Kaspersky/kaspersky_endpoint_security/tests/test_not_processed.json
@@ -25,7 +25,7 @@
       "vendor": "Kaspersky"
     },
     "process": {
-      "executable": "C:\\Windows\\System32\"\\\"msiexec.exe",
+      "executable": "C:\\Windows\\System32\\msiexec.exe",
       "pid": 7684
     },
     "related": {

--- a/Kaspersky/kaspersky_endpoint_security/tests/test_not_processed_no_reason.json
+++ b/Kaspersky/kaspersky_endpoint_security/tests/test_not_processed_no_reason.json
@@ -1,0 +1,36 @@
+{
+  "input": {
+    "message": "Event type: Object not processed\\r\\nUser: NT AUTHORITY\\SYSTEM (System user)\\r\\nComponent: Malware Scan\\r\\nResult description: Not processed\\r\\nObject type: File\\r\\nPath to object: D:\\"
+  },
+  "expected": {
+    "message": "Event type: Object not processed\\r\\nUser: NT AUTHORITY\\SYSTEM (System user)\\r\\nComponent: Malware Scan\\r\\nResult description: Not processed\\r\\nObject type: File\\r\\nPath to object: D:\\",
+    "event": {
+      "action": "Not processed",
+      "category": [
+        "process"
+      ],
+      "module": "Malware Scan",
+      "reason": "Object not processed",
+      "type": [
+        "info"
+      ]
+    },
+    "file": {
+      "directory": "D:\\"
+    },
+    "observer": {
+      "product": "Kaspersky Endpoint Security",
+      "type": "edr",
+      "vendor": "Kaspersky"
+    },
+    "related": {
+      "user": [
+        "SYSTEM"
+      ]
+    },
+    "user": {
+      "domain": "NT AUTHORITY",
+      "name": "SYSTEM"
+    }
+  }
+}

--- a/Kaspersky/kaspersky_endpoint_security/tests/test_not_processed_without_process_identity.json
+++ b/Kaspersky/kaspersky_endpoint_security/tests/test_not_processed_without_process_identity.json
@@ -1,0 +1,37 @@
+{
+  "input": {
+    "message": "Event type: Object not processed\\r\\nApplication type: Unknown application\\r\\nUser: NT AUTHORITY\\SYSTEM (System user)\\r\\nComponent: File Threat Protection\\r\\nResult description: Not processed\\r\\nObject type: File\\r\\nPath to object: \\\\?\\Volume{589e6702-0000-0000-0000-010000000000}\\System Volume Information\\r\\nObject name: MountPointManagerRemoteDatabase\\r\\nReason: Skipped"
+  },
+  "expected": {
+    "message": "Event type: Object not processed\\r\\nApplication type: Unknown application\\r\\nUser: NT AUTHORITY\\SYSTEM (System user)\\r\\nComponent: File Threat Protection\\r\\nResult description: Not processed\\r\\nObject type: File\\r\\nPath to object: \\\\?\\Volume{589e6702-0000-0000-0000-010000000000}\\System Volume Information\\r\\nObject name: MountPointManagerRemoteDatabase\\r\\nReason: Skipped",
+    "event": {
+      "action": "Not processed",
+      "category": [
+        "process"
+      ],
+      "module": "File Threat Protection",
+      "reason": "Object not processed because of Skipped",
+      "type": [
+        "info"
+      ]
+    },
+    "file": {
+      "directory": "\\\\?\\Volume{589e6702-0000-0000-0000-010000000000}\\System Volume Information",
+      "name": "MountPointManagerRemoteDatabase"
+    },
+    "observer": {
+      "product": "Kaspersky Endpoint Security",
+      "type": "edr",
+      "vendor": "Kaspersky"
+    },
+    "related": {
+      "user": [
+        "SYSTEM"
+      ]
+    },
+    "user": {
+      "domain": "NT AUTHORITY",
+      "name": "SYSTEM"
+    }
+  }
+}

--- a/Kaspersky/kaspersky_endpoint_security/tests/test_processing_error.json
+++ b/Kaspersky/kaspersky_endpoint_security/tests/test_processing_error.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "Event type: Processing error\\r\\nName: WINWORD.EXE\\r\\nApplication path: C:\\Program Files\\Microsoft Office\\root\\Office16\\r\\nProcess ID: 12820\\r\\nUser: EXAMPLE\\user.test (Initiator)\\r\\nComponent: File Threat Protection\\r\\nResult description: Processing error\\r\\nObject type: File\\r\\nPath to object: \\\\server.example.local\\profiles$\\user.test\\Outlook\\r\\nObject name: user.test@example.org.ost\\r\\nReason: Read error"
+    "message": "Event type: Processing error\\r\\nName: WINWORD.EXE\\r\\nApplication path: C:\\Program Files\\Microsoft Office\\root\\Office16\\r\\nProcess ID: 12820\\r\\nUser: EXAMPLE\\user.test (Initiator)\\r\\nComponent: File Threat Protection\\r\\nResult description: Processing error\\r\\nObject type: File\\r\\nPath to object: \\\\server.example.com\\profiles$\\user.test\\Outlook\\r\\nObject name: user.test@example.org.ost\\r\\nReason: Read error"
   },
   "expected": {
-    "message": "Event type: Processing error\\r\\nName: WINWORD.EXE\\r\\nApplication path: C:\\Program Files\\Microsoft Office\\root\\Office16\\r\\nProcess ID: 12820\\r\\nUser: EXAMPLE\\user.test (Initiator)\\r\\nComponent: File Threat Protection\\r\\nResult description: Processing error\\r\\nObject type: File\\r\\nPath to object: \\\\server.example.local\\profiles$\\user.test\\Outlook\\r\\nObject name: user.test@example.org.ost\\r\\nReason: Read error",
+    "message": "Event type: Processing error\\r\\nName: WINWORD.EXE\\r\\nApplication path: C:\\Program Files\\Microsoft Office\\root\\Office16\\r\\nProcess ID: 12820\\r\\nUser: EXAMPLE\\user.test (Initiator)\\r\\nComponent: File Threat Protection\\r\\nResult description: Processing error\\r\\nObject type: File\\r\\nPath to object: \\\\server.example.com\\profiles$\\user.test\\Outlook\\r\\nObject name: user.test@example.org.ost\\r\\nReason: Read error",
     "event": {
       "action": "Processing error",
       "category": [
@@ -16,7 +16,7 @@
       ]
     },
     "file": {
-      "directory": "\\\\server.example.local\\profiles$\\user.test\\Outlook",
+      "directory": "\\\\server.example.com\\profiles$\\user.test\\Outlook",
       "name": "user.test@example.org.ost"
     },
     "observer": {

--- a/Kaspersky/kaspersky_endpoint_security/tests/test_processing_error.json
+++ b/Kaspersky/kaspersky_endpoint_security/tests/test_processing_error.json
@@ -1,0 +1,41 @@
+{
+  "input": {
+    "message": "Event type: Processing error\\r\\nName: WINWORD.EXE\\r\\nApplication path: C:\\Program Files\\Microsoft Office\\root\\Office16\\r\\nProcess ID: 12820\\r\\nUser: EXAMPLE\\user.test (Initiator)\\r\\nComponent: File Threat Protection\\r\\nResult description: Processing error\\r\\nObject type: File\\r\\nPath to object: \\\\server.example.local\\profiles$\\user.test\\Outlook\\r\\nObject name: user.test@example.org.ost\\r\\nReason: Read error"
+  },
+  "expected": {
+    "message": "Event type: Processing error\\r\\nName: WINWORD.EXE\\r\\nApplication path: C:\\Program Files\\Microsoft Office\\root\\Office16\\r\\nProcess ID: 12820\\r\\nUser: EXAMPLE\\user.test (Initiator)\\r\\nComponent: File Threat Protection\\r\\nResult description: Processing error\\r\\nObject type: File\\r\\nPath to object: \\\\server.example.local\\profiles$\\user.test\\Outlook\\r\\nObject name: user.test@example.org.ost\\r\\nReason: Read error",
+    "event": {
+      "action": "Processing error",
+      "category": [
+        "process"
+      ],
+      "module": "File Threat Protection",
+      "reason": "Processing error because of Read error",
+      "type": [
+        "info"
+      ]
+    },
+    "file": {
+      "directory": "\\\\server.example.local\\profiles$\\user.test\\Outlook",
+      "name": "user.test@example.org.ost"
+    },
+    "observer": {
+      "product": "Kaspersky Endpoint Security",
+      "type": "edr",
+      "vendor": "Kaspersky"
+    },
+    "process": {
+      "executable": "C:\\Program Files\\Microsoft Office\\root\\Office16\\WINWORD.EXE",
+      "pid": 12820
+    },
+    "related": {
+      "user": [
+        "user.test"
+      ]
+    },
+    "user": {
+      "domain": "EXAMPLE",
+      "name": "user.test"
+    }
+  }
+}


### PR DESCRIPTION
## Description

Relates to https://github.com/SekoiaLab/integration/issues/1792

### Added

- Add parsing support for `Result description: Processing error` events by extending `set_not_processed_fields` filter (shared stage)
- Newly populated ECS fields for `Processing error` events (existing field names, no schema addition):
	- `event.action`
	- `event.category`
	- `event.module`
	- `event.reason`
	- `event.type`
	- `file.directory`
	- `file.name`
	- `process.executable`
	- `process.pid`
	- `user.domain`
	- `user.name`

### Changed

- Modify parsing logic for existing ECS fields in `set_not_processed_fields`:
    - `event.reason`
    - `process.executable`
    - `user.domain`
    - `user.name`
- Improve parsing for `Not processed` events when optional fields are missing
- Improve user parsing robustness for identities with spaces in domain names (for example `NT AUTHORITY\\SYSTEM`)

### Fixed

- Fix `TypeError` in `set_not_processed_fields` when `Reason` is missing by making `event.reason` null-safe
- Fix `TypeError` in `set_not_processed_fields` when `Application path` or `Name` is missing by making `process.executable` null-safe
- Normalize `process.executable` path composition for `Not processed` events

## Type of Change

- [ ] New intake format
- [x] Update to existing intake format
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (please describe):

## Affected Intake Formats

- Vendor/product: Kaspersky/kaspersky_endpoint_security

## Checklist

<!-- Ensure all requirements are met before submitting -->

### 🔒 CRITICAL - Security Requirements (MUST BE VERIFIED FIRST)

- [ ] **No real email addresses** in test files (use: user@example.com, test@example.org)
- [ ] **No real passwords or API keys** (use: "P@ssw0rd!", "xxxxxxxxxxxx", "FAKE_TOKEN_123")
- [ ] **No real IP addresses** (use TEST-NET ranges: 192.0.2.x, 198.51.100.x, 203.0.113.x)
- [ ] **No real phone numbers** (use: +1-555-0100 or similar test numbers)
- [ ] **No real names or PII** (use: "John Doe", "Jane Smith", "User123")
- [ ] **No real company/organization names** in test data (unless public vendors)
- [ ] **No real usernames, hostnames, or domain names** (use: user1, host.example.com, test.corp)
- [ ] All test data has been anonymized and verified

### Required for All PRs

- [ ] Code has been linted
    - [ ] with the linter for manifest, smart-descriptions, and test files (`uv run python linter.py check --changes` in utils/)
    - [ ] with Prettier for the parser code files (`npx prettier --write <module>/<format>/ingest/parser.yml`)
- [ ] All CI/CD checks pass
- [ ] Changes follow the contribution guidelines in `CONTRIBUTING.md`

### Required for New/Updated Intake Formats

- [ ] Clear descriptions provided for modules and formats
- [ ] Logo files included for new modules/formats
- [ ] Parser test coverage is at least 75%
- [ ] At least one smart-description is provided
- [ ] README.md updated (if applicable)
- [ ] Taxonomy mappings are correct and documented
- [ ] Test cases cover edge cases and error handling

### Testing

- [ ] Local tests pass (`uv run pytest` in utils/)
- [ ] Sample data is representative and **completely anonymized**
- [ ] **No sensitive information** (PII, credentials, real IPs, real emails) in test files
- [ ] Test data uses example.com/example.org domains and TEST-NET IP ranges
- [ ] Parser handles malformed data gracefully

### Documentation

- [ ] Code changes are documented
- [ ] Smart-descriptions are clear and informative
- [ ] Field mappings are explained

## Additional Notes

<!-- Add any additional context, screenshots, or information that would help reviewers -->

## Related Issues

<!-- Link any related issues using #issue_number -->

Closes #

## Summary by Sourcery

Extend Kaspersky Endpoint Security intake parsing for additional not-processed event types and harden field extraction for edge cases.

New Features:
- Support parsing of Kaspersky events with `Result description: Processing error` in the shared `set_not_processed_fields` stage.
- Populate additional ECS fields for not-processed and processing-error events, including event, file, process, and user attributes.

Bug Fixes:
- Prevent TypeErrors in `set_not_processed_fields` when `Reason`, `Application path`, or `Name` fields are missing in incoming events.
- Normalize and correct `process.executable` path composition for not-processed events to handle partial path data.

Enhancements:
- Improve parsing robustness for not-processed events when optional fields are absent, including safer construction of composite fields.
- Make user identity parsing more resilient to domains with spaces and special formats (for example `NT AUTHORITY\\SYSTEM`).

Documentation:
- Document the new behavior and field mappings for not-processed and processing-error events in the intake CHANGELOG.

Tests:
- Add parser test fixtures for not-processed events missing reason or process identity fields and for processing-error events.