### PR TITLE
fix/sonicwall_sma_align_series

### DIFF
--- a/SonicWall/README.md
+++ b/SonicWall/README.md
@@ -7,5 +7,5 @@ Sonic Wall is a cybersecurity company specialized in content control and network
 ## Intakes
 
 - SonicWall Firewall
-- SonicWall SMA 100 Series
-- SonicWall SMA 1000 Series
+- SonicWall Secure Mobile Access 100 Series
+- SonicWall Secure Mobile Access 1000 Series

--- a/SonicWall/sonicwall-sma-100/CHANGELOG.md
+++ b/SonicWall/sonicwall-sma-100/CHANGELOG.md
@@ -11,13 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Deprecate _SonicWall/sonicwall-sma-100_ and recommend _SonicWall/sonicwall-sma-1000_ as replacement
 - Align _SonicWall/sonicwall-sma-100_ manifest wording and naming conventions with _SonicWall/sonicwall-sma-1000_
 - Replace legacy `data_sources` entry with normalized taxonomy keys:
-	- `Authentication logs`
-	- `Network device logs`
+  - `Authentication logs`
+  - `Network device logs`
 - Update ECS fields parsing:
-	- `@timestamp`: add an explicit date format for `vp_time` parsing to improve timestamp parsing robustness
-	- `event.dataset`: set value to `sonicwall.sma.100.sslvpn` for consistent event categorization
+  - `@timestamp`: add an explicit date format for `vp_time` parsing to improve timestamp parsing robustness
+  - `event.dataset`: set value to `sonicwall.sma.100.sslvpn` for consistent event categorization
 - Scope smart-descriptions to `event.dataset = sonicwall.sma.100.sslvpn` to avoid over-broad matching
 
 ## [1.1.0] - 2026-08-19

--- a/SonicWall/sonicwall-sma-100/CHANGELOG.md
+++ b/SonicWall/sonicwall-sma-100/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-08-20
+
+### Changed
+
+- Align _SonicWall/sonicwall-sma-100_ manifest wording and naming conventions with _SonicWall/sonicwall-sma-1000_
+- Replace legacy `data_sources` entry with normalized taxonomy keys:
+	- `Authentication logs`
+	- `Network device logs`
+- Update ECS fields parsing:
+	- `@timestamp`: add an explicit date format for `vp_time` parsing to improve timestamp parsing robustness
+	- `event.dataset`: set value to `sonicwall.sma.100.sslvpn` for consistent event categorization
+- Scope smart-descriptions to `event.dataset = sonicwall.sma.100.sslvpn` to avoid over-broad matching
+
 ## [1.1.0] - 2026-08-19
 
 ### Changed

--- a/SonicWall/sonicwall-sma-100/_meta/manifest.yml
+++ b/SonicWall/sonicwall-sma-100/_meta/manifest.yml
@@ -1,7 +1,9 @@
 uuid: 622999fe-d383-4d41-9f2d-eed5013fe463
-name: SonicWall Secure Mobile Access 100 Series
+name: SonicWall Secure Mobile Access 100 Series [DEPRECATED]
 slug: sonicwall-sma-100
-description: SonicWall Secure Mobile Access 100 Series logs are structured key-value records that capture SSL VPN access and user authentication activity for monitoring and investigation.
+description: >-
+  SonicWall Secure Mobile Access 100 Series logs are structured key-value records that capture SSL VPN access and user authentication activity for monitoring and investigation.
+  This integration is now deprecated. Please use SonicWall Secure Mobile Access 1000 Series instead.
 data_sources:
   Authentication logs: SSL VPN events capture user identity and login context.
   Network device logs: SSL VPN appliance telemetry provides network access event details.

--- a/SonicWall/sonicwall-sma-100/_meta/manifest.yml
+++ b/SonicWall/sonicwall-sma-100/_meta/manifest.yml
@@ -1,7 +1,8 @@
 uuid: 622999fe-d383-4d41-9f2d-eed5013fe463
-name: SonicWall Secure Mobile Access
+name: SonicWall Secure Mobile Access 100 Series
 slug: sonicwall-sma-100
