### PR TITLE
fix(Microsoft): normalize Defender email message IDs

### DIFF
--- a/Microsoft/microsoft-365-defender/CHANGELOG.md
+++ b/Microsoft/microsoft-365-defender/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Normalize `email.message_id` by removing surrounding angle brackets from Microsoft Defender XDR `InternetMessageId` values when present.
+
 ## [1.0.8] - 2026-08-12
 
 ### Added

--- a/Microsoft/microsoft-365-defender/ingest/parser.yml
+++ b/Microsoft/microsoft-365-defender/ingest/parser.yml
@@ -143,7 +143,7 @@ stages:
           destination.port: "{{json_event.message.properties.RemotePort or json_event.message.properties.DestinationPort}}"
           email.delivery_timestamp: "{{parse_raw_event_data.data.get('Entities', [])[0].get('ReceivedDate')|to_rfc3339()}}"
           email.local_id: "{{json_event.message.properties.NetworkMessageId or parse_raw_event_data.data.get('Entities', [])[0].get('NetworkMessageId')}}"
-          email.message_id: "{{json_event.message.properties.InternetMessageId or parse_raw_event_data.data.get('Entities', [])[0].get('InternetMessageId')}}"
+          email.message_id: "{{(json_event.message.properties.InternetMessageId or parse_raw_event_data.data.get('Entities', [])[0].get('InternetMessageId')).strip('>').strip('<')}}"
           email.subject: "{{json_event.message.properties.EmailSubject or json_event.message.properties.Subject or parse_raw_event_data.data.get('Entities', [])[0].get('Subject')}}"
           file.directory: "{{json_event.message.properties.FolderPath}}"
           file.hash.md5: "{{json_event.message.properties.MD5}}"

--- a/Microsoft/microsoft-365-defender/tests/test_email_events_2.json
+++ b/Microsoft/microsoft-365-defender/tests/test_email_events_2.json
@@ -53,7 +53,7 @@
         ]
       },
       "local_id": "22222222-2222-2222-2222-222222222222",
-      "message_id": "<AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA@AAAAAAAAAAAAA.something.prod.outlook.com>",
+      "message_id": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA@AAAAAAAAAAAAA.something.prod.outlook.com",
       "subject": "[Security Alert] D\u00e9tection d\u2019un clic sur un lien de phishing",
       "to": {
         "address": [


### PR DESCRIPTION
## Description

Normalize `email.message_id` values in the Microsoft Defender XDR / Microsoft 365 Defender intake by removing surrounding angle brackets from `InternetMessageId`.

Microsoft Defender commonly provides RFC-style Internet Message IDs in the form:

`<message-id@example.com>`

The Defender intake currently copies this value directly to `email.message_id`, preserving the surrounding `<` and `>` characters.

Other Sekoia email intakes, including the Office 365 intake, normalize this field without the surrounding brackets. The Defender parser also already performs the same normalization for `InternetMessageId` values extracted from AlertEvidence `AdditionalFields`.

This inconsistency makes cross-intake searches for the same email message ID less reliable because the same identifier may be indexed as either:

`message-id@example.com`

or:

`<message-id@example.com>`

This change normalizes the common Microsoft Defender `InternetMessageId` mapping by stripping surrounding angle brackets before populating `email.message_id`.

An existing `AdvancedHunting-EmailEvents` test containing a bracketed `InternetMessageId` has been updated to verify the normalized result.

## Type of Change

- [ ] New intake format
- [ ] Other (please describe):
- [x] Update to existing intake format
- [x] Bug fix
- [ ] Documentation update

## Affected Intake Formats

- Vendor/product: Microsoft Defender XDR / Microsoft 365 Defender

## Checklist

### 🔒 CRITICAL - Security Requirements (MUST BE VERIFIED FIRST)

- [x] **No real email addresses** introduced by this change
- [x] **No real passwords or API keys** introduced by this change
- [ ] **No real IP addresses** in test files (the existing fixture contains legacy synthetic `1.2.3.4`; this PR does not modify or introduce it)
- [x] **No real phone numbers** introduced by this change
- [x] **No real names or PII** introduced by this change
- [x] **No real company/organization names** introduced by this change
- [ ] **No real usernames, hostnames, or domain names** (the existing fixture uses legacy synthetic `company.com`; this PR does not modify or introduce it)
- [x] No new raw test data was added; only the expected normalized `email.message_id` value was changed

### Required for All PRs

- [ ] Code has been linted
    - [ ] with the linter for manifest, smart-descriptions, and test files (`uv run python linter.py check --changes` in utils/)
    - [ ] with Prettier for the parser code files (`npx prettier --write <module>/<format>/ingest/parser.yml`)
- [ ] All CI/CD checks pass
- [x] Changes follow the contribution guidelines in `CONTRIBUTING.md`

### Required for New/Updated Intake Formats

- [ ] Clear descriptions provided for modules and formats — N/A, existing format
- [ ] Logo files included for new modules/formats — N/A, existing format
- [ ] Parser test coverage is at least 75% — existing format; not recalculated by this PR
- [ ] At least one smart-description is provided — no smart-description change required
- [ ] README.md updated (if applicable) — N/A
- [ ] Taxonomy mappings are correct and documented — N/A, no taxonomy mapping changes
- [ ] Test cases cover edge cases and error handling — no parser error-handling behavior changed

### Testing

- [ ] Local tests pass (`uv run pytest` in utils/)
- [x] Existing representative sample data is used
- [x] **No sensitive information** was added by this change
- [ ] Test data uses example.com/example.org domains and TEST-NET IP ranges — existing fixture predates this requirement and was not otherwise modified
- [ ] Parser handles malformed data gracefully — not affected by this change

### Documentation

- [x] Code changes are documented in `CHANGELOG.md`
- [ ] Smart-descriptions are clear and informative — N/A, no smart-description change
- [x] Field mapping behavior is explained in this PR

## Additional Notes

The Microsoft Defender parser already normalizes `InternetMessageId` when it is extracted from AlertEvidence `AdditionalFields`:

`email.message_id: "{{parse_additional_fields.fields.InternetMessageId.strip('>').strip('<')}}"`

This PR applies equivalent normalization to the common `InternetMessageId` mapping so email message IDs are represented consistently across Microsoft Defender event types.

The Office 365 intake also already normalizes surrounding angle brackets from `InternetMessageId`, so this change improves consistency between Microsoft email-related intakes.

No new test fixture was introduced. The existing `test_email_events_2.json` fixture was updated only to expect the normalized `email.message_id`.

Local repository lint/test commands have not been run in this environment. CI results will be used to validate the change before the PR is marked ready for review.

## Related Issues

N/A

## Summary by Sourcery

Normalize Microsoft Defender email message IDs to ensure consistent cross-intake searching.

Bug Fixes:
- Normalize Microsoft Defender XDR `InternetMessageId` values before populating `email.message_id`, removing surrounding angle brackets for consistent message ID indexing.

Tests:
- Update the existing Advanced Hunting email-events test expectation to verify normalized message IDs.