### PR TITLE
fix(CiscoSecureAccess): map DNS roaming clients to host fields

### DIFF
--- a/CiscoSecureAccess/cisco-secure-access-dns/CHANGELOG.md
+++ b/CiscoSecureAccess/cisco-secure-access-dns/CHANGELOG.md
@@ -6,3 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- Map AnyConnect roaming client identities to `host.name`, `host.hostname`, and
+  `host.ip` to improve endpoint search and asset correlation.
+- Prefer the roaming-client hostname in DNS smart descriptions when available.

--- a/CiscoSecureAccess/cisco-secure-access-dns/_meta/smart-descriptions.json
+++ b/CiscoSecureAccess/cisco-secure-access-dns/_meta/smart-descriptions.json
@@ -1,5 +1,14 @@
 [
   {
+    "value": "{event.action} DNS request for {dns.question.name} from {host.name} ({source.ip})",
+    "conditions": [
+      { "field": "event.action" },
+      { "field": "dns.question.name" },
+      { "field": "host.name" },
+      { "field": "source.ip" }
+    ]
+  },
+  {
     "value": "{event.action} DNS request for {dns.question.name} from {source.ip}",
     "conditions": [
       { "field": "event.action" },

--- a/CiscoSecureAccess/cisco-secure-access-dns/ingest/parser.yml
+++ b/CiscoSecureAccess/cisco-secure-access-dns/ingest/parser.yml
@@ -70,6 +70,23 @@ stages:
           source.nat.ip: "{{parsed_dsv.message.external_ip}}"
         filter: "{{parsed_dsv.message.external_ip | is_ipaddress}}"
 
+      # Cisco Secure Access exposes the endpoint hostname as an identity when the
+      # request originates from an AnyConnect roaming client. Normalize it to
+      # host.* so the endpoint can participate in Sekoia asset correlation.
+      - set:
+          host.name: "{{parsed_dsv.message.most_granular_identity}}"
+          host.hostname: "{{parsed_dsv.message.most_granular_identity}}"
+        filter: >-
+          {{parsed_dsv.message.most_granular_identity_type == "Anyconnect Roaming Client"
+          and parsed_dsv.message.most_granular_identity | length > 0}}
+
+      - set:
+          host.ip:
+            - "{{parsed_dsv.message.internal_ip}}"
+        filter: >-
+          {{parsed_dsv.message.most_granular_identity_type == "Anyconnect Roaming Client"
+          and parsed_dsv.message.internal_ip | is_ipaddress}}
+
   set_custom_fields:
     actions:
       - set:

--- a/CiscoSecureAccess/cisco-secure-access-dns/tests/test_roaming_client_asset.json
+++ b/CiscoSecureAccess/cisco-secure-access-dns/tests/test_roaming_client_asset.json
@@ -10,9 +10,7 @@
         "network"
       ],
       "dataset": "dns",
-      "outcome": [
-        "success"
-      ],
+      "outcome": "success",
       "type": [
         "connection",
         "protocol"
@@ -62,8 +60,8 @@
     },
     "related": {
       "hosts": [
-        "WIN11-CLIENT01",
-        "example.com"
+        "example.com",
+        "WIN11-CLIENT01"
       ],
       "ip": [
         "192.0.2.10",

--- a/CiscoSecureAccess/cisco-secure-access-dns/tests/test_roaming_client_asset.json
+++ b/CiscoSecureAccess/cisco-secure-access-dns/tests/test_roaming_client_asset.json
@@ -1,0 +1,81 @@
+{
+  "input": {
+    "message": "\"2024-09-11 18:46:00\",\"WIN11-CLIENT01\",\"WIN11-CLIENT01\",\"192.0.2.10\",\"198.51.100.20\",\"Allowed\",\"1 (A)\",\"NOERROR\",\"example.com.\",\"Software/Technology,Application\",\"Anyconnect Roaming Client\",\"Anyconnect Roaming Client\",\"\",\"\",\"\",\"REDACTED\""
+  },
+  "expected": {
+    "message": "\"2024-09-11 18:46:00\",\"WIN11-CLIENT01\",\"WIN11-CLIENT01\",\"192.0.2.10\",\"198.51.100.20\",\"Allowed\",\"1 (A)\",\"NOERROR\",\"example.com.\",\"Software/Technology,Application\",\"Anyconnect Roaming Client\",\"Anyconnect Roaming Client\",\"\",\"\",\"\",\"REDACTED\"",
+    "event": {
+      "action": "allowed",
+      "category": [
+        "network"
+      ],
+      "dataset": "dns",
+      "outcome": [
+        "success"
+      ],
+      "type": [
+        "connection",
+        "protocol"
+      ]
+    },
+    "@timestamp": "2024-09-11T18:46:00Z",
+    "cisco_secure_access": {
+      "dns": {
+        "categories": [
+          "Application",
+          "Software/Technology"
+        ],
+        "identities": [
+          "WIN11-CLIENT01"
+        ],
+        "identity_types": [
+          "Anyconnect Roaming Client"
+        ],
+        "most_granular_identity": "WIN11-CLIENT01",
+        "most_granular_identity_type": "Anyconnect Roaming Client"
+      }
+    },
+    "dns": {
+      "question": {
+        "name": "example.com",
+        "registered_domain": "example.com",
+        "top_level_domain": "com",
+        "type": "A"
+      },
+      "response_code": "NOERROR",
+      "type": "query"
+    },
+    "host": {
+      "name": "WIN11-CLIENT01",
+      "hostname": "WIN11-CLIENT01",
+      "ip": [
+        "192.0.2.10"
+      ]
+    },
+    "observer": {
+      "product": "Secure Access",
+      "type": "dns",
+      "vendor": "Cisco"
+    },
+    "organization": {
+      "id": "REDACTED"
+    },
+    "related": {
+      "hosts": [
+        "WIN11-CLIENT01",
+        "example.com"
+      ],
+      "ip": [
+        "192.0.2.10",
+        "198.51.100.20"
+      ]
+    },
+    "source": {
+      "address": "192.0.2.10",
+      "ip": "192.0.2.10",
+      "nat": {
+        "ip": "198.51.100.20"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

Improve Cisco Secure Access DNS endpoint normalization so DNS requests generated by AnyConnect roaming clients can correlate to Sekoia host/global assets.

The current parser stores the endpoint identity in vendor-specific fields such as:

- `cisco_secure_access.dns.most_granular_identity`
- `cisco_secure_access.dns.most_granular_identity_type`

but does not populate ECS `host.*` fields.

In a production export of 900 Cisco Secure Access DNS events:

- 900/900 events parsed successfully.
- 718/900 events had `most_granular_identity_type = "Anyconnect Roaming Client"`.
- Those events represented 139 unique endpoint identities.
- None of the events contained `host.*` fields.
- None of the events received host asset correlation through `sekoiaio.assets.host.*`.

This change maps the AnyConnect roaming-client identity to:

- `host.name`
- `host.hostname`
- `host.ip`

The existing `source.ip` and `source.nat.ip` mappings are preserved.

The mapping is intentionally limited to events where:

`most_granular_identity_type == "Anyconnect Roaming Client"`

so identities of type `Networks` are not incorrectly represented as endpoint hosts.

The DNS smart description is also enhanced to include the endpoint hostname when it is available, while retaining the existing source-IP-only description as a fallback.

## Type of Change

- [ ] New intake format
- [x] Update to existing intake format
- [x] Bug fix
- [ ] Documentation update
- [ ] Other (please describe):

## Affected Intake Formats

- Vendor/product: Cisco Secure Access - DNS

## Checklist

### 🔒 CRITICAL - Security Requirements (MUST BE VERIFIED FIRST)

- [x] **No real email addresses** in test files (use: user@example.com, test@example.org)
- [x] **No real passwords or API keys** (use: "P@ssw0rd!", "xxxxxxxxxxxx", "FAKE_TOKEN_123")
- [x] **No real IP addresses** (use TEST-NET ranges: 192.0.2.x, 198.51.100.x, 203.0.113.x)
- [x] **No real phone numbers** (use: +1-555-0100 or similar test numbers)
- [x] **No real names or PII** (use: "John Doe", "Jane Smith", "User123")
- [x] **No real company/organization names** in test data (unless public vendors)
- [x] **No real usernames, hostnames, or domain names** (use: user1, host.example.com, test.corp)
- [x] All test data has been anonymized and verified

### Required for All PRs

- [ ] Code has been linted
    - [ ] with the linter for manifest, smart-descriptions, and test files (`uv run python linter.py check --changes` in utils/)
    - [ ] with Prettier for the parser code files (`npx prettier --write <module>/<format>/ingest/parser.yml`)
- [ ] All CI/CD checks pass
- [x] Changes follow the contribution guidelines in `CONTRIBUTING.md`

### Required for New/Updated Intake Formats

- [x] Clear descriptions provided for modules and formats
- [ ] Logo files included for new modules/formats — N/A, existing format
- [ ] Parser test coverage is at least 75%
- [x] At least one smart-description is provided
- [ ] README.md updated (if applicable) — N/A, no README change required
- [x] Taxonomy mappings are correct and documented
- [ ] Test cases cover edge cases and error handling

### Testing

- [ ] Local tests pass (`uv run pytest` in utils/)
- [x] Sample data is representative and **completely anonymized**
- [x] **No sensitive information** (PII, credentials, real IPs, real emails) in test files
- [x] Test data uses example.com/example.org domains and TEST-NET IP ranges
- [ ] Parser handles malformed data gracefully

### Documentation

- [x] Code changes are documented
- [x] Smart-descriptions are clear and informative
- [x] Field mappings are explained

## Additional Notes

The sibling Cisco Secure Access Web parser already maps its endpoint hostname to `host.name` and `host.hostname`. This change brings the DNS intake into closer alignment with that ECS normalization.

A separate follow-up improvement may be useful for events where an Active Directory user is the most-granular identity but an AnyConnect roaming-client hostname is also present in the parallel `identities` / `identity_types` arrays. This PR intentionally does not attempt positional correlation of those arrays.

## Related Issues

N/A

## Summary by Sourcery

Map Cisco Secure Access DNS roaming-client identities to ECS host fields and improve endpoint-aware event descriptions.

Bug Fixes:
- Normalize AnyConnect roaming-client identities into ECS host fields to enable endpoint search and asset correlation for Cisco Secure Access DNS events.

Enhancements:
- Enhance DNS smart descriptions to prefer the roaming-client hostname while retaining the source-IP fallback.

Documentation:
- Document the new roaming-client host mappings and smart-description behavior in the changelog.

Tests:
- Add coverage for AnyConnect roaming-client host normalization and asset correlation.