-description: SonicWall Secure Mobile Access offers secure and seamless remote access to corporate resources, applications, and data, enhancing workforce mobility while maintaining robust security and compliance measures.
+description: SonicWall Secure Mobile Access 100 Series logs are structured key-value records that capture SSL VPN access and user authentication activity for monitoring and investigation.
 data_sources:
-  DNS records: Both DNS queries and responses handled by the SonicWall domain name servers can be recorded.
+  Authentication logs: SSL VPN events capture user identity and login context.
+  Network device logs: SSL VPN appliance telemetry provides network access event details.
 automation_module_uuid: 44d88f8b-84e8-400c-bf1e-eeef54ff8bf4

--- a/SonicWall/sonicwall-sma-100/_meta/smart-descriptions.json
+++ b/SonicWall/sonicwall-sma-100/_meta/smart-descriptions.json
@@ -3,6 +3,10 @@
     "value": "User {user.name} with domain {user.domain} perform action from source {source.ip} on destination {destination.address}",
     "conditions": [
       {
+        "field": "event.dataset",
+        "value": "sonicwall.sma.100.sslvpn"
+      },
+      {
         "field": "user.name"
       },
       {
@@ -19,6 +23,10 @@
   {
     "value": "User {user.name} perform action from source {source.ip} on destination {destination.address}",
     "conditions": [
+      {
+        "field": "event.dataset",
+        "value": "sonicwall.sma.100.sslvpn"
+      },
       {
         "field": "user.name"
       },

--- a/SonicWall/sonicwall-sma-100/ingest/parser.yml
+++ b/SonicWall/sonicwall-sma-100/ingest/parser.yml
@@ -13,6 +13,7 @@ pipeline:
       name: date.parse
       properties:
         input_field: "{{ parsed_event.result.vp_time }}"
+        format: "%Y-%m-%d %H:%M:%S %Z"
         output_field: date
 
   - name: set_default_fields
@@ -33,6 +34,7 @@ stages:
     actions:
       - set:
           event.category: ["network"]
+          event.dataset: sonicwall.sma.100.sslvpn
           event.type: ["info"]
           observer.vendor: "SonicWall"
           observer.product: "Secure Mobile Access"

--- a/SonicWall/sonicwall-sma-100/tests/test_event.json
+++ b/SonicWall/sonicwall-sma-100/tests/test_event.json
@@ -8,6 +8,7 @@
       "category": [
         "network"
       ],
+      "dataset": "sonicwall.sma.100.sslvpn",
       "type": [
         "info"
       ]

--- a/SonicWall/sonicwall-sma-1000/_meta/manifest.yml
+++ b/SonicWall/sonicwall-sma-1000/_meta/manifest.yml
@@ -1,7 +1,7 @@
 uuid: 4ed0693e-98dc-40b3-bcba-1fa61e309dd1
 name: SonicWall Secure Mobile Access 1000 Series
 slug: sonicwall-sma-1000
-description: SonicWall Secure Mobile Access 1000 Series 12.5 logs are structured text-based records (mostly syslog-like and HTTP access formats, with XML exports) that capture timestamped system, administrative, access, tunnel, flow, web proxy, unregistered device, and WorkPlace events for monitoring, auditing, and incident analysis.
+description: SonicWall Secure Mobile Access 1000 Series logs are structured text-based records (mostly syslog-like and HTTP access formats, with XML exports) that capture timestamped system, administrative, access, tunnel, flow, web proxy, unregistered device, and WorkPlace events for monitoring, auditing, and incident analysis.
 data_sources:
   Asset management: Unregistered Device Log Messages expose exported XML device inventory context.
   Authentication logs: WorkPlace Logs provide portal shortcut and authorization troubleshooting telemetry.


### PR DESCRIPTION
## Description

Relates to https://github.com/SekoiaLab/detection-rules/issues/3968

### Changed

- Deprecate _SonicWall/sonicwall-sma-100_ and recommend _SonicWall/sonicwall-sma-1000_ as replacement
- Align _SonicWall/sonicwall-sma-100_ manifest wording and naming conventions with _SonicWall/sonicwall-sma-1000_
- Replace legacy `data_sources` entry with normalized taxonomy keys:
  - `Authentication logs`
  - `Network device logs`
- Update ECS fields parsing:
  - `@timestamp`: add an explicit date format for `vp_time` parsing to improve timestamp parsing robustness
  - `event.dataset`: set value to `sonicwall.sma.100.sslvpn` for consistent event categorization
- Scope smart-descriptions to `event.dataset = sonicwall.sma.100.sslvpn` to avoid over-broad matching

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] New intake format
- [ ] Update to existing intake format
- [x] Bug fix
- [ ] Documentation update
- [x] Other (please describe): Intake format deprecation

## Affected Intake Formats

<!-- List the vendor/product formats affected by this PR -->

- Vendor/product:
  - SonicWall/sonicwall-sma-100
  - SonicWall/sonicwall-sma-1000

## Checklist

<!-- Ensure all requirements are met before submitting -->

### 🔒 CRITICAL - Security Requirements (MUST BE VERIFIED FIRST)

- [ ] **No real email addresses** in test files (use: user@example.com, test@example.org)
- [ ] **No real passwords or API keys** (use: "P@ssw0rd!", "xxxxxxxxxxxx", "FAKE_TOKEN_123")
- [ ] **No real IP addresses** (use TEST-NET ranges: 192.0.2.x, 198.51.100.x, 203.0.113.x)
- [ ] **No real phone numbers** (use: +1-555-0100 or similar test numbers)
- [ ] **No real names or PII** (use: "John Doe", "Jane Smith", "User123")
- [ ] **No real company/organization names** in test data (unless public vendors)
- [ ] **No real usernames, hostnames, or domain names** (use: user1, host.example.com, test.corp)
- [ ] All test data has been anonymized and verified

### Required for All PRs

- [ ] Code has been linted
    - [ ] with the linter for manifest, smart-descriptions, and test files (`uv run python linter.py check --changes` in utils/)
    - [ ] with Prettier for the parser code files (`npx prettier --write <module>/<format>/ingest/parser.yml`)
- [ ] All CI/CD checks pass
- [ ] Changes follow the contribution guidelines in `CONTRIBUTING.md`

### Required for New/Updated Intake Formats

- [ ] Clear descriptions provided for modules and formats
- [ ] Logo files included for new modules/formats
- [ ] Parser test coverage is at least 75%
- [ ] At least one smart-description is provided
- [ ] README.md updated (if applicable)
- [ ] Taxonomy mappings are correct and documented
- [ ] Test cases cover edge cases and error handling

### Testing

- [ ] Local tests pass (`uv run pytest` in utils/)
- [ ] Sample data is representative and **completely anonymized**
- [ ] **No sensitive information** (PII, credentials, real IPs, real emails) in test files
- [ ] Test data uses example.com/example.org domains and TEST-NET IP ranges
- [ ] Parser handles malformed data gracefully

### Documentation

- [ ] Code changes are documented
- [ ] Smart-descriptions are clear and informative
- [ ] Field mappings are explained

## Additional Notes

<!-- Add any additional context, screenshots, or information that would help reviewers -->

## Related Issues

<!-- Link any related issues using #issue_number -->

Closes #

## Summary by Sourcery

Align SonicWall SMA intake metadata and event categorization while improving parsing robustness and directing users from the deprecated SMA 100 integration to the 1000 Series.

Bug Fixes:
- Improve SonicWall SMA 100 event timestamp parsing and constrain smart descriptions to the correct SSL VPN event dataset.

Enhancements:
- Align SonicWall Secure Mobile Access 100 and 1000 Series naming and manifest metadata, normalize SMA 100 data-source taxonomy, and mark the SMA 100 integration as deprecated in favor of the 1000 Series.
- Standardize SMA 100 event categorization with the `sonicwall.sma.100.sslvpn` dataset.

Documentation:
- Update SonicWall intake documentation and changelog to reflect Secure Mobile Access naming and SMA 100 deprecation.

Tests:
- Update SMA 100 test event data for the revised event fields.