### PR TITLE
feature/aws_cloudtrail_add_fields

### DIFF
--- a/AWS/aws-cloudtrail/CHANGELOG.md
+++ b/AWS/aws-cloudtrail/CHANGELOG.md
@@ -6,3 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## 2026-08-05
+
+### Added
+
+- Parse new custom fields from `userIdentity`:
+    - action.properties.userIdentity.inScopeOf.credentialsIssuedTo
+    - action.properties.userIdentity.inScopeOf.issuerType
+    - aws.cloudtrail.user_identity.inScopeOf.credentialsIssuedTo
+    - aws.cloudtrail.user_identity.inScopeOf.issuerType

--- a/AWS/aws-cloudtrail/_meta/fields.yml
+++ b/AWS/aws-cloudtrail/_meta/fields.yml
@@ -38,6 +38,16 @@ action.properties.userIdentity.arn:
   name: action.properties.userIdentity.arn
   type: keyword
 
+action.properties.userIdentity.inScopeOf.credentialsIssuedTo:
+  description: ARN of the resource that received the issued credentials
+  name: action.properties.userIdentity.inScopeOf.credentialsIssuedTo
+  type: keyword
+
+action.properties.userIdentity.inScopeOf.issuerType:
+  description: Type of the AWS issuer that scoped the credentials
+  name: action.properties.userIdentity.inScopeOf.issuerType
+  type: keyword
+
 action.properties.userIdentity.invokedBy:
   description: User invoked by
   name: action.properties.userIdentity.invokedBy
@@ -145,6 +155,16 @@ aws.cloudtrail.user_identity.arn:
     name: User ARN
     property: account_login
     type: user-account
+  type: keyword
+
+aws.cloudtrail.user_identity.inScopeOf.credentialsIssuedTo:
+  description: ARN of the resource that received the issued credentials
+  name: aws.cloudtrail.user_identity.inScopeOf.credentialsIssuedTo
+  type: keyword
+
+aws.cloudtrail.user_identity.inScopeOf.issuerType:
+  description: Type of the AWS issuer that scoped the credentials
+  name: aws.cloudtrail.user_identity.inScopeOf.issuerType
   type: keyword
 
 aws.cloudtrail.user_identity.principalId:

--- a/AWS/aws-cloudtrail/_meta/smart-descriptions.json
+++ b/AWS/aws-cloudtrail/_meta/smart-descriptions.json
@@ -1,5 +1,30 @@
 [
   {
+    "value": "{aws.cloudtrail.user_identity.inScopeOf.issuerType} issued credentials to {aws.cloudtrail.user_identity.inScopeOf.credentialsIssuedTo} for {event.action}",
+    "conditions": [
+      {
+        "field": "action.type",
+        "value": "AwsApiCall"
+      },
+      {
+        "field": "aws.cloudtrail.user_identity.inScopeOf.issuerType"
+      },
+      {
+        "field": "aws.cloudtrail.user_identity.inScopeOf.credentialsIssuedTo"
+      },
+      {
+        "field": "event.action"
+      }
+    ],
+    "relationships": [
+      {
+        "source": "aws.cloudtrail.user_identity.inScopeOf.issuerType",
+        "target": "aws.cloudtrail.user_identity.inScopeOf.credentialsIssuedTo",
+        "type": "issued"
+      }
+    ]
+  },
+  {
     "value": "{aws.cloudtrail.user_identity.arn} called {event.action} method from {event.provider}",
     "conditions": [
       {

--- a/AWS/aws-cloudtrail/ingest/parser.yml
+++ b/AWS/aws-cloudtrail/ingest/parser.yml
@@ -84,6 +84,8 @@ stages:
           action.properties.errorMessage: "{{json_event.message.errorMessage}}"
           action.properties.recipientAccountId: "{{json_event.message.recipientAccountId}}"
           action.properties.userIdentity: "{{json_event.message.userIdentity}}"
+          action.properties.userIdentity.inScopeOf.issuerType: "{{json_event.message.userIdentity.inScopeOf.issuerType}}"
+          action.properties.userIdentity.inScopeOf.credentialsIssuedTo: "{{json_event.message.userIdentity.inScopeOf.credentialsIssuedTo}}"
           action.properties.resources: "{{json_event.message.resources}}"
           action.properties.requestParameters.userData: "{{json_event.message.requestParameters.userData}}"
           action.properties.responseElements.publiclyAccessible: "{{json_event.message.responseElements.publiclyAccessible}}"
@@ -92,6 +94,8 @@ stages:
     actions:
       - set:
           aws.cloudtrail.user_identity: "{{json_event.message.userIdentity}}"
+          aws.cloudtrail.user_identity.inScopeOf.issuerType: "{{json_event.message.userIdentity.inScopeOf.issuerType}}"
+          aws.cloudtrail.user_identity.inScopeOf.credentialsIssuedTo: "{{json_event.message.userIdentity.inScopeOf.credentialsIssuedTo}}"
           aws.cloudtrail.response_elements.pendingModifiedValues.masterUserPassword: "{{json_event.message.responseElements.pendingModifiedValues.masterUserPassword}}"
           aws.cloudtrail.response_elements.user.userName: "{{json_event.message.responseElements.user.userName}}"
           aws.cloudtrail.cluster_name: "{{json_event.message.responseElements.cluster.clusterName}}"

--- a/AWS/aws-cloudtrail/tests/event_sts_get_caller_identity_in_scope_of.json
+++ b/AWS/aws-cloudtrail/tests/event_sts_get_caller_identity_in_scope_of.json
@@ -1,0 +1,107 @@
+{
+  "input": {
+    "message": "{\"eventVersion\":\"1.11\",\"userIdentity\":{\"type\":\"AssumedRole\",\"principalId\":\"AROATESTEXAMPLE1234:i-0abc123def4567890\",\"arn\":\"arn:aws:sts::111122223333:assumed-role/example-ec2-role/i-0abc123def4567890\",\"accountId\":\"111122223333\",\"accessKeyId\":\"ASIAXXXXXXXXXXXXXXXX\",\"sessionContext\":{\"sessionIssuer\":{\"type\":\"Role\",\"principalId\":\"AROATESTEXAMPLE1234\",\"arn\":\"arn:aws:iam::111122223333:role/example-ec2-role\",\"accountId\":\"111122223333\",\"userName\":\"example-ec2-role\"},\"attributes\":{\"creationDate\":\"2026-07-29T14:42:24Z\",\"mfaAuthenticated\":\"false\"},\"ec2RoleDelivery\":\"2.0\"},\"inScopeOf\":{\"issuerType\":\"AWS::EC2::Instance\",\"credentialsIssuedTo\":\"arn:aws:ec2:eu-north-1:111122223333:instance/i-0abc123def4567890\"}},\"eventTime\":\"2026-07-29T14:45:54Z\",\"eventSource\":\"sts.amazonaws.com\",\"eventName\":\"GetCallerIdentity\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"203.0.113.10\",\"userAgent\":\"aws-cli/2.36.10 md/awscrt#0.36.0 ua/2.1 os/linux#6.12.0 md/arch#x86_64 lang/python#3.14.6\",\"requestParameters\":null,\"responseElements\":null,\"requestID\":\"7024ebb7-89b7-4d52-8702-d4c141feef47\",\"eventID\":\"8b745882-9e22-4e08-9fbb-b06aa2d5f061\",\"readOnly\":true,\"eventType\":\"AwsApiCall\",\"managementEvent\":true,\"recipientAccountId\":\"111122223333\",\"eventCategory\":\"Management\",\"tlsDetails\":{\"tlsVersion\":\"TLSv1.3\",\"cipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"clientProvidedHostHeader\":\"sts.amazonaws.com\",\"keyExchange\":\"X25519MLKEM768\"}}"
+  },
+  "expected": {
+    "message": "{\"eventVersion\":\"1.11\",\"userIdentity\":{\"type\":\"AssumedRole\",\"principalId\":\"AROATESTEXAMPLE1234:i-0abc123def4567890\",\"arn\":\"arn:aws:sts::111122223333:assumed-role/example-ec2-role/i-0abc123def4567890\",\"accountId\":\"111122223333\",\"accessKeyId\":\"ASIAXXXXXXXXXXXXXXXX\",\"sessionContext\":{\"sessionIssuer\":{\"type\":\"Role\",\"principalId\":\"AROATESTEXAMPLE1234\",\"arn\":\"arn:aws:iam::111122223333:role/example-ec2-role\",\"accountId\":\"111122223333\",\"userName\":\"example-ec2-role\"},\"attributes\":{\"creationDate\":\"2026-07-29T14:42:24Z\",\"mfaAuthenticated\":\"false\"},\"ec2RoleDelivery\":\"2.0\"},\"inScopeOf\":{\"issuerType\":\"AWS::EC2::Instance\",\"credentialsIssuedTo\":\"arn:aws:ec2:eu-north-1:111122223333:instance/i-0abc123def4567890\"}},\"eventTime\":\"2026-07-29T14:45:54Z\",\"eventSource\":\"sts.amazonaws.com\",\"eventName\":\"GetCallerIdentity\",\"awsRegion\":\"us-east-1\",\"sourceIPAddress\":\"203.0.113.10\",\"userAgent\":\"aws-cli/2.36.10 md/awscrt#0.36.0 ua/2.1 os/linux#6.12.0 md/arch#x86_64 lang/python#3.14.6\",\"requestParameters\":null,\"responseElements\":null,\"requestID\":\"7024ebb7-89b7-4d52-8702-d4c141feef47\",\"eventID\":\"8b745882-9e22-4e08-9fbb-b06aa2d5f061\",\"readOnly\":true,\"eventType\":\"AwsApiCall\",\"managementEvent\":true,\"recipientAccountId\":\"111122223333\",\"eventCategory\":\"Management\",\"tlsDetails\":{\"tlsVersion\":\"TLSv1.3\",\"cipherSuite\":\"TLS_AES_128_GCM_SHA256\",\"clientProvidedHostHeader\":\"sts.amazonaws.com\",\"keyExchange\":\"X25519MLKEM768\"}}",
+    "event": {
+      "action": "GetCallerIdentity",
+      "category": [
+        "network"
+      ],
+      "outcome": "success",
+      "provider": "sts.amazonaws.com",
+      "type": [
+        "access"
+      ]
+    },
+    "@timestamp": "2026-07-29T14:45:54Z",
+    "action": {
+      "name": "GetCallerIdentity",
+      "outcome": "success",
+      "properties": {
+        "recipientAccountId": "111122223333",
+        "userIdentity": {
+          "accountId": "111122223333",
+          "arn": "arn:aws:sts::111122223333:assumed-role/example-ec2-role/i-0abc123def4567890",
+          "inScopeOf": {
+            "credentialsIssuedTo": "arn:aws:ec2:eu-north-1:111122223333:instance/i-0abc123def4567890",
+            "issuerType": "AWS::EC2::Instance"
+          },
+          "principalId": "AROATESTEXAMPLE1234:i-0abc123def4567890",
+          "sessionContext": {
+            "attributes": {
+              "mfaAuthenticated": "false"
+            },
+            "sessionIssuer": {
+              "arn": "arn:aws:iam::111122223333:role/example-ec2-role",
+              "type": "Role",
+              "userName": "example-ec2-role"
+            }
+          },
+          "type": "AssumedRole"
+        }
+      },
+      "target": "network-traffic",
+      "type": "AwsApiCall"
+    },
+    "aws": {
+      "cloudtrail": {
+        "user_identity": {
+          "accessKeyId": "ASIAXXXXXXXXXXXXXXXX",
+          "accountId": "111122223333",
+          "arn": "arn:aws:sts::111122223333:assumed-role/example-ec2-role/i-0abc123def4567890",
+          "inScopeOf": {
+            "credentialsIssuedTo": "arn:aws:ec2:eu-north-1:111122223333:instance/i-0abc123def4567890",
+            "issuerType": "AWS::EC2::Instance"
+          },
+          "principalId": "AROATESTEXAMPLE1234:i-0abc123def4567890",
+          "sessionContext": {
+            "sessionIssuer": {
+              "arn": "arn:aws:iam::111122223333:role/example-ec2-role",
+              "userName": "example-ec2-role"
+            }
+          },
+          "type": "AssumedRole"
+        }
+      }
+    },
+    "cloud": {
+      "account": {
+        "id": "111122223333"
+      },
+      "provider": "aws",
+      "region": "us-east-1",
+      "service": {
+        "name": "cloudtrail"
+      }
+    },
+    "related": {
+      "ip": [
+        "203.0.113.10"
+      ]
+    },
+    "source": {
+      "address": "203.0.113.10",
+      "ip": "203.0.113.10"
+    },
+    "tls": {
+      "cipher": "TLS_AES_128_GCM_SHA256",
+      "version": "TLSv1.3"
+    },
+    "user": {
+      "id": "111122223333"
+    },
+    "user_agent": {
+      "device": {
+        "name": "Other"
+      },
+      "name": "aws-cli",
+      "original": "aws-cli/2.36.10 md/awscrt#0.36.0 ua/2.1 os/linux#6.12.0 md/arch#x86_64 lang/python#3.14.6",
+      "os": {
+        "name": "Linux"
+      },
+      "version": "2.36.10"
+    }
+  }
+}


### PR DESCRIPTION
## Description

Relates to https://github.com/SekoiaLab/integration/issues/1835

### Added

- Parse new custom fields from `userIdentity`:
    - action.properties.userIdentity.inScopeOf.credentialsIssuedTo
    - action.properties.userIdentity.inScopeOf.issuerType
    - aws.cloudtrail.user_identity.inScopeOf.credentialsIssuedTo
    - aws.cloudtrail.user_identity.inScopeOf.issuerType

## Type of Change

- [ ] New intake format
- [x] Update to existing intake format
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (please describe):

## Affected Intake Formats

- Vendor/product: AWS/aws-cloudtrail

## Checklist

<!-- Ensure all requirements are met before submitting -->

### 🔒 CRITICAL - Security Requirements (MUST BE VERIFIED FIRST)

- [ ] **No real email addresses** in test files (use: user@example.com, test@example.org)
- [ ] **No real passwords or API keys** (use: "P@ssw0rd!", "xxxxxxxxxxxx", "FAKE_TOKEN_123")
- [ ] **No real IP addresses** (use TEST-NET ranges: 192.0.2.x, 198.51.100.x, 203.0.113.x)
- [ ] **No real phone numbers** (use: +1-555-0100 or similar test numbers)
- [ ] **No real names or PII** (use: "John Doe", "Jane Smith", "User123")
- [ ] **No real company/organization names** in test data (unless public vendors)
- [ ] **No real usernames, hostnames, or domain names** (use: user1, host.example.com, test.corp)
- [ ] All test data has been anonymized and verified

### Required for All PRs

- [ ] Code has been linted
    - [ ] with the linter for manifest, smart-descriptions, and test files (`uv run python linter.py check --changes` in utils/)
    - [ ] with Prettier for the parser code files (`npx prettier --write <module>/<format>/ingest/parser.yml`)
- [ ] All CI/CD checks pass
- [ ] Changes follow the contribution guidelines in `CONTRIBUTING.md`

### Required for New/Updated Intake Formats

- [ ] Clear descriptions provided for modules and formats
- [ ] Logo files included for new modules/formats
- [ ] Parser test coverage is at least 75%
- [ ] At least one smart-description is provided
- [ ] README.md updated (if applicable)
- [ ] Taxonomy mappings are correct and documented
- [ ] Test cases cover edge cases and error handling

### Testing

- [ ] Local tests pass (`uv run pytest` in utils/)
- [ ] Sample data is representative and **completely anonymized**
- [ ] **No sensitive information** (PII, credentials, real IPs, real emails) in test files
- [ ] Test data uses example.com/example.org domains and TEST-NET IP ranges
- [ ] Parser handles malformed data gracefully

### Documentation

- [ ] Code changes are documented
- [ ] Smart-descriptions are clear and informative
- [ ] Field mappings are explained

## Additional Notes

<!-- Add any additional context, screenshots, or information that would help reviewers -->

## Related Issues

<!-- Link any related issues using #issue_number -->

Closes #

## Summary by Sourcery

Extend AWS CloudTrail intake to capture additional userIdentity scoping metadata.

New Features:
- Add new action.properties.userIdentity.inScopeOf.* and aws.cloudtrail.user_identity.inScopeOf.* fields for credentials issuer context.

Enhancements:
- Map new inScopeOf issuerType and credentialsIssuedTo attributes from CloudTrail events in the parser and document them in the changelog.

Tests:
- Add a new STS GetCallerIdentity in-scope-of event fixture to cover the new userIdentity fields.