### PR TITLE
fix/fortinet_fortigate_remove_password_field

### DIFF
--- a/Fortinet/fortigate/CHANGELOG.md
+++ b/Fortinet/fortigate/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2026-08-25
+
+### Removed
+
+- Remove parsing of credential-like password values from incident payloads to prevent high-risk exposure of raw secrets in normalized events
+- Remove custom fields:
+  - `fortinet.fortigate.password`
+
 ## [1.0.2] - 2026-08-14
 
 ### Added

--- a/Fortinet/fortigate/CHANGELOG.md
+++ b/Fortinet/fortigate/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.3] - 2026-08-25
 
+### Fixed
+
+- Anonymize all JSON test fixtures by replacing non-example email domains and non-reserved IP values with RFC 5737 test ranges, while preserving parsing-relevant value shapes
+
 ### Removed
 
 - Remove parsing of credential-like password values from incident payloads to prevent high-risk exposure of raw secrets in normalized events

--- a/Fortinet/fortigate/_meta/fields.yml
+++ b/Fortinet/fortigate/_meta/fields.yml
@@ -153,11 +153,6 @@ fortinet.fortigate.operation:
   name: fortinet.fortigate.operation
   type: keyword
 
-fortinet.fortigate.password:
-  description: Password value reported by the incident detection payload.
-  name: fortinet.fortigate.password
-  type: keyword
-
 fortinet.fortigate.policyid:
   description: ID of the policy
   name: fortinet.fortigate.policyid

--- a/Fortinet/fortigate/ingest/parser.yml
+++ b/Fortinet/fortigate/ingest/parser.yml
@@ -87,7 +87,7 @@ pipeline:
       properties:
         input_field: "{{ parsed_event.message.msg }}"
         output_field: result
-        pattern: "\\\"?EventID=%{NOTSPACE:EventID} IncidentID=%{NOTSPACE:IncidentID} Tagkey=%{DATA:Tagkey} DecoyGroup=%{NOTSPACE:DecoyGroup} DecoyType=%{NOTSPACE:DecoyType} MITRE_ATT&CK_ID=%{NOTSPACE:MITRE_ATTCK_ID} AttackerIP=%{IP:AttackerIP} AttackerPort=%{INT:AttackerPort} VictimIP=%{IP:VictimIP} VictimPort=%{INT:VictimPort} Operation=%{NOTSPACE:Operation} Severity=%{NOTSPACE:Severity} TagID=%{NOTSPACE:TagID} AttackerMac=%{MAC:AttackerMac} Service=%{NOTSPACE:Service} Username=%{NOTSPACE:Username}(?: Password=%{NOTSPACE})? Description=\\\\\\\"%{DATA:Description}\\\\\\\"\\\"?"
+        pattern: "\\\"?EventID=%{NOTSPACE:EventID} IncidentID=%{NOTSPACE:IncidentID} Tagkey=%{DATA:Tagkey} DecoyGroup=%{NOTSPACE:DecoyGroup} DecoyType=%{NOTSPACE:DecoyType} MITRE_ATT&CK_ID=%{NOTSPACE:MITRE_ATTCK_ID} AttackerIP=%{IP:AttackerIP} AttackerPort=%{INT:AttackerPort} VictimIP=%{IP:VictimIP} VictimPort=%{INT:VictimPort} Operation=%{NOTSPACE:Operation} Severity=%{NOTSPACE:Severity} TagID=%{NOTSPACE:TagID} AttackerMac=%{MAC:AttackerMac} Service=%{NOTSPACE:Service} Username=%{NOTSPACE:Username}(?: (?:Password=%{NOTSPACE}|\\*+))? Description=\\\\\\\"%{DATA:Description}\\\\\\\"\\\"?"
     filter: >
       {{
         parsed_event.message.get("type") == "event"

--- a/Fortinet/fortigate/ingest/parser.yml
+++ b/Fortinet/fortigate/ingest/parser.yml
@@ -87,7 +87,7 @@ pipeline:
       properties:
         input_field: "{{ parsed_event.message.msg }}"
         output_field: result
-        pattern: "\\\"?EventID=%{NOTSPACE:EventID} IncidentID=%{NOTSPACE:IncidentID} Tagkey=%{DATA:Tagkey} DecoyGroup=%{NOTSPACE:DecoyGroup} DecoyType=%{NOTSPACE:DecoyType} MITRE_ATT&CK_ID=%{NOTSPACE:MITRE_ATTCK_ID} AttackerIP=%{IP:AttackerIP} AttackerPort=%{INT:AttackerPort} VictimIP=%{IP:VictimIP} VictimPort=%{INT:VictimPort} Operation=%{NOTSPACE:Operation} Severity=%{NOTSPACE:Severity} TagID=%{NOTSPACE:TagID} AttackerMac=%{MAC:AttackerMac} Service=%{NOTSPACE:Service} Username=%{NOTSPACE:Username} Password=%{NOTSPACE:Password} Description=\\\\\\\"%{DATA:Description}\\\\\\\"\\\"?"
+        pattern: "\\\"?EventID=%{NOTSPACE:EventID} IncidentID=%{NOTSPACE:IncidentID} Tagkey=%{DATA:Tagkey} DecoyGroup=%{NOTSPACE:DecoyGroup} DecoyType=%{NOTSPACE:DecoyType} MITRE_ATT&CK_ID=%{NOTSPACE:MITRE_ATTCK_ID} AttackerIP=%{IP:AttackerIP} AttackerPort=%{INT:AttackerPort} VictimIP=%{IP:VictimIP} VictimPort=%{INT:VictimPort} Operation=%{NOTSPACE:Operation} Severity=%{NOTSPACE:Severity} TagID=%{NOTSPACE:TagID} AttackerMac=%{MAC:AttackerMac} Service=%{NOTSPACE:Service} Username=%{NOTSPACE:Username}(?: Password=%{NOTSPACE})? Description=\\\\\\\"%{DATA:Description}\\\\\\\"\\\"?"
     filter: >
       {{
         parsed_event.message.get("type") == "event"
@@ -131,7 +131,6 @@ stages:
           fortinet.fortigate.incident.id: "{{parsed_incident_fields.result.IncidentID}}"
           fortinet.fortigate.loghost: "{{parsed_event.message.loghost}}"
           fortinet.fortigate.operation: "{{parsed_incident_fields.result.Operation}}"
-          fortinet.fortigate.password: "{{parsed_incident_fields.result.Password}}"
           fortinet.fortigate.tag.id: "{{parsed_incident_fields.result.TagID}}"
           fortinet.fortigate.tag.key: "{{parsed_incident_fields.result.Tagkey}}"
           fortinet.fortigate.tzone: "{{parsed_event.message.tzone}}"

--- a/Fortinet/fortigate/tests/DLP.CEF.json
+++ b/Fortinet/fortigate/tests/DLP.CEF.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|24576|utm:dlp dlp block|4|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0954024576 cat=utm:dlp FTNTFGTsubtype=dlp FTNTFGTeventtype=dlp FTNTFGTlevel=warning FTNTFGTvd=vdom1 FTNTFGTeventtime=1545949776 FTNTFGTfilteridx=1 FTNTFGTdlpextra=test-dlp3 FTNTFGTfiltertype=file-type FTNTFGTfiltercat=file FTNTFGTseverity=medium FTNTFGTpolicyid=1 externalId=12680 FTNTFGTepoch=418303178 FTNTFGTeventid=0 duser=bob src=10.1.100.11 spt=33638 deviceInboundInterface=port12 FTNTFGTsrcintfrole=undefined dst=example.com dpt=80 deviceOutboundInterface=port11 FTNTFGTdstintfrole=undefined proto=6 app=HTTP FTNTFGTfiletype=gif deviceDirection=0 act=block dhost=example.com request=/dlp/flower.gif requestClientApplication=curl/7.47.0 fname=flower.gif fsize=1209 FTNTFGTprofile=test-dlp"
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|24576|utm:dlp dlp block|4|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0954024576 cat=utm:dlp FTNTFGTsubtype=dlp FTNTFGTeventtype=dlp FTNTFGTlevel=warning FTNTFGTvd=vdom1 FTNTFGTeventtime=1545949776 FTNTFGTfilteridx=1 FTNTFGTdlpextra=test-dlp3 FTNTFGTfiltertype=file-type FTNTFGTfiltercat=file FTNTFGTseverity=medium FTNTFGTpolicyid=1 externalId=12680 FTNTFGTepoch=418303178 FTNTFGTeventid=0 duser=bob src=198.51.100.11 spt=33638 deviceInboundInterface=port12 FTNTFGTsrcintfrole=undefined dst=example.com dpt=80 deviceOutboundInterface=port11 FTNTFGTdstintfrole=undefined proto=6 app=HTTP FTNTFGTfiletype=gif deviceDirection=0 act=block dhost=example.com request=/dlp/flower.gif requestClientApplication=curl/7.47.0 fname=flower.gif fsize=1209 FTNTFGTprofile=test-dlp"
   },
   "expected": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|24576|utm:dlp dlp block|4|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0954024576 cat=utm:dlp FTNTFGTsubtype=dlp FTNTFGTeventtype=dlp FTNTFGTlevel=warning FTNTFGTvd=vdom1 FTNTFGTeventtime=1545949776 FTNTFGTfilteridx=1 FTNTFGTdlpextra=test-dlp3 FTNTFGTfiltertype=file-type FTNTFGTfiltercat=file FTNTFGTseverity=medium FTNTFGTpolicyid=1 externalId=12680 FTNTFGTepoch=418303178 FTNTFGTeventid=0 duser=bob src=10.1.100.11 spt=33638 deviceInboundInterface=port12 FTNTFGTsrcintfrole=undefined dst=example.com dpt=80 deviceOutboundInterface=port11 FTNTFGTdstintfrole=undefined proto=6 app=HTTP FTNTFGTfiletype=gif deviceDirection=0 act=block dhost=example.com request=/dlp/flower.gif requestClientApplication=curl/7.47.0 fname=flower.gif fsize=1209 FTNTFGTprofile=test-dlp",
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|24576|utm:dlp dlp block|4|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0954024576 cat=utm:dlp FTNTFGTsubtype=dlp FTNTFGTeventtype=dlp FTNTFGTlevel=warning FTNTFGTvd=vdom1 FTNTFGTeventtime=1545949776 FTNTFGTfilteridx=1 FTNTFGTdlpextra=test-dlp3 FTNTFGTfiltertype=file-type FTNTFGTfiltercat=file FTNTFGTseverity=medium FTNTFGTpolicyid=1 externalId=12680 FTNTFGTepoch=418303178 FTNTFGTeventid=0 duser=bob src=198.51.100.11 spt=33638 deviceInboundInterface=port12 FTNTFGTsrcintfrole=undefined dst=example.com dpt=80 deviceOutboundInterface=port11 FTNTFGTdstintfrole=undefined proto=6 app=HTTP FTNTFGTfiletype=gif deviceDirection=0 act=block dhost=example.com request=/dlp/flower.gif requestClientApplication=curl/7.47.0 fname=flower.gif fsize=1209 FTNTFGTprofile=test-dlp",
     "event": {
       "action": "block",
       "category": "utm",
@@ -70,15 +70,15 @@
         "example.com"
       ],
       "ip": [
-        "10.1.100.11"
+        "198.51.100.11"
       ],
       "user": [
         "bob"
       ]
     },
     "source": {
-      "address": "10.1.100.11",
-      "ip": "10.1.100.11",
+      "address": "198.51.100.11",
+      "ip": "198.51.100.11",
       "port": 33638
     },
     "url": {

--- a/Fortinet/fortigate/tests/DNS.CEF.json
+++ b/Fortinet/fortigate/tests/DNS.CEF.json
@@ -6,7 +6,7 @@
     "message": "CEF:0|Fortinet|Fortigate|v6.0.3|54802|dns:dns-response pass|3|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=1501054802 cat=dns:dns-response FTNTFGTsubtype=dns-response FTNTFGTlevel=notice FTNTFGTvd=vdom1 FTNTFGTeventtime=1545950726 FTNTFGTpolicyid=1 externalId=13355 duser=bob src=10.1.100.11 spt=54621 deviceInboundInterface=port12 FTNTFGTsrcintfrole=lan dst=172.16.200.55 dpt=53 deviceOutboundInterface=port11 FTNTFGTdstintfrole=wan proto=17 FTNTFGTprofile=default FTNTFGTsrcmac=a2:e9:00:ec:40:01 FTNTFGTxid=5137 FTNTFGTqname=example.org FTNTFGTqtype=A FTNTFGTqtypeval=1 FTNTFGTqclass=IN FTNTFGTipaddr=104.80.89.26, 104.80.89.24 msg=Domain is monitored act=pass FTNTFGTcat=52 FTNTFGTcatdesc=Information Technology",
     "event": {
       "action": "pass",
-      "category": "dns",
+      "category": "52",
       "code": "1501054802",
       "dataset": "dns:dns-response",
       "outcome": "success",

--- a/Fortinet/fortigate/tests/DNS.CEF.json
+++ b/Fortinet/fortigate/tests/DNS.CEF.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|54802|dns:dns-response pass|3|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=1501054802 cat=dns:dns-response FTNTFGTsubtype=dns-response FTNTFGTlevel=notice FTNTFGTvd=vdom1 FTNTFGTeventtime=1545950726 FTNTFGTpolicyid=1 externalId=13355 duser=bob src=10.1.100.11 spt=54621 deviceInboundInterface=port12 FTNTFGTsrcintfrole=lan dst=172.16.200.55 dpt=53 deviceOutboundInterface=port11 FTNTFGTdstintfrole=wan proto=17 FTNTFGTprofile=default FTNTFGTsrcmac=a2:e9:00:ec:40:01 FTNTFGTxid=5137 FTNTFGTqname=example.org FTNTFGTqtype=A FTNTFGTqtypeval=1 FTNTFGTqclass=IN FTNTFGTipaddr=104.80.89.26, 104.80.89.24 msg=Domain is monitored act=pass FTNTFGTcat=52 FTNTFGTcatdesc=Information Technology"
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|54802|dns:dns-response pass|3|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=1501054802 cat=dns:dns-response FTNTFGTsubtype=dns-response FTNTFGTlevel=notice FTNTFGTvd=vdom1 FTNTFGTeventtime=1545950726 FTNTFGTpolicyid=1 externalId=13355 duser=bob src=198.51.100.11 spt=54621 deviceInboundInterface=port12 FTNTFGTsrcintfrole=lan dst=203.0.113.55 dpt=53 deviceOutboundInterface=port11 FTNTFGTdstintfrole=wan proto=17 FTNTFGTprofile=default FTNTFGTsrcmac=02:e9:00:ec:40:01 FTNTFGTxid=5137 FTNTFGTqname=example.org FTNTFGTqtype=A FTNTFGTqtypeval=1 FTNTFGTqclass=IN FTNTFGTipaddr=198.51.100.26, 198.51.100.24 msg=Domain is monitored act=pass FTNTFGTcat=52 FTNTFGTcatdesc=Information Technology"
   },
   "expected": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|54802|dns:dns-response pass|3|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=1501054802 cat=dns:dns-response FTNTFGTsubtype=dns-response FTNTFGTlevel=notice FTNTFGTvd=vdom1 FTNTFGTeventtime=1545950726 FTNTFGTpolicyid=1 externalId=13355 duser=bob src=10.1.100.11 spt=54621 deviceInboundInterface=port12 FTNTFGTsrcintfrole=lan dst=172.16.200.55 dpt=53 deviceOutboundInterface=port11 FTNTFGTdstintfrole=wan proto=17 FTNTFGTprofile=default FTNTFGTsrcmac=a2:e9:00:ec:40:01 FTNTFGTxid=5137 FTNTFGTqname=example.org FTNTFGTqtype=A FTNTFGTqtypeval=1 FTNTFGTqclass=IN FTNTFGTipaddr=104.80.89.26, 104.80.89.24 msg=Domain is monitored act=pass FTNTFGTcat=52 FTNTFGTcatdesc=Information Technology",
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|54802|dns:dns-response pass|3|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=1501054802 cat=dns:dns-response FTNTFGTsubtype=dns-response FTNTFGTlevel=notice FTNTFGTvd=vdom1 FTNTFGTeventtime=1545950726 FTNTFGTpolicyid=1 externalId=13355 duser=bob src=198.51.100.11 spt=54621 deviceInboundInterface=port12 FTNTFGTsrcintfrole=lan dst=203.0.113.55 dpt=53 deviceOutboundInterface=port11 FTNTFGTdstintfrole=wan proto=17 FTNTFGTprofile=default FTNTFGTsrcmac=02:e9:00:ec:40:01 FTNTFGTxid=5137 FTNTFGTqname=example.org FTNTFGTqtype=A FTNTFGTqtypeval=1 FTNTFGTqclass=IN FTNTFGTipaddr=198.51.100.26, 198.51.100.24 msg=Domain is monitored act=pass FTNTFGTcat=52 FTNTFGTcatdesc=Information Technology",
     "event": {
       "action": "pass",
       "category": "52",
@@ -21,8 +21,8 @@
       "type": "dns-response"
     },
     "destination": {
-      "address": "172.16.200.55",
-      "ip": "172.16.200.55",
+      "address": "203.0.113.55",
+      "ip": "203.0.113.55",
       "port": 53,
       "user": {
         "name": "bob"
@@ -75,8 +75,8 @@
         "example.org"
       ],
       "ip": [
-        "10.1.100.11",
-        "172.16.200.55"
+        "198.51.100.11",
+        "203.0.113.55"
       ],
       "user": [
         "bob"
@@ -86,9 +86,9 @@
       "category": "Information Technology"
     },
     "source": {
-      "address": "10.1.100.11",
-      "ip": "10.1.100.11",
-      "mac": "a2:e9:00:ec:40:01",
+      "address": "198.51.100.11",
+      "ip": "198.51.100.11",
+      "mac": "02:e9:00:ec:40:01",
       "port": 54621
     }
   }

--- a/Fortinet/fortigate/tests/DNS.STANDARD.json
+++ b/Fortinet/fortigate/tests/DNS.STANDARD.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "time=15:51:59 devname=\"my-device\" devid=\"1111111111111111\" eventtime=1668001919663486001 tz=\"+0100\" logid=\"1500054000\" type=\"utm\" subtype=\"dns\" eventtype=\"dns-query\" level=\"information\" vd=\"root\" policyid=1685 poluuid=\"4470d4c5-7e12-4a8f-a369-08eff4a43b5b\" policytype=\"policy\" sessionid=933308058 srcip=1.2.3.4 srcport=35305 srccountry=\"Reserved\" srcintf=\"INTF-1\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstport=53 dstcountry=\"Reserved\" dstintf=\"INTF-2\" dstintfrole=\"lan\" proto=17 profile=\"DNS Filtering Normal\" xid=42240 qtype=\"NS\" qtypeval=2 qclass=\"IN\""
+    "message": "time=15:51:59 devname=\"my-device\" devid=\"1111111111111111\" eventtime=1668001919663486001 tz=\"+0100\" logid=\"1500054000\" type=\"utm\" subtype=\"dns\" eventtype=\"dns-query\" level=\"information\" vd=\"root\" policyid=1685 poluuid=\"4470d4c5-7e12-4a8f-a369-08eff4a43b5b\" policytype=\"policy\" sessionid=933308058 srcip=198.51.100.4 srcport=35305 srccountry=\"Reserved\" srcintf=\"INTF-1\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstport=53 dstcountry=\"Reserved\" dstintf=\"INTF-2\" dstintfrole=\"lan\" proto=17 profile=\"DNS Filtering Normal\" xid=42240 qtype=\"NS\" qtypeval=2 qclass=\"IN\""
   },
   "expected": {
-    "message": "time=15:51:59 devname=\"my-device\" devid=\"1111111111111111\" eventtime=1668001919663486001 tz=\"+0100\" logid=\"1500054000\" type=\"utm\" subtype=\"dns\" eventtype=\"dns-query\" level=\"information\" vd=\"root\" policyid=1685 poluuid=\"4470d4c5-7e12-4a8f-a369-08eff4a43b5b\" policytype=\"policy\" sessionid=933308058 srcip=1.2.3.4 srcport=35305 srccountry=\"Reserved\" srcintf=\"INTF-1\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstport=53 dstcountry=\"Reserved\" dstintf=\"INTF-2\" dstintfrole=\"lan\" proto=17 profile=\"DNS Filtering Normal\" xid=42240 qtype=\"NS\" qtypeval=2 qclass=\"IN\"",
+    "message": "time=15:51:59 devname=\"my-device\" devid=\"1111111111111111\" eventtime=1668001919663486001 tz=\"+0100\" logid=\"1500054000\" type=\"utm\" subtype=\"dns\" eventtype=\"dns-query\" level=\"information\" vd=\"root\" policyid=1685 poluuid=\"4470d4c5-7e12-4a8f-a369-08eff4a43b5b\" policytype=\"policy\" sessionid=933308058 srcip=198.51.100.4 srcport=35305 srccountry=\"Reserved\" srcintf=\"INTF-1\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstport=53 dstcountry=\"Reserved\" dstintf=\"INTF-2\" dstintfrole=\"lan\" proto=17 profile=\"DNS Filtering Normal\" xid=42240 qtype=\"NS\" qtypeval=2 qclass=\"IN\"",
     "event": {
       "category": "utm",
       "code": "1500054000",
@@ -66,16 +66,16 @@
         "my-device"
       ],
       "ip": [
-        "1.2.3.4",
-        "192.0.2.1"
+        "192.0.2.1",
+        "198.51.100.4"
       ]
     },
     "rule": {
       "ruleset": "policy"
     },
     "source": {
-      "address": "1.2.3.4",
-      "ip": "1.2.3.4",
+      "address": "198.51.100.4",
+      "ip": "198.51.100.4",
       "port": 35305
     }
   }

--- a/Fortinet/fortigate/tests/DNS2.STANDARD.json
+++ b/Fortinet/fortigate/tests/DNS2.STANDARD.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "time=15:58:39 devname=\"dev-name\" devid=\"1111111111111111\" eventtime=1668002319383195535 tz=\"+0100\" logid=\"1500054000\" type=\"utm\" subtype=\"dns\" eventtype=\"dns-query\" level=\"information\" vd=\"root\" policyid=770 poluuid=\"f2aef0f2-a721-49cf-9dd3-b27f7f5b90bc\" policytype=\"policy\" sessionid=933538554 user=\"user1\" srcip=1.2.3.4 srcport=45362 srccountry=\"Reserved\" srcintf=\"intf-1\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstport=53 dstcountry=\"Reserved\" dstintf=\"intf-2\" dstintfrole=\"undefined\" proto=17 profile=\"DNS Filtering Normal\" xid=32649 qname=\"[example.com]\" qtype=\"A\" qtypeval=1 qclass=\"IN\""
+    "message": "time=15:58:39 devname=\"dev-name\" devid=\"1111111111111111\" eventtime=1668002319383195535 tz=\"+0100\" logid=\"1500054000\" type=\"utm\" subtype=\"dns\" eventtype=\"dns-query\" level=\"information\" vd=\"root\" policyid=770 poluuid=\"f2aef0f2-a721-49cf-9dd3-b27f7f5b90bc\" policytype=\"policy\" sessionid=933538554 user=\"user1\" srcip=198.51.100.4 srcport=45362 srccountry=\"Reserved\" srcintf=\"intf-1\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstport=53 dstcountry=\"Reserved\" dstintf=\"intf-2\" dstintfrole=\"undefined\" proto=17 profile=\"DNS Filtering Normal\" xid=32649 qname=\"[example.com]\" qtype=\"A\" qtypeval=1 qclass=\"IN\""
   },
   "expected": {
-    "message": "time=15:58:39 devname=\"dev-name\" devid=\"1111111111111111\" eventtime=1668002319383195535 tz=\"+0100\" logid=\"1500054000\" type=\"utm\" subtype=\"dns\" eventtype=\"dns-query\" level=\"information\" vd=\"root\" policyid=770 poluuid=\"f2aef0f2-a721-49cf-9dd3-b27f7f5b90bc\" policytype=\"policy\" sessionid=933538554 user=\"user1\" srcip=1.2.3.4 srcport=45362 srccountry=\"Reserved\" srcintf=\"intf-1\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstport=53 dstcountry=\"Reserved\" dstintf=\"intf-2\" dstintfrole=\"undefined\" proto=17 profile=\"DNS Filtering Normal\" xid=32649 qname=\"[example.com]\" qtype=\"A\" qtypeval=1 qclass=\"IN\"",
+    "message": "time=15:58:39 devname=\"dev-name\" devid=\"1111111111111111\" eventtime=1668002319383195535 tz=\"+0100\" logid=\"1500054000\" type=\"utm\" subtype=\"dns\" eventtype=\"dns-query\" level=\"information\" vd=\"root\" policyid=770 poluuid=\"f2aef0f2-a721-49cf-9dd3-b27f7f5b90bc\" policytype=\"policy\" sessionid=933538554 user=\"user1\" srcip=198.51.100.4 srcport=45362 srccountry=\"Reserved\" srcintf=\"intf-1\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstport=53 dstcountry=\"Reserved\" dstintf=\"intf-2\" dstintfrole=\"undefined\" proto=17 profile=\"DNS Filtering Normal\" xid=32649 qname=\"[example.com]\" qtype=\"A\" qtypeval=1 qclass=\"IN\"",
     "event": {
       "category": "utm",
       "code": "1500054000",
@@ -70,8 +70,8 @@
         "example.com"
       ],
       "ip": [
-        "1.2.3.4",
-        "192.0.2.1"
+        "192.0.2.1",
+        "198.51.100.4"
       ],
       "user": [
         "user1"
@@ -81,8 +81,8 @@
       "ruleset": "policy"
     },
     "source": {
-      "address": "1.2.3.4",
-      "ip": "1.2.3.4",
+      "address": "198.51.100.4",
+      "ip": "198.51.100.4",
       "port": 45362,
       "user": {
         "name": "user1"

--- a/Fortinet/fortigate/tests/IPS.CEF.json
+++ b/Fortinet/fortigate/tests/IPS.CEF.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|16384|utm:ips signature reset|7|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0419016384 cat=utm:ips FTNTFGTsubtype=ips FTNTFGTeventtype=signature FTNTFGTlevel=alert FTNTFGTvd=vdom1 FTNTFGTeventtime=1545938887 FTNTFGTseverity=info src=example.com FTNTFGTsrccountry=Reserved dst=10.1.100.11 deviceInboundInterface=port11 FTNTFGTsrcintfrole=undefined deviceOutboundInterface=port12 FTNTFGTdstintfrole=undefined externalId=901 act=reset proto=6 app=HTTP FTNTFGTpolicyid=1 FTNTFGTattack=Eicar.Virus.Test.File spt=80 dpt=44362 dhost=example.com request=/virus/eicar.com deviceDirection=0 FTNTFGTattackid=29844 FTNTFGTprofile=test-ips FTNTFGTref=http://www.fortinet.com/ids/VID29844 duser=bob FTNTFGTincidentserialno=877326946 msg=file_transfer: Eicar.Virus.Test.File,"
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|16384|utm:ips signature reset|7|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0419016384 cat=utm:ips FTNTFGTsubtype=ips FTNTFGTeventtype=signature FTNTFGTlevel=alert FTNTFGTvd=vdom1 FTNTFGTeventtime=1545938887 FTNTFGTseverity=info src=example.com FTNTFGTsrccountry=Reserved dst=198.51.100.11 deviceInboundInterface=port11 FTNTFGTsrcintfrole=undefined deviceOutboundInterface=port12 FTNTFGTdstintfrole=undefined externalId=901 act=reset proto=6 app=HTTP FTNTFGTpolicyid=1 FTNTFGTattack=Eicar.Virus.Test.File spt=80 dpt=44362 dhost=example.com request=/virus/eicar.com deviceDirection=0 FTNTFGTattackid=29844 FTNTFGTprofile=test-ips FTNTFGTref=http://www.fortinet.com/ids/VID29844 duser=bob FTNTFGTincidentserialno=877326946 msg=file_transfer: Eicar.Virus.Test.File,"
   },
   "expected": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|16384|utm:ips signature reset|7|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0419016384 cat=utm:ips FTNTFGTsubtype=ips FTNTFGTeventtype=signature FTNTFGTlevel=alert FTNTFGTvd=vdom1 FTNTFGTeventtime=1545938887 FTNTFGTseverity=info src=example.com FTNTFGTsrccountry=Reserved dst=10.1.100.11 deviceInboundInterface=port11 FTNTFGTsrcintfrole=undefined deviceOutboundInterface=port12 FTNTFGTdstintfrole=undefined externalId=901 act=reset proto=6 app=HTTP FTNTFGTpolicyid=1 FTNTFGTattack=Eicar.Virus.Test.File spt=80 dpt=44362 dhost=example.com request=/virus/eicar.com deviceDirection=0 FTNTFGTattackid=29844 FTNTFGTprofile=test-ips FTNTFGTref=http://www.fortinet.com/ids/VID29844 duser=bob FTNTFGTincidentserialno=877326946 msg=file_transfer: Eicar.Virus.Test.File,",
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|16384|utm:ips signature reset|7|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0419016384 cat=utm:ips FTNTFGTsubtype=ips FTNTFGTeventtype=signature FTNTFGTlevel=alert FTNTFGTvd=vdom1 FTNTFGTeventtime=1545938887 FTNTFGTseverity=info src=example.com FTNTFGTsrccountry=Reserved dst=198.51.100.11 deviceInboundInterface=port11 FTNTFGTsrcintfrole=undefined deviceOutboundInterface=port12 FTNTFGTdstintfrole=undefined externalId=901 act=reset proto=6 app=HTTP FTNTFGTpolicyid=1 FTNTFGTattack=Eicar.Virus.Test.File spt=80 dpt=44362 dhost=example.com request=/virus/eicar.com deviceDirection=0 FTNTFGTattackid=29844 FTNTFGTprofile=test-ips FTNTFGTref=http://www.fortinet.com/ids/VID29844 duser=bob FTNTFGTincidentserialno=877326946 msg=file_transfer: Eicar.Virus.Test.File,",
     "event": {
       "action": "reset",
       "category": "utm",
@@ -21,9 +21,9 @@
       "type": "ips"
     },
     "destination": {
-      "address": "10.1.100.11",
+      "address": "198.51.100.11",
       "domain": "example.com",
-      "ip": "10.1.100.11",
+      "ip": "198.51.100.11",
       "port": 44362,
       "user": {
         "name": "bob"
@@ -73,7 +73,7 @@
         "example.com"
       ],
       "ip": [
-        "10.1.100.11"
+        "198.51.100.11"
       ],
       "user": [
         "bob"

--- a/Fortinet/fortigate/tests/IP_SEC.STANDARD.json
+++ b/Fortinet/fortigate/tests/IP_SEC.STANDARD.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "time=17:24:16 devname=\"abc\" devid=\"1\" logid=\"0101037130\" type=\"event\" subtype=\"vpn\" level=\"error\" vd=\"root\" eventtime=1580142256 logdesc=\"Progress IPsec phase 2\" msg=\"progress IPsec phase 2\" action=\"negotiate\" remip=1.1.1.1 locip=192.0.2.1 remport=500 locport=500 outintf=\"N/A\" cookies=\"07f928d94dd975ea/89b1d990f54f0b82\" user=\"N/A\" group=\"N/A\" xauthuser=\"N/A\" xauthgroup=\"N/A\" assignip=N/A vpntunnel=\"VPN-FOOBAR\" status=\"failure\" init=\"local\" exch=\"CREATE_CHILD\" dir=\"inbound\" role=\"initiator\" result=\"ERROR\" version=\"IKEv2\""
+    "message": "time=17:24:16 devname=\"abc\" devid=\"1\" logid=\"0101037130\" type=\"event\" subtype=\"vpn\" level=\"error\" vd=\"root\" eventtime=1580142256 logdesc=\"Progress IPsec phase 2\" msg=\"progress IPsec phase 2\" action=\"negotiate\" remip=192.0.2.101 locip=192.0.2.1 remport=500 locport=500 outintf=\"N/A\" cookies=\"07f928d94dd975ea/89b1d990f54f0b82\" user=\"N/A\" group=\"N/A\" xauthuser=\"N/A\" xauthgroup=\"N/A\" assignip=N/A vpntunnel=\"VPN-FOOBAR\" status=\"failure\" init=\"local\" exch=\"CREATE_CHILD\" dir=\"inbound\" role=\"initiator\" result=\"ERROR\" version=\"IKEv2\""
   },
   "expected": {
-    "message": "time=17:24:16 devname=\"abc\" devid=\"1\" logid=\"0101037130\" type=\"event\" subtype=\"vpn\" level=\"error\" vd=\"root\" eventtime=1580142256 logdesc=\"Progress IPsec phase 2\" msg=\"progress IPsec phase 2\" action=\"negotiate\" remip=1.1.1.1 locip=192.0.2.1 remport=500 locport=500 outintf=\"N/A\" cookies=\"07f928d94dd975ea/89b1d990f54f0b82\" user=\"N/A\" group=\"N/A\" xauthuser=\"N/A\" xauthgroup=\"N/A\" assignip=N/A vpntunnel=\"VPN-FOOBAR\" status=\"failure\" init=\"local\" exch=\"CREATE_CHILD\" dir=\"inbound\" role=\"initiator\" result=\"ERROR\" version=\"IKEv2\"",
+    "message": "time=17:24:16 devname=\"abc\" devid=\"1\" logid=\"0101037130\" type=\"event\" subtype=\"vpn\" level=\"error\" vd=\"root\" eventtime=1580142256 logdesc=\"Progress IPsec phase 2\" msg=\"progress IPsec phase 2\" action=\"negotiate\" remip=192.0.2.101 locip=192.0.2.1 remport=500 locport=500 outintf=\"N/A\" cookies=\"07f928d94dd975ea/89b1d990f54f0b82\" user=\"N/A\" group=\"N/A\" xauthuser=\"N/A\" xauthgroup=\"N/A\" assignip=N/A vpntunnel=\"VPN-FOOBAR\" status=\"failure\" init=\"local\" exch=\"CREATE_CHILD\" dir=\"inbound\" role=\"initiator\" result=\"ERROR\" version=\"IKEv2\"",
     "event": {
       "action": "negotiate",
       "category": "event",
@@ -51,13 +51,13 @@
         "abc"
       ],
       "ip": [
-        "1.1.1.1",
-        "192.0.2.1"
+        "192.0.2.1",
+        "192.0.2.101"
       ]
     },
     "source": {
-      "address": "1.1.1.1",
-      "ip": "1.1.1.1",
+      "address": "192.0.2.101",
+      "ip": "192.0.2.101",
       "port": 500
     }
   }

--- a/Fortinet/fortigate/tests/LOGOUT.STANDARD.json
+++ b/Fortinet/fortigate/tests/LOGOUT.STANDARD.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "time=16:48:00 devname=\"abc\" devid=\"1\" logid=\"0100032003\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" eventtime=1619621280 logdesc=\"Admin logout successful\" sn=\"1619620402\" user=\"test\" ui=\"jsconsole\" method=\"jsconsole\" srcip=1.1.1.1 dstip=192.0.2.1 action=\"logout\" status=\"success\" duration=878 reason=\"exit\" msg=\"Administrator test logged out from jsconsole\""
+    "message": "time=16:48:00 devname=\"abc\" devid=\"1\" logid=\"0100032003\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" eventtime=1619621280 logdesc=\"Admin logout successful\" sn=\"1619620402\" user=\"test\" ui=\"jsconsole\" method=\"jsconsole\" srcip=192.0.2.101 dstip=192.0.2.1 action=\"logout\" status=\"success\" duration=878 reason=\"exit\" msg=\"Administrator test logged out from jsconsole\""
   },
   "expected": {
-    "message": "time=16:48:00 devname=\"abc\" devid=\"1\" logid=\"0100032003\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" eventtime=1619621280 logdesc=\"Admin logout successful\" sn=\"1619620402\" user=\"test\" ui=\"jsconsole\" method=\"jsconsole\" srcip=1.1.1.1 dstip=192.0.2.1 action=\"logout\" status=\"success\" duration=878 reason=\"exit\" msg=\"Administrator test logged out from jsconsole\"",
+    "message": "time=16:48:00 devname=\"abc\" devid=\"1\" logid=\"0100032003\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" eventtime=1619621280 logdesc=\"Admin logout successful\" sn=\"1619620402\" user=\"test\" ui=\"jsconsole\" method=\"jsconsole\" srcip=192.0.2.101 dstip=192.0.2.1 action=\"logout\" status=\"success\" duration=878 reason=\"exit\" msg=\"Administrator test logged out from jsconsole\"",
     "event": {
       "action": "logout",
       "category": "event",
@@ -50,16 +50,16 @@
         "abc"
       ],
       "ip": [
-        "1.1.1.1",
-        "192.0.2.1"
+        "192.0.2.1",
+        "192.0.2.101"
       ],
       "user": [
         "test"
       ]
     },
     "source": {
-      "address": "1.1.1.1",
-      "ip": "1.1.1.1",
+      "address": "192.0.2.101",
+      "ip": "192.0.2.101",
       "user": {
         "name": "test"
       }

--- a/Fortinet/fortigate/tests/SSH.CEF-2.json
+++ b/Fortinet/fortigate/tests/SSH.CEF-2.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|61002|utm:ssh ssh-command passthrough|3|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=1600061002 cat=utm:ssh FTNTFGTsubtype=ssh FTNTFGTeventtype=ssh-command FTNTFGTlevel=notice FTNTFGTvd=vdom1 FTNTFGTeventtime=1545950175 FTNTFGTpolicyid=1 externalId=12921 duser=bob FTNTFGTprofile=test-ssh src=10.1.100.11 spt=56698 dst=172.16.200.55 dpt=22 deviceInboundInterface=port12 FTNTFGTsrcintfrole=lan deviceOutboundInterface=port11 FTNTFGTdstintfrole=wan proto=6 act=passthrough FTNTFGTlogin=root FTNTFGTcommand=ls FTNTFGTseverity=low"
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|61002|utm:ssh ssh-command passthrough|3|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=1600061002 cat=utm:ssh FTNTFGTsubtype=ssh FTNTFGTeventtype=ssh-command FTNTFGTlevel=notice FTNTFGTvd=vdom1 FTNTFGTeventtime=1545950175 FTNTFGTpolicyid=1 externalId=12921 duser=bob FTNTFGTprofile=test-ssh src=198.51.100.11 spt=56698 dst=203.0.113.55 dpt=22 deviceInboundInterface=port12 FTNTFGTsrcintfrole=lan deviceOutboundInterface=port11 FTNTFGTdstintfrole=wan proto=6 act=passthrough FTNTFGTlogin=root FTNTFGTcommand=ls FTNTFGTseverity=low"
   },
   "expected": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|61002|utm:ssh ssh-command passthrough|3|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=1600061002 cat=utm:ssh FTNTFGTsubtype=ssh FTNTFGTeventtype=ssh-command FTNTFGTlevel=notice FTNTFGTvd=vdom1 FTNTFGTeventtime=1545950175 FTNTFGTpolicyid=1 externalId=12921 duser=bob FTNTFGTprofile=test-ssh src=10.1.100.11 spt=56698 dst=172.16.200.55 dpt=22 deviceInboundInterface=port12 FTNTFGTsrcintfrole=lan deviceOutboundInterface=port11 FTNTFGTdstintfrole=wan proto=6 act=passthrough FTNTFGTlogin=root FTNTFGTcommand=ls FTNTFGTseverity=low",
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|61002|utm:ssh ssh-command passthrough|3|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=1600061002 cat=utm:ssh FTNTFGTsubtype=ssh FTNTFGTeventtype=ssh-command FTNTFGTlevel=notice FTNTFGTvd=vdom1 FTNTFGTeventtime=1545950175 FTNTFGTpolicyid=1 externalId=12921 duser=bob FTNTFGTprofile=test-ssh src=198.51.100.11 spt=56698 dst=203.0.113.55 dpt=22 deviceInboundInterface=port12 FTNTFGTsrcintfrole=lan deviceOutboundInterface=port11 FTNTFGTdstintfrole=wan proto=6 act=passthrough FTNTFGTlogin=root FTNTFGTcommand=ls FTNTFGTseverity=low",
     "event": {
       "action": "passthrough",
       "category": "utm",
@@ -19,8 +19,8 @@
       "type": "ssh"
     },
     "destination": {
-      "address": "172.16.200.55",
-      "ip": "172.16.200.55",
+      "address": "203.0.113.55",
+      "ip": "203.0.113.55",
       "port": 22,
       "user": {
         "name": "bob"
@@ -62,16 +62,16 @@
     },
     "related": {
       "ip": [
-        "10.1.100.11",
-        "172.16.200.55"
+        "198.51.100.11",
+        "203.0.113.55"
       ],
       "user": [
         "bob"
       ]
     },
     "source": {
-      "address": "10.1.100.11",
-      "ip": "10.1.100.11",
+      "address": "198.51.100.11",
+      "ip": "198.51.100.11",
       "port": 56698
     }
   }

--- a/Fortinet/fortigate/tests/VoIP.CEF.json
+++ b/Fortinet/fortigate/tests/VoIP.CEF.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|44032|utm:voip voip permit start|2|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0814044032 cat=utm:voip FTNTFGTsubtype=voip FTNTFGTeventtype=voip FTNTFGTlevel=information FTNTFGTvd=vdom1 FTNTFGTeventtime=1545958028 externalId=18975 FTNTFGTepoch=0 FTNTFGTevent_id=6857 src=10.1.100.11 spt=5060 dst=172.16.200.55 dpt=5060 proto=17 deviceInboundInterface=port12 deviceOutboundInterface=port11 FTNTFGTpolicy_id=1 FTNTFGTprofile=default FTNTFGTvoip_proto=sip FTNTFGTkind=call act=permit outcome=start FTNTFGTduration=0 FTNTFGTdir=session_origin FTNTFGTcall_id=3444-13134@127.0.0.1 suser=user1 duser=user1"
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|44032|utm:voip voip permit start|2|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0814044032 cat=utm:voip FTNTFGTsubtype=voip FTNTFGTeventtype=voip FTNTFGTlevel=information FTNTFGTvd=vdom1 FTNTFGTeventtime=1545958028 externalId=18975 FTNTFGTepoch=0 FTNTFGTevent_id=6857 src=198.51.100.11 spt=5060 dst=203.0.113.55 dpt=5060 proto=17 deviceInboundInterface=port12 deviceOutboundInterface=port11 FTNTFGTpolicy_id=1 FTNTFGTprofile=default FTNTFGTvoip_proto=sip FTNTFGTkind=call act=permit outcome=start FTNTFGTduration=0 FTNTFGTdir=session_origin FTNTFGTcall_id=3444-13134@198.51.100.127 suser=user1 duser=user1"
   },
   "expected": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|44032|utm:voip voip permit start|2|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0814044032 cat=utm:voip FTNTFGTsubtype=voip FTNTFGTeventtype=voip FTNTFGTlevel=information FTNTFGTvd=vdom1 FTNTFGTeventtime=1545958028 externalId=18975 FTNTFGTepoch=0 FTNTFGTevent_id=6857 src=10.1.100.11 spt=5060 dst=172.16.200.55 dpt=5060 proto=17 deviceInboundInterface=port12 deviceOutboundInterface=port11 FTNTFGTpolicy_id=1 FTNTFGTprofile=default FTNTFGTvoip_proto=sip FTNTFGTkind=call act=permit outcome=start FTNTFGTduration=0 FTNTFGTdir=session_origin FTNTFGTcall_id=3444-13134@127.0.0.1 suser=user1 duser=user1",
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|44032|utm:voip voip permit start|2|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0814044032 cat=utm:voip FTNTFGTsubtype=voip FTNTFGTeventtype=voip FTNTFGTlevel=information FTNTFGTvd=vdom1 FTNTFGTeventtime=1545958028 externalId=18975 FTNTFGTepoch=0 FTNTFGTevent_id=6857 src=198.51.100.11 spt=5060 dst=203.0.113.55 dpt=5060 proto=17 deviceInboundInterface=port12 deviceOutboundInterface=port11 FTNTFGTpolicy_id=1 FTNTFGTprofile=default FTNTFGTvoip_proto=sip FTNTFGTkind=call act=permit outcome=start FTNTFGTduration=0 FTNTFGTdir=session_origin FTNTFGTcall_id=3444-13134@198.51.100.127 suser=user1 duser=user1",
     "event": {
       "action": "permit",
       "category": "utm",
@@ -19,8 +19,8 @@
       "type": "voip"
     },
     "destination": {
-      "address": "172.16.200.55",
-      "ip": "172.16.200.55",
+      "address": "203.0.113.55",
+      "ip": "203.0.113.55",
       "port": 5060,
       "user": {
         "name": "user1"
@@ -56,16 +56,16 @@
     },
     "related": {
       "ip": [
-        "10.1.100.11",
-        "172.16.200.55"
+        "198.51.100.11",
+        "203.0.113.55"
       ],
       "user": [
         "user1"
       ]
     },
     "source": {
-      "address": "10.1.100.11",
-      "ip": "10.1.100.11",
+      "address": "198.51.100.11",
+      "ip": "198.51.100.11",
       "port": 5060,
       "user": {
         "name": "user1"

--- a/Fortinet/fortigate/tests/WAD.STANDARD.json
+++ b/Fortinet/fortigate/tests/WAD.STANDARD.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "time=15:29:39 devname=\"abc\" devid=\"1\" logid=\"0105048039\" type=\"event\" subtype=\"wad\" level=\"error\" vd=\"PRX1-AA\" eventtime=1619616579 logdesc=\"SSL fatal alert sent\" session_id=473f963d policyid=0 srcip=192.0.2.1 srcport=47782 dstip=1.1.1.1 dstport=8002 action=\"send\" alert=\"2\" desc=\"illegal parameter\" msg=\"SSL Alert sent\""
+    "message": "time=15:29:39 devname=\"abc\" devid=\"1\" logid=\"0105048039\" type=\"event\" subtype=\"wad\" level=\"error\" vd=\"PRX1-AA\" eventtime=1619616579 logdesc=\"SSL fatal alert sent\" session_id=473f963d policyid=0 srcip=192.0.2.1 srcport=47782 dstip=192.0.2.101 dstport=8002 action=\"send\" alert=\"2\" desc=\"illegal parameter\" msg=\"SSL Alert sent\""
   },
   "expected": {
-    "message": "time=15:29:39 devname=\"abc\" devid=\"1\" logid=\"0105048039\" type=\"event\" subtype=\"wad\" level=\"error\" vd=\"PRX1-AA\" eventtime=1619616579 logdesc=\"SSL fatal alert sent\" session_id=473f963d policyid=0 srcip=192.0.2.1 srcport=47782 dstip=1.1.1.1 dstport=8002 action=\"send\" alert=\"2\" desc=\"illegal parameter\" msg=\"SSL Alert sent\"",
+    "message": "time=15:29:39 devname=\"abc\" devid=\"1\" logid=\"0105048039\" type=\"event\" subtype=\"wad\" level=\"error\" vd=\"PRX1-AA\" eventtime=1619616579 logdesc=\"SSL fatal alert sent\" session_id=473f963d policyid=0 srcip=192.0.2.1 srcport=47782 dstip=192.0.2.101 dstport=8002 action=\"send\" alert=\"2\" desc=\"illegal parameter\" msg=\"SSL Alert sent\"",
     "event": {
       "action": "send",
       "category": "event",
@@ -22,8 +22,8 @@
       "type": "wad"
     },
     "destination": {
-      "address": "1.1.1.1",
-      "ip": "1.1.1.1",
+      "address": "192.0.2.101",
+      "ip": "192.0.2.101",
       "port": 8002
     },
     "fortinet": {
@@ -50,8 +50,8 @@
         "abc"
       ],
       "ip": [
-        "1.1.1.1",
-        "192.0.2.1"
+        "192.0.2.1",
+        "192.0.2.101"
       ]
     },
     "source": {

--- a/Fortinet/fortigate/tests/WAF.CEF.json
+++ b/Fortinet/fortigate/tests/WAF.CEF.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|30258|utm:waf waf-http-constraint passthrough|4|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=1203030258 cat=utm:waf FTNTFGTsubtype=waf FTNTFGTeventtype=waf-http-constraint FTNTFGTlevel=warning FTNTFGTvd=vdom1 FTNTFGTeventtime=1545951320 FTNTFGTpolicyid=1 externalId=13614 duser=bob FTNTFGTprofile=waf_test src=10.1.100.11 spt=57304 dst=example.com dpt=80 deviceInboundInterface=port12 FTNTFGTsrcintfrole=lan deviceOutboundInterface=port11 FTNTFGTdstintfrole=wan proto=6 app=HTTP request=http://example.com/index.html?https://example.com/ FTNTFGTseverity=medium act=passthrough deviceDirection=0 requestClientApplication=curl/7.47.0 FTNTFGTconstraint=url-param-num FTNTFGTrawdata=Method\\=GET|User-Agent\\=curl/7.47.0"
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|30258|utm:waf waf-http-constraint passthrough|4|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=1203030258 cat=utm:waf FTNTFGTsubtype=waf FTNTFGTeventtype=waf-http-constraint FTNTFGTlevel=warning FTNTFGTvd=vdom1 FTNTFGTeventtime=1545951320 FTNTFGTpolicyid=1 externalId=13614 duser=bob FTNTFGTprofile=waf_test src=198.51.100.11 spt=57304 dst=example.com dpt=80 deviceInboundInterface=port12 FTNTFGTsrcintfrole=lan deviceOutboundInterface=port11 FTNTFGTdstintfrole=wan proto=6 app=HTTP request=http://example.com/index.html?https://example.com/ FTNTFGTseverity=medium act=passthrough deviceDirection=0 requestClientApplication=curl/7.47.0 FTNTFGTconstraint=url-param-num FTNTFGTrawdata=Method\\=GET|User-Agent\\=curl/7.47.0"
   },
   "expected": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|30258|utm:waf waf-http-constraint passthrough|4|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=1203030258 cat=utm:waf FTNTFGTsubtype=waf FTNTFGTeventtype=waf-http-constraint FTNTFGTlevel=warning FTNTFGTvd=vdom1 FTNTFGTeventtime=1545951320 FTNTFGTpolicyid=1 externalId=13614 duser=bob FTNTFGTprofile=waf_test src=10.1.100.11 spt=57304 dst=example.com dpt=80 deviceInboundInterface=port12 FTNTFGTsrcintfrole=lan deviceOutboundInterface=port11 FTNTFGTdstintfrole=wan proto=6 app=HTTP request=http://example.com/index.html?https://example.com/ FTNTFGTseverity=medium act=passthrough deviceDirection=0 requestClientApplication=curl/7.47.0 FTNTFGTconstraint=url-param-num FTNTFGTrawdata=Method\\=GET|User-Agent\\=curl/7.47.0",
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|30258|utm:waf waf-http-constraint passthrough|4|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=1203030258 cat=utm:waf FTNTFGTsubtype=waf FTNTFGTeventtype=waf-http-constraint FTNTFGTlevel=warning FTNTFGTvd=vdom1 FTNTFGTeventtime=1545951320 FTNTFGTpolicyid=1 externalId=13614 duser=bob FTNTFGTprofile=waf_test src=198.51.100.11 spt=57304 dst=example.com dpt=80 deviceInboundInterface=port12 FTNTFGTsrcintfrole=lan deviceOutboundInterface=port11 FTNTFGTdstintfrole=wan proto=6 app=HTTP request=http://example.com/index.html?https://example.com/ FTNTFGTseverity=medium act=passthrough deviceDirection=0 requestClientApplication=curl/7.47.0 FTNTFGTconstraint=url-param-num FTNTFGTrawdata=Method\\=GET|User-Agent\\=curl/7.47.0",
     "event": {
       "action": "passthrough",
       "category": "utm",
@@ -64,15 +64,15 @@
     },
     "related": {
       "ip": [
-        "10.1.100.11"
+        "198.51.100.11"
       ],
       "user": [
         "bob"
       ]
     },
     "source": {
-      "address": "10.1.100.11",
-      "ip": "10.1.100.11",
+      "address": "198.51.100.11",
+      "ip": "198.51.100.11",
       "port": 57304
     },
     "url": {

--- a/Fortinet/fortigate/tests/anomaly.CEF-2.json
+++ b/Fortinet/fortigate/tests/anomaly.CEF-2.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "0|Fortinet|Fortigate|v6.0.3|18433|utm:anomaly anomaly clear_session|7|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0720018433 cat=utm:anomaly FTNTFGTsubtype=anomaly FTNTFGTeventtype=anomaly FTNTFGTlevel=alert FTNTFGTvd=vdom1 FTNTFGTeventtime=1545939604 FTNTFGTseverity=critical src=10.1.100.11 FTNTFGTsrccountry=Reserved dst=172.16.200.55 deviceInboundInterface=port12 FTNTFGTsrcintfrole=undefined externalId=0 act=clear_session proto=1 app=PING cnt=1 FTNTFGTattack=icmp_flood FTNTFGTicmpid=0x3053 FTNTFGTicmptype=0x08 FTNTFGTicmpcode=0x00 FTNTFGTattackid=16777316 FTNTFGTpolicyid=1 FTNTFGTpolicytype=DoS-policy FTNTFGTref=http://www.fortinet.com/ids/VID16777316 msg=anomaly: icmp_flood, 51 > threshold 50 FTNTFGTcrscore=50 FTNTFGTcrlevel=critical"
+    "message": "0|Fortinet|Fortigate|v6.0.3|18433|utm:anomaly anomaly clear_session|7|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0720018433 cat=utm:anomaly FTNTFGTsubtype=anomaly FTNTFGTeventtype=anomaly FTNTFGTlevel=alert FTNTFGTvd=vdom1 FTNTFGTeventtime=1545939604 FTNTFGTseverity=critical src=198.51.100.11 FTNTFGTsrccountry=Reserved dst=203.0.113.55 deviceInboundInterface=port12 FTNTFGTsrcintfrole=undefined externalId=0 act=clear_session proto=1 app=PING cnt=1 FTNTFGTattack=icmp_flood FTNTFGTicmpid=0x3053 FTNTFGTicmptype=0x08 FTNTFGTicmpcode=0x00 FTNTFGTattackid=16777316 FTNTFGTpolicyid=1 FTNTFGTpolicytype=DoS-policy FTNTFGTref=http://www.fortinet.com/ids/VID16777316 msg=anomaly: icmp_flood, 51 > threshold 50 FTNTFGTcrscore=50 FTNTFGTcrlevel=critical"
   },
   "expected": {
-    "message": "0|Fortinet|Fortigate|v6.0.3|18433|utm:anomaly anomaly clear_session|7|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0720018433 cat=utm:anomaly FTNTFGTsubtype=anomaly FTNTFGTeventtype=anomaly FTNTFGTlevel=alert FTNTFGTvd=vdom1 FTNTFGTeventtime=1545939604 FTNTFGTseverity=critical src=10.1.100.11 FTNTFGTsrccountry=Reserved dst=172.16.200.55 deviceInboundInterface=port12 FTNTFGTsrcintfrole=undefined externalId=0 act=clear_session proto=1 app=PING cnt=1 FTNTFGTattack=icmp_flood FTNTFGTicmpid=0x3053 FTNTFGTicmptype=0x08 FTNTFGTicmpcode=0x00 FTNTFGTattackid=16777316 FTNTFGTpolicyid=1 FTNTFGTpolicytype=DoS-policy FTNTFGTref=http://www.fortinet.com/ids/VID16777316 msg=anomaly: icmp_flood, 51 > threshold 50 FTNTFGTcrscore=50 FTNTFGTcrlevel=critical",
+    "message": "0|Fortinet|Fortigate|v6.0.3|18433|utm:anomaly anomaly clear_session|7|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0720018433 cat=utm:anomaly FTNTFGTsubtype=anomaly FTNTFGTeventtype=anomaly FTNTFGTlevel=alert FTNTFGTvd=vdom1 FTNTFGTeventtime=1545939604 FTNTFGTseverity=critical src=198.51.100.11 FTNTFGTsrccountry=Reserved dst=203.0.113.55 deviceInboundInterface=port12 FTNTFGTsrcintfrole=undefined externalId=0 act=clear_session proto=1 app=PING cnt=1 FTNTFGTattack=icmp_flood FTNTFGTicmpid=0x3053 FTNTFGTicmptype=0x08 FTNTFGTicmpcode=0x00 FTNTFGTattackid=16777316 FTNTFGTpolicyid=1 FTNTFGTpolicytype=DoS-policy FTNTFGTref=http://www.fortinet.com/ids/VID16777316 msg=anomaly: icmp_flood, 51 > threshold 50 FTNTFGTcrscore=50 FTNTFGTcrlevel=critical",
     "event": {
       "action": "clear_session",
       "category": "utm",
@@ -25,8 +25,8 @@
       "type": "anomaly"
     },
     "destination": {
-      "address": "172.16.200.55",
-      "ip": "172.16.200.55"
+      "address": "203.0.113.55",
+      "ip": "203.0.113.55"
     },
     "fortinet": {
       "fortigate": {
@@ -73,16 +73,16 @@
     },
     "related": {
       "ip": [
-        "10.1.100.11",
-        "172.16.200.55"
+        "198.51.100.11",
+        "203.0.113.55"
       ]
     },
     "rule": {
       "ruleset": "DoS-policy"
     },
     "source": {
-      "address": "10.1.100.11",
-      "ip": "10.1.100.11"
+      "address": "198.51.100.11",
+      "ip": "198.51.100.11"
     }
   }
 }

--- a/Fortinet/fortigate/tests/anomaly.CEF.json
+++ b/Fortinet/fortigate/tests/anomaly.CEF.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "CEF:0|Fortinet|Fortigate|v5.6.0|18433|anomaly:anomaly clear_ session|7|FTNTFGTlogid=0720018433 cat=anomaly:anomaly FTNTFGTsubtype=anomaly FTNTFGTlevel=alert FTNTFGTvd=vdom1 FTNTFGTseverity=critical src=1.1.1.1 dst=192.0.2.1 deviceInboundInterface=port15 externalId=0 act=clear_session proto=1 app=icmp/146/81 cnt=306 FTNTFGTattack=icmp_flood dpt=20882 FTNTFGTicmptype=0x92 FTNTFGTicmpcode=0x51 FTNTFGTattackid=16777316 FTNTFGTprofile=DoS-policy1 cs2=http://www.fortinet.com/ids/VID16777316 cs2Label=Reference msg=anomaly: icmp_flood, 34 > threshold 25, repeats 306 times FTNTFGTcrscore=50 FTNTFGTcrlevel=critical"
+    "message": "CEF:0|Fortinet|Fortigate|v5.6.0|18433|anomaly:anomaly clear_ session|7|FTNTFGTlogid=0720018433 cat=anomaly:anomaly FTNTFGTsubtype=anomaly FTNTFGTlevel=alert FTNTFGTvd=vdom1 FTNTFGTseverity=critical src=192.0.2.101 dst=192.0.2.1 deviceInboundInterface=port15 externalId=0 act=clear_session proto=1 app=icmp/146/81 cnt=306 FTNTFGTattack=icmp_flood dpt=20882 FTNTFGTicmptype=0x92 FTNTFGTicmpcode=0x51 FTNTFGTattackid=16777316 FTNTFGTprofile=DoS-policy1 cs2=http://www.fortinet.com/ids/VID16777316 cs2Label=Reference msg=anomaly: icmp_flood, 34 > threshold 25, repeats 306 times FTNTFGTcrscore=50 FTNTFGTcrlevel=critical"
   },
   "expected": {
-    "message": "CEF:0|Fortinet|Fortigate|v5.6.0|18433|anomaly:anomaly clear_ session|7|FTNTFGTlogid=0720018433 cat=anomaly:anomaly FTNTFGTsubtype=anomaly FTNTFGTlevel=alert FTNTFGTvd=vdom1 FTNTFGTseverity=critical src=1.1.1.1 dst=192.0.2.1 deviceInboundInterface=port15 externalId=0 act=clear_session proto=1 app=icmp/146/81 cnt=306 FTNTFGTattack=icmp_flood dpt=20882 FTNTFGTicmptype=0x92 FTNTFGTicmpcode=0x51 FTNTFGTattackid=16777316 FTNTFGTprofile=DoS-policy1 cs2=http://www.fortinet.com/ids/VID16777316 cs2Label=Reference msg=anomaly: icmp_flood, 34 > threshold 25, repeats 306 times FTNTFGTcrscore=50 FTNTFGTcrlevel=critical",
+    "message": "CEF:0|Fortinet|Fortigate|v5.6.0|18433|anomaly:anomaly clear_ session|7|FTNTFGTlogid=0720018433 cat=anomaly:anomaly FTNTFGTsubtype=anomaly FTNTFGTlevel=alert FTNTFGTvd=vdom1 FTNTFGTseverity=critical src=192.0.2.101 dst=192.0.2.1 deviceInboundInterface=port15 externalId=0 act=clear_session proto=1 app=icmp/146/81 cnt=306 FTNTFGTattack=icmp_flood dpt=20882 FTNTFGTicmptype=0x92 FTNTFGTicmpcode=0x51 FTNTFGTattackid=16777316 FTNTFGTprofile=DoS-policy1 cs2=http://www.fortinet.com/ids/VID16777316 cs2Label=Reference msg=anomaly: icmp_flood, 34 > threshold 25, repeats 306 times FTNTFGTcrscore=50 FTNTFGTcrlevel=critical",
     "event": {
       "action": "clear_session",
       "category": "anomaly",
@@ -71,13 +71,13 @@
     },
     "related": {
       "ip": [
-        "1.1.1.1",
-        "192.0.2.1"
+        "192.0.2.1",
+        "192.0.2.101"
       ]
     },
     "source": {
-      "address": "1.1.1.1",
-      "ip": "1.1.1.1"
+      "address": "192.0.2.101",
+      "ip": "192.0.2.101"
     }
   }
 }

--- a/Fortinet/fortigate/tests/anomaly.CSV.json
+++ b/Fortinet/fortigate/tests/anomaly.CSV.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "date=2016-02-12,time=14:10:42,logid=0720018433,type=anomaly,subtype=anomaly,level=alert,vd=\"vdom1\",severity=critical,srcip=1.1.1.1,dstip=192.0.2.1,srcintf=\"port15\",sessionid=0,action=clear_session,proto=1,service=\"icmp/146/81\",count=306,attack=\"icmp_ flood\",dstport=20882,icmptype=0x92,icmpcode=0x51,attackid=16777316,profile=\"DoS-policy1\",ref=\"http://www.fortinet.com/ids/VID16777316\",msg=\"anomaly: icmp_flood, 34 > threshold 25, repeats 306 times\",crscore=50,crlevel=critical"
+    "message": "date=2016-02-12,time=14:10:42,logid=0720018433,type=anomaly,subtype=anomaly,level=alert,vd=\"vdom1\",severity=critical,srcip=192.0.2.101,dstip=192.0.2.1,srcintf=\"port15\",sessionid=0,action=clear_session,proto=1,service=\"icmp/146/81\",count=306,attack=\"icmp_ flood\",dstport=20882,icmptype=0x92,icmpcode=0x51,attackid=16777316,profile=\"DoS-policy1\",ref=\"http://www.fortinet.com/ids/VID16777316\",msg=\"anomaly: icmp_flood, 34 > threshold 25, repeats 306 times\",crscore=50,crlevel=critical"
   },
   "expected": {
-    "message": "date=2016-02-12,time=14:10:42,logid=0720018433,type=anomaly,subtype=anomaly,level=alert,vd=\"vdom1\",severity=critical,srcip=1.1.1.1,dstip=192.0.2.1,srcintf=\"port15\",sessionid=0,action=clear_session,proto=1,service=\"icmp/146/81\",count=306,attack=\"icmp_ flood\",dstport=20882,icmptype=0x92,icmpcode=0x51,attackid=16777316,profile=\"DoS-policy1\",ref=\"http://www.fortinet.com/ids/VID16777316\",msg=\"anomaly: icmp_flood, 34 > threshold 25, repeats 306 times\",crscore=50,crlevel=critical",
+    "message": "date=2016-02-12,time=14:10:42,logid=0720018433,type=anomaly,subtype=anomaly,level=alert,vd=\"vdom1\",severity=critical,srcip=192.0.2.101,dstip=192.0.2.1,srcintf=\"port15\",sessionid=0,action=clear_session,proto=1,service=\"icmp/146/81\",count=306,attack=\"icmp_ flood\",dstport=20882,icmptype=0x92,icmpcode=0x51,attackid=16777316,profile=\"DoS-policy1\",ref=\"http://www.fortinet.com/ids/VID16777316\",msg=\"anomaly: icmp_flood, 34 > threshold 25, repeats 306 times\",crscore=50,crlevel=critical",
     "event": {
       "action": "clear_session",
       "category": "anomaly",
@@ -69,13 +69,13 @@
     },
     "related": {
       "ip": [
-        "1.1.1.1",
-        "192.0.2.1"
+        "192.0.2.1",
+        "192.0.2.101"
       ]
     },
     "source": {
-      "address": "1.1.1.1",
-      "ip": "1.1.1.1"
+      "address": "192.0.2.101",
+      "ip": "192.0.2.101"
     }
   }
 }

--- a/Fortinet/fortigate/tests/anomaly.STANDARD.json
+++ b/Fortinet/fortigate/tests/anomaly.STANDARD.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "date=2016-02-12 time=14:10:42 logid=0720018433 type=anomaly subtype=anomaly level=alert vd=\"vdom1\" severity=critical srcip=1.1.1.1 dstip=192.0.2.1 srcintf=\"port15\" sessionid=0 action=clear_session proto=1 service=\"icmp/146/81\" count=306 attack=\"icmp_ flood\" dstport=20882 icmptype=0x92 icmpcode=0x51 attackid=16777316 profile=\"DoS-policy1\" ref=\"http://www.fortinet.com/ids/VID16777316\" msg=\"anomaly: icmp_flood, 34 > threshold 25, repeats 306 times\" crscore=50 crlevel=critical"
+    "message": "date=2016-02-12 time=14:10:42 logid=0720018433 type=anomaly subtype=anomaly level=alert vd=\"vdom1\" severity=critical srcip=192.0.2.101 dstip=192.0.2.1 srcintf=\"port15\" sessionid=0 action=clear_session proto=1 service=\"icmp/146/81\" count=306 attack=\"icmp_ flood\" dstport=20882 icmptype=0x92 icmpcode=0x51 attackid=16777316 profile=\"DoS-policy1\" ref=\"http://www.fortinet.com/ids/VID16777316\" msg=\"anomaly: icmp_flood, 34 > threshold 25, repeats 306 times\" crscore=50 crlevel=critical"
   },
   "expected": {
-    "message": "date=2016-02-12 time=14:10:42 logid=0720018433 type=anomaly subtype=anomaly level=alert vd=\"vdom1\" severity=critical srcip=1.1.1.1 dstip=192.0.2.1 srcintf=\"port15\" sessionid=0 action=clear_session proto=1 service=\"icmp/146/81\" count=306 attack=\"icmp_ flood\" dstport=20882 icmptype=0x92 icmpcode=0x51 attackid=16777316 profile=\"DoS-policy1\" ref=\"http://www.fortinet.com/ids/VID16777316\" msg=\"anomaly: icmp_flood, 34 > threshold 25, repeats 306 times\" crscore=50 crlevel=critical",
+    "message": "date=2016-02-12 time=14:10:42 logid=0720018433 type=anomaly subtype=anomaly level=alert vd=\"vdom1\" severity=critical srcip=192.0.2.101 dstip=192.0.2.1 srcintf=\"port15\" sessionid=0 action=clear_session proto=1 service=\"icmp/146/81\" count=306 attack=\"icmp_ flood\" dstport=20882 icmptype=0x92 icmpcode=0x51 attackid=16777316 profile=\"DoS-policy1\" ref=\"http://www.fortinet.com/ids/VID16777316\" msg=\"anomaly: icmp_flood, 34 > threshold 25, repeats 306 times\" crscore=50 crlevel=critical",
     "event": {
       "action": "clear_session",
       "category": "anomaly",
@@ -69,13 +69,13 @@
     },
     "related": {
       "ip": [
-        "1.1.1.1",
-        "192.0.2.1"
+        "192.0.2.1",
+        "192.0.2.101"
       ]
     },
     "source": {
-      "address": "1.1.1.1",
-      "ip": "1.1.1.1"
+      "address": "192.0.2.101",
+      "ip": "192.0.2.101"
     }
   }
 }

--- a/Fortinet/fortigate/tests/antivirus.CEF-2.json
+++ b/Fortinet/fortigate/tests/antivirus.CEF-2.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|08192|utm:virus infected blocked|4|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0211008192 cat=utm:virus FTNTFGTsubtype=virus FTNTFGTeventtype=infected FTNTFGTlevel=warning FTNTFGTvd=vdom1 FTNTFGTeventtime=1545938448 msg=File is infected. act=blocked app=HTTP externalId=695 src=10.1.100.11 dst=example.com spt=44356 dpt=80 deviceInboundInterface=port12 FTNTFGTsrcintfrole=undefined deviceOutboundInterface=port11 FTNTFGTdstintfrole=undefined FTNTFGTpolicyid=1 proto=6 deviceDirection=0 fname=eicar.com FTNTFGTquarskip=File-was-not-quarantined. FTNTFGTvirus=EICAR_TEST_FILE FTNTFGTdtype=Virus FTNTFGTref=http://www.fortinet.com/ve?vn\\=EICAR_TEST_FILE FTNTFGTvirusid=2172 request=http://example.com/virus/eicar.com FTNTFGTprofile=g-default duser=bob requestClientApplication=curl/7.47.0 FTNTFGTanalyticscksum=275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f FTNTFGTanalyticssubmit=false FTNTFGTcrscore=50 FTNTFGTcrlevel=critical"
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|08192|utm:virus infected blocked|4|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0211008192 cat=utm:virus FTNTFGTsubtype=virus FTNTFGTeventtype=infected FTNTFGTlevel=warning FTNTFGTvd=vdom1 FTNTFGTeventtime=1545938448 msg=File is infected. act=blocked app=HTTP externalId=695 src=198.51.100.11 dst=example.com spt=44356 dpt=80 deviceInboundInterface=port12 FTNTFGTsrcintfrole=undefined deviceOutboundInterface=port11 FTNTFGTdstintfrole=undefined FTNTFGTpolicyid=1 proto=6 deviceDirection=0 fname=eicar.com FTNTFGTquarskip=File-was-not-quarantined. FTNTFGTvirus=EICAR_TEST_FILE FTNTFGTdtype=Virus FTNTFGTref=http://www.fortinet.com/ve?vn\\=EICAR_TEST_FILE FTNTFGTvirusid=2172 request=http://example.com/virus/eicar.com FTNTFGTprofile=g-default duser=bob requestClientApplication=curl/7.47.0 FTNTFGTanalyticscksum=275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f FTNTFGTanalyticssubmit=false FTNTFGTcrscore=50 FTNTFGTcrlevel=critical"
   },
   "expected": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|08192|utm:virus infected blocked|4|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0211008192 cat=utm:virus FTNTFGTsubtype=virus FTNTFGTeventtype=infected FTNTFGTlevel=warning FTNTFGTvd=vdom1 FTNTFGTeventtime=1545938448 msg=File is infected. act=blocked app=HTTP externalId=695 src=10.1.100.11 dst=example.com spt=44356 dpt=80 deviceInboundInterface=port12 FTNTFGTsrcintfrole=undefined deviceOutboundInterface=port11 FTNTFGTdstintfrole=undefined FTNTFGTpolicyid=1 proto=6 deviceDirection=0 fname=eicar.com FTNTFGTquarskip=File-was-not-quarantined. FTNTFGTvirus=EICAR_TEST_FILE FTNTFGTdtype=Virus FTNTFGTref=http://www.fortinet.com/ve?vn\\=EICAR_TEST_FILE FTNTFGTvirusid=2172 request=http://example.com/virus/eicar.com FTNTFGTprofile=g-default duser=bob requestClientApplication=curl/7.47.0 FTNTFGTanalyticscksum=275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f FTNTFGTanalyticssubmit=false FTNTFGTcrscore=50 FTNTFGTcrlevel=critical",
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|08192|utm:virus infected blocked|4|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0211008192 cat=utm:virus FTNTFGTsubtype=virus FTNTFGTeventtype=infected FTNTFGTlevel=warning FTNTFGTvd=vdom1 FTNTFGTeventtime=1545938448 msg=File is infected. act=blocked app=HTTP externalId=695 src=198.51.100.11 dst=example.com spt=44356 dpt=80 deviceInboundInterface=port12 FTNTFGTsrcintfrole=undefined deviceOutboundInterface=port11 FTNTFGTdstintfrole=undefined FTNTFGTpolicyid=1 proto=6 deviceDirection=0 fname=eicar.com FTNTFGTquarskip=File-was-not-quarantined. FTNTFGTvirus=EICAR_TEST_FILE FTNTFGTdtype=Virus FTNTFGTref=http://www.fortinet.com/ve?vn\\=EICAR_TEST_FILE FTNTFGTvirusid=2172 request=http://example.com/virus/eicar.com FTNTFGTprofile=g-default duser=bob requestClientApplication=curl/7.47.0 FTNTFGTanalyticscksum=275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f FTNTFGTanalyticssubmit=false FTNTFGTcrscore=50 FTNTFGTcrlevel=critical",
     "event": {
       "action": "blocked",
       "category": "utm",
@@ -68,15 +68,15 @@
     },
     "related": {
       "ip": [
-        "10.1.100.11"
+        "198.51.100.11"
       ],
       "user": [
         "bob"
       ]
     },
     "source": {
-      "address": "10.1.100.11",
-      "ip": "10.1.100.11",
+      "address": "198.51.100.11",
+      "ip": "198.51.100.11",
       "port": 44356
     },
     "url": {

--- a/Fortinet/fortigate/tests/antivirus.CEF.json
+++ b/Fortinet/fortigate/tests/antivirus.CEF.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "CEF:0|Fortinet|Fortigate|v5.6.0|08192|utm:virus infected blocked|4|FTNTFGTlogid=0211008192 cat=utm:virus FTNTFGTsubtype=virus FTNTFGTeventtype=infected FTNTFGTlevel=warning FTNTFGTvd=vdom1 msg=File is infected act=blocked app=HTTP externalId=56633 src=1.1.1.1 dst=192.0.2.1 spt=45719 dpt=80 deviceInboundInterface=port15 deviceOutboundInterface=port19 proto=6 deviceDirection=0 fname=eicar.com FTNTFGTchecksum=1dd02bdb FTNTFGTquarskip=No-skip cs1=EICAR_TEST_FILE cs1Label=Virus FTNTFGTdtype=Virus cs2=http://www.fortinet.com/ve?vn\\=EICAR_TEST_FILE cs2Label=Reference FTNTFGTvirusid=2172 request=http://example.net/eicar.com FTNTFGTprofile=default duser= requestClientApplication=Wget/1 10 2 FTNTFGTanalyticscksum=131f95c51cc819465fa1797f6ccacf9d494aaaff46fa3eac73ae63ffbdfd8267 FTNTFGTanalyticssubmit=false FTNTFGTcrscore=50 FTNTFGTcrlevel=critical"
+    "message": "CEF:0|Fortinet|Fortigate|v5.6.0|08192|utm:virus infected blocked|4|FTNTFGTlogid=0211008192 cat=utm:virus FTNTFGTsubtype=virus FTNTFGTeventtype=infected FTNTFGTlevel=warning FTNTFGTvd=vdom1 msg=File is infected act=blocked app=HTTP externalId=56633 src=192.0.2.101 dst=192.0.2.1 spt=45719 dpt=80 deviceInboundInterface=port15 deviceOutboundInterface=port19 proto=6 deviceDirection=0 fname=eicar.com FTNTFGTchecksum=1dd02bdb FTNTFGTquarskip=No-skip cs1=EICAR_TEST_FILE cs1Label=Virus FTNTFGTdtype=Virus cs2=http://www.fortinet.com/ve?vn\\=EICAR_TEST_FILE cs2Label=Reference FTNTFGTvirusid=2172 request=http://example.net/eicar.com FTNTFGTprofile=default duser= requestClientApplication=Wget/1 10 2 FTNTFGTanalyticscksum=131f95c51cc819465fa1797f6ccacf9d494aaaff46fa3eac73ae63ffbdfd8267 FTNTFGTanalyticssubmit=false FTNTFGTcrscore=50 FTNTFGTcrlevel=critical"
   },
   "expected": {
-    "message": "CEF:0|Fortinet|Fortigate|v5.6.0|08192|utm:virus infected blocked|4|FTNTFGTlogid=0211008192 cat=utm:virus FTNTFGTsubtype=virus FTNTFGTeventtype=infected FTNTFGTlevel=warning FTNTFGTvd=vdom1 msg=File is infected act=blocked app=HTTP externalId=56633 src=1.1.1.1 dst=192.0.2.1 spt=45719 dpt=80 deviceInboundInterface=port15 deviceOutboundInterface=port19 proto=6 deviceDirection=0 fname=eicar.com FTNTFGTchecksum=1dd02bdb FTNTFGTquarskip=No-skip cs1=EICAR_TEST_FILE cs1Label=Virus FTNTFGTdtype=Virus cs2=http://www.fortinet.com/ve?vn\\=EICAR_TEST_FILE cs2Label=Reference FTNTFGTvirusid=2172 request=http://example.net/eicar.com FTNTFGTprofile=default duser= requestClientApplication=Wget/1 10 2 FTNTFGTanalyticscksum=131f95c51cc819465fa1797f6ccacf9d494aaaff46fa3eac73ae63ffbdfd8267 FTNTFGTanalyticssubmit=false FTNTFGTcrscore=50 FTNTFGTcrlevel=critical",
+    "message": "CEF:0|Fortinet|Fortigate|v5.6.0|08192|utm:virus infected blocked|4|FTNTFGTlogid=0211008192 cat=utm:virus FTNTFGTsubtype=virus FTNTFGTeventtype=infected FTNTFGTlevel=warning FTNTFGTvd=vdom1 msg=File is infected act=blocked app=HTTP externalId=56633 src=192.0.2.101 dst=192.0.2.1 spt=45719 dpt=80 deviceInboundInterface=port15 deviceOutboundInterface=port19 proto=6 deviceDirection=0 fname=eicar.com FTNTFGTchecksum=1dd02bdb FTNTFGTquarskip=No-skip cs1=EICAR_TEST_FILE cs1Label=Virus FTNTFGTdtype=Virus cs2=http://www.fortinet.com/ve?vn\\=EICAR_TEST_FILE cs2Label=Reference FTNTFGTvirusid=2172 request=http://example.net/eicar.com FTNTFGTprofile=default duser= requestClientApplication=Wget/1 10 2 FTNTFGTanalyticscksum=131f95c51cc819465fa1797f6ccacf9d494aaaff46fa3eac73ae63ffbdfd8267 FTNTFGTanalyticssubmit=false FTNTFGTcrscore=50 FTNTFGTcrlevel=critical",
     "event": {
       "action": "blocked",
       "category": "utm",
@@ -63,13 +63,13 @@
     },
     "related": {
       "ip": [
-        "1.1.1.1",
-        "192.0.2.1"
+        "192.0.2.1",
+        "192.0.2.101"
       ]
     },
     "source": {
-      "address": "1.1.1.1",
-      "ip": "1.1.1.1",
+      "address": "192.0.2.101",
+      "ip": "192.0.2.101",
       "port": 45719
     },
     "url": {

--- a/Fortinet/fortigate/tests/app_ctrl.json
+++ b/Fortinet/fortigate/tests/app_ctrl.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "message": "time=09:47:30 devname=\"TEST_DEV_NAME1\" devid=\"TEST_DEV_ID\" logid=\"1059028704\" type=\"utm\" subtype=\"app-ctrl\" eventtype=\"app-ctrl-all\" level=\"information\" vd=\"root\" eventtime=1741250850 appid=0000 srcip=1.2.3.4 dstip=3.4.5.6 srcport=11116 dstport=80 srcintf=\"root-enoveo0\" srcintfrole=\"undefined\" dstintf=\"internet-100\" dstintfrole=\"undefined\" proto=6 service=\"HTTP\" direction=\"outgoing\" policyid=293 sessionid=1947800834 applist=\"g-default\" appcat=\"Web.Client\" app=\"HTTP.BROWSER_Firefox\" action=\"pass\" hostname=\"example.com\" incidentserialno=235885632 url=\"/canonical.html\" msg=\"Web.Client: HTTP.BROWSER_Firefox,\" apprisk=\"elevated\"",
+    "message": "time=09:47:30 devname=\"TEST_DEV_NAME1\" devid=\"TEST_DEV_ID\" logid=\"1059028704\" type=\"utm\" subtype=\"app-ctrl\" eventtype=\"app-ctrl-all\" level=\"information\" vd=\"root\" eventtime=1741250850 appid=0000 srcip=198.51.100.4 dstip=203.0.113.6 srcport=11116 dstport=80 srcintf=\"root-enoveo0\" srcintfrole=\"undefined\" dstintf=\"internet-100\" dstintfrole=\"undefined\" proto=6 service=\"HTTP\" direction=\"outgoing\" policyid=293 sessionid=1947800834 applist=\"g-default\" appcat=\"Web.Client\" app=\"HTTP.BROWSER_Firefox\" action=\"pass\" hostname=\"example.com\" incidentserialno=235885632 url=\"/canonical.html\" msg=\"Web.Client: HTTP.BROWSER_Firefox,\" apprisk=\"elevated\"",
     "sekoiaio": {
       "intake": {
         "dialect": "Fortinet FortiGate",
@@ -9,7 +9,7 @@
     }
   },
   "expected": {
-    "message": "time=09:47:30 devname=\"TEST_DEV_NAME1\" devid=\"TEST_DEV_ID\" logid=\"1059028704\" type=\"utm\" subtype=\"app-ctrl\" eventtype=\"app-ctrl-all\" level=\"information\" vd=\"root\" eventtime=1741250850 appid=0000 srcip=1.2.3.4 dstip=3.4.5.6 srcport=11116 dstport=80 srcintf=\"root-enoveo0\" srcintfrole=\"undefined\" dstintf=\"internet-100\" dstintfrole=\"undefined\" proto=6 service=\"HTTP\" direction=\"outgoing\" policyid=293 sessionid=1947800834 applist=\"g-default\" appcat=\"Web.Client\" app=\"HTTP.BROWSER_Firefox\" action=\"pass\" hostname=\"example.com\" incidentserialno=235885632 url=\"/canonical.html\" msg=\"Web.Client: HTTP.BROWSER_Firefox,\" apprisk=\"elevated\"",
+    "message": "time=09:47:30 devname=\"TEST_DEV_NAME1\" devid=\"TEST_DEV_ID\" logid=\"1059028704\" type=\"utm\" subtype=\"app-ctrl\" eventtype=\"app-ctrl-all\" level=\"information\" vd=\"root\" eventtime=1741250850 appid=0000 srcip=198.51.100.4 dstip=203.0.113.6 srcport=11116 dstport=80 srcintf=\"root-enoveo0\" srcintfrole=\"undefined\" dstintf=\"internet-100\" dstintfrole=\"undefined\" proto=6 service=\"HTTP\" direction=\"outgoing\" policyid=293 sessionid=1947800834 applist=\"g-default\" appcat=\"Web.Client\" app=\"HTTP.BROWSER_Firefox\" action=\"pass\" hostname=\"example.com\" incidentserialno=235885632 url=\"/canonical.html\" msg=\"Web.Client: HTTP.BROWSER_Firefox,\" apprisk=\"elevated\"",
     "event": {
       "action": "pass",
       "category": "utm",
@@ -27,9 +27,9 @@
       "type": "app-ctrl"
     },
     "destination": {
-      "address": "3.4.5.6",
+      "address": "203.0.113.6",
       "domain": "example.com",
-      "ip": "3.4.5.6",
+      "ip": "203.0.113.6",
       "port": 80
     },
     "file": {
@@ -77,8 +77,8 @@
         "example.com"
       ],
       "ip": [
-        "1.2.3.4",
-        "3.4.5.6"
+        "198.51.100.4",
+        "203.0.113.6"
       ]
     },
     "rule": {
@@ -87,8 +87,8 @@
       "ruleset": "g-default"
     },
     "source": {
-      "address": "1.2.3.4",
-      "ip": "1.2.3.4",
+      "address": "198.51.100.4",
+      "ip": "198.51.100.4",
       "port": 11116
     },
     "url": {

--- a/Fortinet/fortigate/tests/app_ctrl_1.json
+++ b/Fortinet/fortigate/tests/app_ctrl_1.json
@@ -63,9 +63,9 @@
       "level": "information"
     },
     "network": {
-      "application": "HTTPS",
+      "application": "YouTube_Video.Access",
       "direction": "inbound",
-      "protocol": "https",
+      "protocol": "youtube_video.access",
       "transport": "tcp"
     },
     "observer": {

--- a/Fortinet/fortigate/tests/app_ctrl_1.json
+++ b/Fortinet/fortigate/tests/app_ctrl_1.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "message": "0|Fortinet|Fortigate|v7.2.10|28704|utm:app-ctrl signature|2|deviceExternalId=FG3H0E5819900415 FTNTFGTeventtime=1741265077985865088 FTNTFGTtz=+0100 FTNTFGTlogid=1059028704 cat=utm:app-ctrl FTNTFGTsubtype=app-ctrl FTNTFGTeventtype=signature FTNTFGTlevel=information FTNTFGTvd=root FTNTFGTappid=16420 duser=testUser FTNTFGTgroup=testGroup src=1.2.3.4 FTNTFGTsrccountry=Reserved dst=3.4.5.6 FTNTFGTdstcountry=United States spt=52854 dpt=443 deviceInboundInterface=vlan-1024 FTNTFGTsrcintfrole=lan deviceOutboundInterface=vlan-1033 FTNTFGTdstintfrole=wan proto=6 app=HTTPS deviceDirection=0 FTNTFGTpolicyid=5 externalId=70046266 FTNTFGTapplist=app-ctrl-bme act=pass FTNTFGTappcat=Video/Audio FTNTFGTapp=YouTube_Video.Access dhost=example.com FTNTFGTincidentserialno=231408777 request=/youtubei/v1/player?https://example.com/ requestClientApplication=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 FTNTFGThttpmethod=POST FTNTFGTreferralurl=https://example.com/ msg=Video/Audio: YouTube_Video.Access FTNTFGTclouduser=1.2.3.4 fname=LA CACABOX sur REPO & AMONG-US 3D - POTATOZ VOD FTNTFGTapprisk=elevated FTNTFGTcloudaction=others",
+    "message": "0|Fortinet|Fortigate|v7.2.10|28704|utm:app-ctrl signature|2|deviceExternalId=FG3H0E5819900415 FTNTFGTeventtime=1741265077985865088 FTNTFGTtz=+0100 FTNTFGTlogid=1059028704 cat=utm:app-ctrl FTNTFGTsubtype=app-ctrl FTNTFGTeventtype=signature FTNTFGTlevel=information FTNTFGTvd=root FTNTFGTappid=16420 duser=testUser FTNTFGTgroup=testGroup src=198.51.100.4 FTNTFGTsrccountry=Reserved dst=203.0.113.6 FTNTFGTdstcountry=United States spt=52854 dpt=443 deviceInboundInterface=vlan-1024 FTNTFGTsrcintfrole=lan deviceOutboundInterface=vlan-1033 FTNTFGTdstintfrole=wan proto=6 app=HTTPS deviceDirection=0 FTNTFGTpolicyid=5 externalId=70046266 FTNTFGTapplist=app-ctrl-bme act=pass FTNTFGTappcat=Video/Audio FTNTFGTapp=YouTube_Video.Access dhost=example.com FTNTFGTincidentserialno=231408777 request=/youtubei/v1/player?https://example.com/ requestClientApplication=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/192.0.2.122 Safari/537.36 FTNTFGThttpmethod=POST FTNTFGTreferralurl=https://example.com/ msg=Video/Audio: YouTube_Video.Access FTNTFGTclouduser=198.51.100.4 fname=LA CACABOX sur REPO & AMONG-US 3D - POTATOZ VOD FTNTFGTapprisk=elevated FTNTFGTcloudaction=others",
     "sekoiaio": {
       "intake": {
         "dialect": "Fortinet FortiGate",
@@ -9,7 +9,7 @@
     }
   },
   "expected": {
-    "message": "0|Fortinet|Fortigate|v7.2.10|28704|utm:app-ctrl signature|2|deviceExternalId=FG3H0E5819900415 FTNTFGTeventtime=1741265077985865088 FTNTFGTtz=+0100 FTNTFGTlogid=1059028704 cat=utm:app-ctrl FTNTFGTsubtype=app-ctrl FTNTFGTeventtype=signature FTNTFGTlevel=information FTNTFGTvd=root FTNTFGTappid=16420 duser=testUser FTNTFGTgroup=testGroup src=1.2.3.4 FTNTFGTsrccountry=Reserved dst=3.4.5.6 FTNTFGTdstcountry=United States spt=52854 dpt=443 deviceInboundInterface=vlan-1024 FTNTFGTsrcintfrole=lan deviceOutboundInterface=vlan-1033 FTNTFGTdstintfrole=wan proto=6 app=HTTPS deviceDirection=0 FTNTFGTpolicyid=5 externalId=70046266 FTNTFGTapplist=app-ctrl-bme act=pass FTNTFGTappcat=Video/Audio FTNTFGTapp=YouTube_Video.Access dhost=example.com FTNTFGTincidentserialno=231408777 request=/youtubei/v1/player?https://example.com/ requestClientApplication=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 FTNTFGThttpmethod=POST FTNTFGTreferralurl=https://example.com/ msg=Video/Audio: YouTube_Video.Access FTNTFGTclouduser=1.2.3.4 fname=LA CACABOX sur REPO & AMONG-US 3D - POTATOZ VOD FTNTFGTapprisk=elevated FTNTFGTcloudaction=others",
+    "message": "0|Fortinet|Fortigate|v7.2.10|28704|utm:app-ctrl signature|2|deviceExternalId=FG3H0E5819900415 FTNTFGTeventtime=1741265077985865088 FTNTFGTtz=+0100 FTNTFGTlogid=1059028704 cat=utm:app-ctrl FTNTFGTsubtype=app-ctrl FTNTFGTeventtype=signature FTNTFGTlevel=information FTNTFGTvd=root FTNTFGTappid=16420 duser=testUser FTNTFGTgroup=testGroup src=198.51.100.4 FTNTFGTsrccountry=Reserved dst=203.0.113.6 FTNTFGTdstcountry=United States spt=52854 dpt=443 deviceInboundInterface=vlan-1024 FTNTFGTsrcintfrole=lan deviceOutboundInterface=vlan-1033 FTNTFGTdstintfrole=wan proto=6 app=HTTPS deviceDirection=0 FTNTFGTpolicyid=5 externalId=70046266 FTNTFGTapplist=app-ctrl-bme act=pass FTNTFGTappcat=Video/Audio FTNTFGTapp=YouTube_Video.Access dhost=example.com FTNTFGTincidentserialno=231408777 request=/youtubei/v1/player?https://example.com/ requestClientApplication=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/192.0.2.122 Safari/537.36 FTNTFGThttpmethod=POST FTNTFGTreferralurl=https://example.com/ msg=Video/Audio: YouTube_Video.Access FTNTFGTclouduser=198.51.100.4 fname=LA CACABOX sur REPO & AMONG-US 3D - POTATOZ VOD FTNTFGTapprisk=elevated FTNTFGTcloudaction=others",
     "event": {
       "action": "pass",
       "category": "utm",
@@ -28,12 +28,12 @@
       "type": "app-ctrl"
     },
     "destination": {
-      "address": "3.4.5.6",
+      "address": "203.0.113.6",
       "domain": "example.com",
       "geo": {
         "country_name": "United States"
       },
-      "ip": "3.4.5.6",
+      "ip": "203.0.113.6",
       "port": 443,
       "user": {
         "name": "testUser"
@@ -91,8 +91,8 @@
         "example.com"
       ],
       "ip": [
-        "1.2.3.4",
-        "3.4.5.6"
+        "198.51.100.4",
+        "203.0.113.6"
       ],
       "user": [
         "testUser"
@@ -104,8 +104,8 @@
       "ruleset": "app-ctrl-bme"
     },
     "source": {
-      "address": "1.2.3.4",
-      "ip": "1.2.3.4",
+      "address": "198.51.100.4",
+      "ip": "198.51.100.4",
       "port": 52854
     },
     "url": {
@@ -118,12 +118,12 @@
         "name": "Other"
       },
       "name": "Chrome",
-      "original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+      "original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/192.0.2.122 Safari/537.36",
       "os": {
         "name": "Windows",
         "version": "10"
       },
-      "version": "122.0.0"
+      "version": "192.0.2"
     }
   }
 }

--- a/Fortinet/fortigate/tests/app_ctrl_2.json
+++ b/Fortinet/fortigate/tests/app_ctrl_2.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "message": "0|Fortinet|Fortigate|v7.0.17|08192|utm:virus infected|4|deviceExternalId=FG120GTK24003942 FTNTFGTeventtime=1741264893005614373 FTNTFGTtz=+0100 FTNTFGTlogid=0211008192 cat=utm:virus FTNTFGTsubtype=virus FTNTFGTeventtype=infected FTNTFGTlevel=warning FTNTFGTvd=root FTNTFGTpolicyid=7 FTNTFGTpoluuid=poluuid FTNTFGTpolicytype=policy msg=File is infected. act=blocked app=IMAP externalId=2861718763 src=1.2.3.4 dst=3.4.5.6 spt=54364 dpt=143 FTNTFGTsrccountry=Reserved FTNTFGTdstcountry=France deviceInboundInterface=400-TOXIII FTNTFGTsrcintfrole=lan deviceOutboundInterface=port1 FTNTFGTdstintfrole=wan FTNTFGTsrcuuid=dstuuuid FTNTFGTdstuuid=dstuuuid proto=6 deviceDirection=0 fname=BULLETIN-TABLE-OVALE.docx FTNTFGTquarskip=Quarantine-disabled FTNTFGTvirus=MSOffice/Agent.PCL!tr.dldr FTNTFGTviruscat=Virus FTNTFGTdtype=av-engine FTNTFGTref=http://test.com/ve?vn\\=sdkdksdkds FTNTFGTvirusid=8032867 FTNTFGTprofile=default suser=user1 duser=user1 FTNTFGTrecipient=\\\\\"testUser@test.test\\\\\" FTNTFGTanalyticscksum=383b017352d7602c7603f5d36a9c3beb23df2f183116e0cc3d81e158e978ee7d FTNTFGTanalyticssubmit=false FTNTFGTcrscore=50 FTNTFGTcraction=2 FTNTFGTcrlevel=critical",
+    "message": "0|Fortinet|Fortigate|v7.0.17|08192|utm:virus infected|4|deviceExternalId=FG120GTK24003942 FTNTFGTeventtime=1741264893005614373 FTNTFGTtz=+0100 FTNTFGTlogid=0211008192 cat=utm:virus FTNTFGTsubtype=virus FTNTFGTeventtype=infected FTNTFGTlevel=warning FTNTFGTvd=root FTNTFGTpolicyid=7 FTNTFGTpoluuid=poluuid FTNTFGTpolicytype=policy msg=File is infected. act=blocked app=IMAP externalId=2861718763 src=198.51.100.4 dst=203.0.113.6 spt=54364 dpt=143 FTNTFGTsrccountry=Reserved FTNTFGTdstcountry=France deviceInboundInterface=400-TOXIII FTNTFGTsrcintfrole=lan deviceOutboundInterface=port1 FTNTFGTdstintfrole=wan FTNTFGTsrcuuid=dstuuuid FTNTFGTdstuuid=dstuuuid proto=6 deviceDirection=0 fname=BULLETIN-TABLE-OVALE.docx FTNTFGTquarskip=Quarantine-disabled FTNTFGTvirus=MSOffice/Agent.PCL!tr.dldr FTNTFGTviruscat=Virus FTNTFGTdtype=av-engine FTNTFGTref=http://test.com/ve?vn\\=sdkdksdkds FTNTFGTvirusid=8032867 FTNTFGTprofile=default suser=user1 duser=user1 FTNTFGTrecipient=\\\\\"testuser@example.com\\\\\" FTNTFGTanalyticscksum=383b017352d7602c7603f5d36a9c3beb23df2f183116e0cc3d81e158e978ee7d FTNTFGTanalyticssubmit=false FTNTFGTcrscore=50 FTNTFGTcraction=2 FTNTFGTcrlevel=critical",
     "sekoiaio": {
       "intake": {
         "dialect": "Fortinet FortiGate",
@@ -9,7 +9,7 @@
     }
   },
   "expected": {
-    "message": "0|Fortinet|Fortigate|v7.0.17|08192|utm:virus infected|4|deviceExternalId=FG120GTK24003942 FTNTFGTeventtime=1741264893005614373 FTNTFGTtz=+0100 FTNTFGTlogid=0211008192 cat=utm:virus FTNTFGTsubtype=virus FTNTFGTeventtype=infected FTNTFGTlevel=warning FTNTFGTvd=root FTNTFGTpolicyid=7 FTNTFGTpoluuid=poluuid FTNTFGTpolicytype=policy msg=File is infected. act=blocked app=IMAP externalId=2861718763 src=1.2.3.4 dst=3.4.5.6 spt=54364 dpt=143 FTNTFGTsrccountry=Reserved FTNTFGTdstcountry=France deviceInboundInterface=400-TOXIII FTNTFGTsrcintfrole=lan deviceOutboundInterface=port1 FTNTFGTdstintfrole=wan FTNTFGTsrcuuid=dstuuuid FTNTFGTdstuuid=dstuuuid proto=6 deviceDirection=0 fname=BULLETIN-TABLE-OVALE.docx FTNTFGTquarskip=Quarantine-disabled FTNTFGTvirus=MSOffice/Agent.PCL!tr.dldr FTNTFGTviruscat=Virus FTNTFGTdtype=av-engine FTNTFGTref=http://test.com/ve?vn\\=sdkdksdkds FTNTFGTvirusid=8032867 FTNTFGTprofile=default suser=user1 duser=user1 FTNTFGTrecipient=\\\\\"testUser@test.test\\\\\" FTNTFGTanalyticscksum=383b017352d7602c7603f5d36a9c3beb23df2f183116e0cc3d81e158e978ee7d FTNTFGTanalyticssubmit=false FTNTFGTcrscore=50 FTNTFGTcraction=2 FTNTFGTcrlevel=critical",
+    "message": "0|Fortinet|Fortigate|v7.0.17|08192|utm:virus infected|4|deviceExternalId=FG120GTK24003942 FTNTFGTeventtime=1741264893005614373 FTNTFGTtz=+0100 FTNTFGTlogid=0211008192 cat=utm:virus FTNTFGTsubtype=virus FTNTFGTeventtype=infected FTNTFGTlevel=warning FTNTFGTvd=root FTNTFGTpolicyid=7 FTNTFGTpoluuid=poluuid FTNTFGTpolicytype=policy msg=File is infected. act=blocked app=IMAP externalId=2861718763 src=198.51.100.4 dst=203.0.113.6 spt=54364 dpt=143 FTNTFGTsrccountry=Reserved FTNTFGTdstcountry=France deviceInboundInterface=400-TOXIII FTNTFGTsrcintfrole=lan deviceOutboundInterface=port1 FTNTFGTdstintfrole=wan FTNTFGTsrcuuid=dstuuuid FTNTFGTdstuuid=dstuuuid proto=6 deviceDirection=0 fname=BULLETIN-TABLE-OVALE.docx FTNTFGTquarskip=Quarantine-disabled FTNTFGTvirus=MSOffice/Agent.PCL!tr.dldr FTNTFGTviruscat=Virus FTNTFGTdtype=av-engine FTNTFGTref=http://test.com/ve?vn\\=sdkdksdkds FTNTFGTvirusid=8032867 FTNTFGTprofile=default suser=user1 duser=user1 FTNTFGTrecipient=\\\\\"testuser@example.com\\\\\" FTNTFGTanalyticscksum=383b017352d7602c7603f5d36a9c3beb23df2f183116e0cc3d81e158e978ee7d FTNTFGTanalyticssubmit=false FTNTFGTcrscore=50 FTNTFGTcraction=2 FTNTFGTcrlevel=critical",
     "event": {
       "action": "blocked",
       "category": "utm",
@@ -28,11 +28,11 @@
       "type": "virus"
     },
     "destination": {
-      "address": "3.4.5.6",
+      "address": "203.0.113.6",
       "geo": {
         "country_name": "France"
       },
-      "ip": "3.4.5.6",
+      "ip": "203.0.113.6",
       "port": 143,
       "user": {
         "name": "user1"
@@ -84,8 +84,8 @@
     },
     "related": {
       "ip": [
-        "1.2.3.4",
-        "3.4.5.6"
+        "198.51.100.4",
+        "203.0.113.6"
       ],
       "user": [
         "user1"
@@ -95,8 +95,8 @@
       "ruleset": "policy"
     },
     "source": {
-      "address": "1.2.3.4",
-      "ip": "1.2.3.4",
+      "address": "198.51.100.4",
+      "ip": "198.51.100.4",
       "port": 54364,
       "user": {
         "name": "user1"

--- a/Fortinet/fortigate/tests/application.CEF.json
+++ b/Fortinet/fortigate/tests/application.CEF.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|28704|utm:app-ctrl app-ctrl-all pass|2|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=1059028704 cat=utm:app-ctrl FTNTFGTsubtype=app-ctrl FTNTFGTeventtype=app-ctrl-all FTNTFGTlevel=information FTNTFGTvd=vdom1 FTNTFGTeventtime=1545949688 FTNTFGTappid=34050 src=10.1.100.11 dst=192.0.2.1 spt=56826 dpt=80 deviceInboundInterface=port12 FTNTFGTsrcintfrole=undefined deviceOutboundInterface=port11 FTNTFGTdstintfrole=undefined proto=6 app=HTTP deviceDirection=1 FTNTFGTpolicyid=1 externalId=12567 FTNTFGTapplist=g-default FTNTFGTappcat=Web.Client FTNTFGTapp=HTTP.BROWSER_Firefox act=pass dhost=example.com FTNTFGTincidentserialno=1702350499 request=/success.txt msg=Web.Client: HTTP.BROWSER_Firefox, FTNTFGTapprisk=elevated suser=example.com\\\\alice"
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|28704|utm:app-ctrl app-ctrl-all pass|2|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=1059028704 cat=utm:app-ctrl FTNTFGTsubtype=app-ctrl FTNTFGTeventtype=app-ctrl-all FTNTFGTlevel=information FTNTFGTvd=vdom1 FTNTFGTeventtime=1545949688 FTNTFGTappid=34050 src=198.51.100.11 dst=192.0.2.1 spt=56826 dpt=80 deviceInboundInterface=port12 FTNTFGTsrcintfrole=undefined deviceOutboundInterface=port11 FTNTFGTdstintfrole=undefined proto=6 app=HTTP deviceDirection=1 FTNTFGTpolicyid=1 externalId=12567 FTNTFGTapplist=g-default FTNTFGTappcat=Web.Client FTNTFGTapp=HTTP.BROWSER_Firefox act=pass dhost=example.com FTNTFGTincidentserialno=1702350499 request=/success.txt msg=Web.Client: HTTP.BROWSER_Firefox, FTNTFGTapprisk=elevated suser=example.com\\\\alice"
   },
   "expected": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|28704|utm:app-ctrl app-ctrl-all pass|2|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=1059028704 cat=utm:app-ctrl FTNTFGTsubtype=app-ctrl FTNTFGTeventtype=app-ctrl-all FTNTFGTlevel=information FTNTFGTvd=vdom1 FTNTFGTeventtime=1545949688 FTNTFGTappid=34050 src=10.1.100.11 dst=192.0.2.1 spt=56826 dpt=80 deviceInboundInterface=port12 FTNTFGTsrcintfrole=undefined deviceOutboundInterface=port11 FTNTFGTdstintfrole=undefined proto=6 app=HTTP deviceDirection=1 FTNTFGTpolicyid=1 externalId=12567 FTNTFGTapplist=g-default FTNTFGTappcat=Web.Client FTNTFGTapp=HTTP.BROWSER_Firefox act=pass dhost=example.com FTNTFGTincidentserialno=1702350499 request=/success.txt msg=Web.Client: HTTP.BROWSER_Firefox, FTNTFGTapprisk=elevated suser=example.com\\\\alice",
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|28704|utm:app-ctrl app-ctrl-all pass|2|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=1059028704 cat=utm:app-ctrl FTNTFGTsubtype=app-ctrl FTNTFGTeventtype=app-ctrl-all FTNTFGTlevel=information FTNTFGTvd=vdom1 FTNTFGTeventtime=1545949688 FTNTFGTappid=34050 src=198.51.100.11 dst=192.0.2.1 spt=56826 dpt=80 deviceInboundInterface=port12 FTNTFGTsrcintfrole=undefined deviceOutboundInterface=port11 FTNTFGTdstintfrole=undefined proto=6 app=HTTP deviceDirection=1 FTNTFGTpolicyid=1 externalId=12567 FTNTFGTapplist=g-default FTNTFGTappcat=Web.Client FTNTFGTapp=HTTP.BROWSER_Firefox act=pass dhost=example.com FTNTFGTincidentserialno=1702350499 request=/success.txt msg=Web.Client: HTTP.BROWSER_Firefox, FTNTFGTapprisk=elevated suser=example.com\\\\alice",
     "event": {
       "action": "pass",
       "category": "utm",
@@ -64,8 +64,8 @@
         "example.com"
       ],
       "ip": [
-        "10.1.100.11",
-        "192.0.2.1"
+        "192.0.2.1",
+        "198.51.100.11"
       ],
       "user": [
         "alice"
@@ -77,8 +77,8 @@
       "ruleset": "g-default"
     },
     "source": {
-      "address": "10.1.100.11",
-      "ip": "10.1.100.11",
+      "address": "198.51.100.11",
+      "ip": "198.51.100.11",
       "port": 56826,
       "user": {
         "domain": "example.com",

--- a/Fortinet/fortigate/tests/application.CEF.json
+++ b/Fortinet/fortigate/tests/application.CEF.json
@@ -38,9 +38,9 @@
       "level": "information"
     },
     "network": {
-      "application": "HTTP",
+      "application": "HTTP.BROWSER_Firefox",
       "direction": "outbound",
-      "protocol": "http",
+      "protocol": "http.browser_firefox",
       "transport": "tcp"
     },
     "observer": {

--- a/Fortinet/fortigate/tests/attack_client_side.json
+++ b/Fortinet/fortigate/tests/attack_client_side.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "date=2018-12-29 time=15:30:25 logid=\"0419016384\" type=\"utm\" subtype=\"ips\" eventtype=\"signature\" level=\"alert\" vd=\"vdom1\" eventtime=1540852225 severity=\"info\" srcip=1.2.3.4 srccountry=\"Reserved\" dstip=example.com srcintf=\"dmz\" srcintfrole=\"lan\" dstintf=\"wan1\" dstintfrole=\"wan\" sessionid=4205 action=\"reset\" proto=6 service=\"HTTP\" policyid=1 attack=\"Virus.File\" srcport=53330 dstport=80 hostname=\"example.com\" url=\"/cgi-bin/upload.py?https://example.com/\" direction=\"outgoing\" attackid=29844 profile=\"ips-test\" ref=\"http://www.fortinet.com/ids/VID29844\" incidentserialno=2111356281 msg=\"file_transfer: Virus.File,\""
+    "message": "date=2018-12-29 time=15:30:25 logid=\"0419016384\" type=\"utm\" subtype=\"ips\" eventtype=\"signature\" level=\"alert\" vd=\"vdom1\" eventtime=1540852225 severity=\"info\" srcip=198.51.100.4 srccountry=\"Reserved\" dstip=example.com srcintf=\"dmz\" srcintfrole=\"lan\" dstintf=\"wan1\" dstintfrole=\"wan\" sessionid=4205 action=\"reset\" proto=6 service=\"HTTP\" policyid=1 attack=\"Virus.File\" srcport=53330 dstport=80 hostname=\"example.com\" url=\"/cgi-bin/upload.py?https://example.com/\" direction=\"outgoing\" attackid=29844 profile=\"ips-test\" ref=\"http://www.fortinet.com/ids/VID29844\" incidentserialno=2111356281 msg=\"file_transfer: Virus.File,\""
   },
   "expected": {
-    "message": "date=2018-12-29 time=15:30:25 logid=\"0419016384\" type=\"utm\" subtype=\"ips\" eventtype=\"signature\" level=\"alert\" vd=\"vdom1\" eventtime=1540852225 severity=\"info\" srcip=1.2.3.4 srccountry=\"Reserved\" dstip=example.com srcintf=\"dmz\" srcintfrole=\"lan\" dstintf=\"wan1\" dstintfrole=\"wan\" sessionid=4205 action=\"reset\" proto=6 service=\"HTTP\" policyid=1 attack=\"Virus.File\" srcport=53330 dstport=80 hostname=\"example.com\" url=\"/cgi-bin/upload.py?https://example.com/\" direction=\"outgoing\" attackid=29844 profile=\"ips-test\" ref=\"http://www.fortinet.com/ids/VID29844\" incidentserialno=2111356281 msg=\"file_transfer: Virus.File,\"",
+    "message": "date=2018-12-29 time=15:30:25 logid=\"0419016384\" type=\"utm\" subtype=\"ips\" eventtype=\"signature\" level=\"alert\" vd=\"vdom1\" eventtime=1540852225 severity=\"info\" srcip=198.51.100.4 srccountry=\"Reserved\" dstip=example.com srcintf=\"dmz\" srcintfrole=\"lan\" dstintf=\"wan1\" dstintfrole=\"wan\" sessionid=4205 action=\"reset\" proto=6 service=\"HTTP\" policyid=1 attack=\"Virus.File\" srcport=53330 dstport=80 hostname=\"example.com\" url=\"/cgi-bin/upload.py?https://example.com/\" direction=\"outgoing\" attackid=29844 profile=\"ips-test\" ref=\"http://www.fortinet.com/ids/VID29844\" incidentserialno=2111356281 msg=\"file_transfer: Virus.File,\"",
     "event": {
       "action": "reset",
       "category": "utm",
@@ -67,12 +67,12 @@
         "example.com"
       ],
       "ip": [
-        "1.2.3.4"
+        "198.51.100.4"
       ]
     },
     "source": {
-      "address": "1.2.3.4",
-      "ip": "1.2.3.4",
+      "address": "198.51.100.4",
+      "ip": "198.51.100.4",
       "port": 53330
     },
     "url": {

--- a/Fortinet/fortigate/tests/attack_server_side.json
+++ b/Fortinet/fortigate/tests/attack_server_side.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "date=2018-12-29 time=14:50:47 logid=\"0419016384\" type=\"utm\" subtype=\"ips\" eventtype=\"signature\" level=\"alert\" vd=\"vdom1\" eventtime=1540849847 severity=\"info\" srcip=1.2.3.4 srccountry=\"Reserved\" dstip=example.com srcintf=\"dmz\" srcintfrole=\"lan\" dstintf=\"wan1\" dstintfrole=\"wan\" sessionid=2979 action=\"reset\" proto=6 service=\"HTTP\" policyid=1 attack=\"Virus.File\" srcport=46552 dstport=80 hostname=\"example.com\" url=\"/virus/example.com\" direction=\"incoming\" attackid=29844 profile=\"ips-test\" ref=\"http://www.fortinet.com/ids/VID29844\" incidentserialno=122164746 msg=\"file_transfer: Virus.File,\""
+    "message": "date=2018-12-29 time=14:50:47 logid=\"0419016384\" type=\"utm\" subtype=\"ips\" eventtype=\"signature\" level=\"alert\" vd=\"vdom1\" eventtime=1540849847 severity=\"info\" srcip=198.51.100.4 srccountry=\"Reserved\" dstip=example.com srcintf=\"dmz\" srcintfrole=\"lan\" dstintf=\"wan1\" dstintfrole=\"wan\" sessionid=2979 action=\"reset\" proto=6 service=\"HTTP\" policyid=1 attack=\"Virus.File\" srcport=46552 dstport=80 hostname=\"example.com\" url=\"/virus/example.com\" direction=\"incoming\" attackid=29844 profile=\"ips-test\" ref=\"http://www.fortinet.com/ids/VID29844\" incidentserialno=122164746 msg=\"file_transfer: Virus.File,\""
   },
   "expected": {
-    "message": "date=2018-12-29 time=14:50:47 logid=\"0419016384\" type=\"utm\" subtype=\"ips\" eventtype=\"signature\" level=\"alert\" vd=\"vdom1\" eventtime=1540849847 severity=\"info\" srcip=1.2.3.4 srccountry=\"Reserved\" dstip=example.com srcintf=\"dmz\" srcintfrole=\"lan\" dstintf=\"wan1\" dstintfrole=\"wan\" sessionid=2979 action=\"reset\" proto=6 service=\"HTTP\" policyid=1 attack=\"Virus.File\" srcport=46552 dstport=80 hostname=\"example.com\" url=\"/virus/example.com\" direction=\"incoming\" attackid=29844 profile=\"ips-test\" ref=\"http://www.fortinet.com/ids/VID29844\" incidentserialno=122164746 msg=\"file_transfer: Virus.File,\"",
+    "message": "date=2018-12-29 time=14:50:47 logid=\"0419016384\" type=\"utm\" subtype=\"ips\" eventtype=\"signature\" level=\"alert\" vd=\"vdom1\" eventtime=1540849847 severity=\"info\" srcip=198.51.100.4 srccountry=\"Reserved\" dstip=example.com srcintf=\"dmz\" srcintfrole=\"lan\" dstintf=\"wan1\" dstintfrole=\"wan\" sessionid=2979 action=\"reset\" proto=6 service=\"HTTP\" policyid=1 attack=\"Virus.File\" srcport=46552 dstport=80 hostname=\"example.com\" url=\"/virus/example.com\" direction=\"incoming\" attackid=29844 profile=\"ips-test\" ref=\"http://www.fortinet.com/ids/VID29844\" incidentserialno=122164746 msg=\"file_transfer: Virus.File,\"",
     "event": {
       "action": "reset",
       "category": "utm",
@@ -67,12 +67,12 @@
         "example.com"
       ],
       "ip": [
-        "1.2.3.4"
+        "198.51.100.4"
       ]
     },
     "source": {
-      "address": "1.2.3.4",
-      "ip": "1.2.3.4",
+      "address": "198.51.100.4",
+      "ip": "198.51.100.4",
       "port": 46552
     },
     "url": {

--- a/Fortinet/fortigate/tests/dhcp_ack.json
+++ b/Fortinet/fortigate/tests/dhcp_ack.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "time=15:05:54 devname=\"INFRA1\" devid=\"DEVICE\" eventtime=1752152754192314929 tz=\"+0200\" logid=\"0100000001\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"INFRA\" logdesc=\"DHCP Ack log\" interface=\"VLAN1\" dhcp_msg=\"Ack\" mac=\"AA:BB:CC:DD:EE:FF\" ip=1.2.3.4 lease=432000 hostname=\"HOSTNAME\" msg=\"DHCP server sends a DHCPACK\""
+    "message": "time=15:05:54 devname=\"INFRA1\" devid=\"DEVICE\" eventtime=1752152754192314929 tz=\"+0200\" logid=\"0100000001\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"INFRA\" logdesc=\"DHCP Ack log\" interface=\"VLAN1\" dhcp_msg=\"Ack\" mac=\"AA:BB:CC:DD:EE:FF\" ip=198.51.100.4 lease=432000 hostname=\"HOSTNAME\" msg=\"DHCP server sends a DHCPACK\""
   },
   "expected": {
-    "message": "time=15:05:54 devname=\"INFRA1\" devid=\"DEVICE\" eventtime=1752152754192314929 tz=\"+0200\" logid=\"0100000001\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"INFRA\" logdesc=\"DHCP Ack log\" interface=\"VLAN1\" dhcp_msg=\"Ack\" mac=\"AA:BB:CC:DD:EE:FF\" ip=1.2.3.4 lease=432000 hostname=\"HOSTNAME\" msg=\"DHCP server sends a DHCPACK\"",
+    "message": "time=15:05:54 devname=\"INFRA1\" devid=\"DEVICE\" eventtime=1752152754192314929 tz=\"+0200\" logid=\"0100000001\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"INFRA\" logdesc=\"DHCP Ack log\" interface=\"VLAN1\" dhcp_msg=\"Ack\" mac=\"AA:BB:CC:DD:EE:FF\" ip=198.51.100.4 lease=432000 hostname=\"HOSTNAME\" msg=\"DHCP server sends a DHCPACK\"",
     "event": {
       "category": "event",
       "code": "0100000001",
@@ -44,12 +44,12 @@
         "INFRA1"
       ],
       "ip": [
-        "1.2.3.4"
+        "198.51.100.4"
       ]
     },
     "source": {
-      "address": "1.2.3.4",
-      "ip": "1.2.3.4",
+      "address": "198.51.100.4",
+      "ip": "198.51.100.4",
       "mac": "AA:BB:CC:DD:EE:FF"
     }
   }

--- a/Fortinet/fortigate/tests/dns.CSV.json
+++ b/Fortinet/fortigate/tests/dns.CSV.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "date=2018-12-27,time=14:45:26,logid=\"1501054802\",type=\"dns\",subtype=\"dns-response\",level=\"notice\",vd=\"vdom1\",eventtime=1545950726,policyid=1,sessionid=13355,user=\"bob\",srcip=1.1.1.1,srcport=54621,srcintf=\"port12\",srcintfrole=\"lan\",dstip=192.0.2.1,dstport=53,dstintf=\"port11\",dstintfrole=\"wan\",proto=17,profile=\"default\",srcmac=\"02:00:00:00:00:00\",xid=5137,qname=\"example.com\",qtype=\"A\",qtypeval=1,qclass=\"IN\",ipaddr=\"104.80.89.26, 104.80.89.24\",msg=\"Domain is monitored\",action=\"pass\",cat=52,catdesc=\"Information Technology\""
+    "message": "date=2018-12-27,time=14:45:26,logid=\"1501054802\",type=\"dns\",subtype=\"dns-response\",level=\"notice\",vd=\"vdom1\",eventtime=1545950726,policyid=1,sessionid=13355,user=\"bob\",srcip=192.0.2.101,srcport=54621,srcintf=\"port12\",srcintfrole=\"lan\",dstip=192.0.2.1,dstport=53,dstintf=\"port11\",dstintfrole=\"wan\",proto=17,profile=\"default\",srcmac=\"02:00:00:00:00:00\",xid=5137,qname=\"example.com\",qtype=\"A\",qtypeval=1,qclass=\"IN\",ipaddr=\"198.51.100.26, 198.51.100.24\",msg=\"Domain is monitored\",action=\"pass\",cat=52,catdesc=\"Information Technology\""
   },
   "expected": {
-    "message": "date=2018-12-27,time=14:45:26,logid=\"1501054802\",type=\"dns\",subtype=\"dns-response\",level=\"notice\",vd=\"vdom1\",eventtime=1545950726,policyid=1,sessionid=13355,user=\"bob\",srcip=1.1.1.1,srcport=54621,srcintf=\"port12\",srcintfrole=\"lan\",dstip=192.0.2.1,dstport=53,dstintf=\"port11\",dstintfrole=\"wan\",proto=17,profile=\"default\",srcmac=\"02:00:00:00:00:00\",xid=5137,qname=\"example.com\",qtype=\"A\",qtypeval=1,qclass=\"IN\",ipaddr=\"104.80.89.26, 104.80.89.24\",msg=\"Domain is monitored\",action=\"pass\",cat=52,catdesc=\"Information Technology\"",
+    "message": "date=2018-12-27,time=14:45:26,logid=\"1501054802\",type=\"dns\",subtype=\"dns-response\",level=\"notice\",vd=\"vdom1\",eventtime=1545950726,policyid=1,sessionid=13355,user=\"bob\",srcip=192.0.2.101,srcport=54621,srcintf=\"port12\",srcintfrole=\"lan\",dstip=192.0.2.1,dstport=53,dstintf=\"port11\",dstintfrole=\"wan\",proto=17,profile=\"default\",srcmac=\"02:00:00:00:00:00\",xid=5137,qname=\"example.com\",qtype=\"A\",qtypeval=1,qclass=\"IN\",ipaddr=\"198.51.100.26, 198.51.100.24\",msg=\"Domain is monitored\",action=\"pass\",cat=52,catdesc=\"Information Technology\"",
     "event": {
       "action": "pass",
       "category": "dns",
@@ -72,8 +72,8 @@
         "example.com"
       ],
       "ip": [
-        "1.1.1.1",
-        "192.0.2.1"
+        "192.0.2.1",
+        "192.0.2.101"
       ],
       "user": [
         "bob"
@@ -83,8 +83,8 @@
       "category": "Information Technology"
     },
     "source": {
-      "address": "1.1.1.1",
-      "ip": "1.1.1.1",
+      "address": "192.0.2.101",
+      "ip": "192.0.2.101",
       "mac": "02:00:00:00:00:00",
       "port": 54621,
       "user": {

--- a/Fortinet/fortigate/tests/email-spamfilter.CEF.json
+++ b/Fortinet/fortigate/tests/email-spamfilter.CEF.json
@@ -25,7 +25,7 @@
       "ip": "172.18.62.158",
       "port": 25,
       "user": {
-        "name": "bob"
+        "name": "test1@server88.qa.fortinet.com"
       }
     },
     "fortinet": {
@@ -66,7 +66,7 @@
         "172.18.62.158"
       ],
       "user": [
-        "bob",
+        "test1@server88.qa.fortinet.com",
         "user1"
       ]
     },

--- a/Fortinet/fortigate/tests/email-spamfilter.CEF.json
+++ b/Fortinet/fortigate/tests/email-spamfilter.CEF.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|20503|utm:emailfilter smtp log-only|2|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0508020503 cat=utm:emailfilter FTNTFGTsubtype=emailfilter FTNTFGTeventtype=smtp FTNTFGTlevel=information FTNTFGTvd=vdom1 FTNTFGTeventtime=1545939418 FTNTFGTpolicyid=1 externalId=1135 duser=bob src=10.1.100.11 spt=35969 deviceInboundInterface=port12 FTNTFGTsrcintfrole=undefined dst=172.18.62.158 dpt=25 deviceOutboundInterface=port11 FTNTFGTdstintfrole=undefined proto=6 app=SMTP FTNTFGTprofile=test-spam act=log-only suser=user1 duser=test1@server88.qa.fortinet.com FTNTFGTsender=user1 FTNTFGTrecipient=test1@server88.qa.fortinet.com deviceDirection=1 msg=general email log FTNTFGTsubject=hello_world2 FTNTFGTsize=216 FTNTFGTattachment=no"
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|20503|utm:emailfilter smtp log-only|2|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0508020503 cat=utm:emailfilter FTNTFGTsubtype=emailfilter FTNTFGTeventtype=smtp FTNTFGTlevel=information FTNTFGTvd=vdom1 FTNTFGTeventtime=1545939418 FTNTFGTpolicyid=1 externalId=1135 duser=bob src=198.51.100.11 spt=35969 deviceInboundInterface=port12 FTNTFGTsrcintfrole=undefined dst=203.0.113.158 dpt=25 deviceOutboundInterface=port11 FTNTFGTdstintfrole=undefined proto=6 app=SMTP FTNTFGTprofile=test-spam act=log-only suser=user1 duser=test1@server88.qa.example.com FTNTFGTsender=user1 FTNTFGTrecipient=test1@server88.qa.example.com deviceDirection=1 msg=general email log FTNTFGTsubject=hello_world2 FTNTFGTsize=216 FTNTFGTattachment=no"
   },
   "expected": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|20503|utm:emailfilter smtp log-only|2|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0508020503 cat=utm:emailfilter FTNTFGTsubtype=emailfilter FTNTFGTeventtype=smtp FTNTFGTlevel=information FTNTFGTvd=vdom1 FTNTFGTeventtime=1545939418 FTNTFGTpolicyid=1 externalId=1135 duser=bob src=10.1.100.11 spt=35969 deviceInboundInterface=port12 FTNTFGTsrcintfrole=undefined dst=172.18.62.158 dpt=25 deviceOutboundInterface=port11 FTNTFGTdstintfrole=undefined proto=6 app=SMTP FTNTFGTprofile=test-spam act=log-only suser=user1 duser=test1@server88.qa.fortinet.com FTNTFGTsender=user1 FTNTFGTrecipient=test1@server88.qa.fortinet.com deviceDirection=1 msg=general email log FTNTFGTsubject=hello_world2 FTNTFGTsize=216 FTNTFGTattachment=no",
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|20503|utm:emailfilter smtp log-only|2|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0508020503 cat=utm:emailfilter FTNTFGTsubtype=emailfilter FTNTFGTeventtype=smtp FTNTFGTlevel=information FTNTFGTvd=vdom1 FTNTFGTeventtime=1545939418 FTNTFGTpolicyid=1 externalId=1135 duser=bob src=198.51.100.11 spt=35969 deviceInboundInterface=port12 FTNTFGTsrcintfrole=undefined dst=203.0.113.158 dpt=25 deviceOutboundInterface=port11 FTNTFGTdstintfrole=undefined proto=6 app=SMTP FTNTFGTprofile=test-spam act=log-only suser=user1 duser=test1@server88.qa.example.com FTNTFGTsender=user1 FTNTFGTrecipient=test1@server88.qa.example.com deviceDirection=1 msg=general email log FTNTFGTsubject=hello_world2 FTNTFGTsize=216 FTNTFGTattachment=no",
     "event": {
       "action": "log-only",
       "category": "utm",
@@ -21,11 +21,11 @@
       "type": "emailfilter"
     },
     "destination": {
-      "address": "172.18.62.158",
-      "ip": "172.18.62.158",
+      "address": "203.0.113.158",
+      "ip": "203.0.113.158",
       "port": 25,
       "user": {
-        "name": "test1@server88.qa.fortinet.com"
+        "name": "test1@server88.qa.example.com"
       }
     },
     "fortinet": {
@@ -62,17 +62,17 @@
     },
     "related": {
       "ip": [
-        "10.1.100.11",
-        "172.18.62.158"
+        "198.51.100.11",
+        "203.0.113.158"
       ],
       "user": [
-        "test1@server88.qa.fortinet.com",
+        "test1@server88.qa.example.com",
         "user1"
       ]
     },
     "source": {
-      "address": "10.1.100.11",
-      "ip": "10.1.100.11",
+      "address": "198.51.100.11",
+      "ip": "198.51.100.11",
       "port": 35969,
       "user": {
         "name": "user1"

--- a/Fortinet/fortigate/tests/event_add_admin.json
+++ b/Fortinet/fortigate/tests/event_add_admin.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "message": "type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Object attribute configured\" user=\"admin\" ui=\"jsconsole(127.0.0.1)\" action=\"Add\" cfgtid=1234567890 cfgpath=\"system.admin\" cfgobj=\"vOcep\" cfgattr=\"password[*]accprofile[super_admin]vdom[root]\" msg=\"Add system.admin vOcep\"",
+    "message": "type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Object attribute configured\" user=\"admin\" ui=\"jsconsole(198.51.100.127)\" action=\"Add\" cfgtid=1234567890 cfgpath=\"system.admin\" cfgobj=\"vOcep\" cfgattr=\"password[*]accprofile[super_admin]vdom[root]\" msg=\"Add system.admin vOcep\"",
     "sekoiaio": {
       "intake": {
         "dialect": "Fortinet FortiGate",
@@ -9,7 +9,7 @@
     }
   },
   "expected": {
-    "message": "type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Object attribute configured\" user=\"admin\" ui=\"jsconsole(127.0.0.1)\" action=\"Add\" cfgtid=1234567890 cfgpath=\"system.admin\" cfgobj=\"vOcep\" cfgattr=\"password[*]accprofile[super_admin]vdom[root]\" msg=\"Add system.admin vOcep\"",
+    "message": "type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Object attribute configured\" user=\"admin\" ui=\"jsconsole(198.51.100.127)\" action=\"Add\" cfgtid=1234567890 cfgpath=\"system.admin\" cfgobj=\"vOcep\" cfgattr=\"password[*]accprofile[super_admin]vdom[root]\" msg=\"Add system.admin vOcep\"",
     "event": {
       "action": "Add",
       "category": "event",
@@ -40,15 +40,15 @@
     },
     "related": {
       "ip": [
-        "127.0.0.1"
+        "198.51.100.127"
       ],
       "user": [
         "admin"
       ]
     },
     "source": {
-      "address": "127.0.0.1",
-      "ip": "127.0.0.1",
+      "address": "198.51.100.127",
+      "ip": "198.51.100.127",
       "user": {
         "name": "admin"
       }

--- a/Fortinet/fortigate/tests/event_admin_login.json
+++ b/Fortinet/fortigate/tests/event_admin_login.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "message": "type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Admin login successful\" sn=\"1234567890\" user=\"admin\" ui=\"jsconsole\" method=\"jsconsole\" srcip=1.1.1.1 dstip=1.1.1.1 action=\"login\" status=\"success\" reason=\"none\" profile=\"super_admin\" msg=\"Administrator admin logged in successfully from jsconsole\"",
+    "message": "type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Admin login successful\" sn=\"1234567890\" user=\"admin\" ui=\"jsconsole\" method=\"jsconsole\" srcip=192.0.2.101 dstip=192.0.2.101 action=\"login\" status=\"success\" reason=\"none\" profile=\"super_admin\" msg=\"Administrator admin logged in successfully from jsconsole\"",
     "sekoiaio": {
       "intake": {
         "dialect": "Fortinet FortiGate",
@@ -9,7 +9,7 @@
     }
   },
   "expected": {
-    "message": "type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Admin login successful\" sn=\"1234567890\" user=\"admin\" ui=\"jsconsole\" method=\"jsconsole\" srcip=1.1.1.1 dstip=1.1.1.1 action=\"login\" status=\"success\" reason=\"none\" profile=\"super_admin\" msg=\"Administrator admin logged in successfully from jsconsole\"",
+    "message": "type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Admin login successful\" sn=\"1234567890\" user=\"admin\" ui=\"jsconsole\" method=\"jsconsole\" srcip=192.0.2.101 dstip=192.0.2.101 action=\"login\" status=\"success\" reason=\"none\" profile=\"super_admin\" msg=\"Administrator admin logged in successfully from jsconsole\"",
     "event": {
       "action": "login",
       "category": "event",
@@ -26,8 +26,8 @@
       "type": "system"
     },
     "destination": {
-      "address": "1.1.1.1",
-      "ip": "1.1.1.1"
+      "address": "192.0.2.101",
+      "ip": "192.0.2.101"
     },
     "fortinet": {
       "fortigate": {
@@ -46,15 +46,15 @@
     },
     "related": {
       "ip": [
-        "1.1.1.1"
+        "192.0.2.101"
       ],
       "user": [
         "admin"
       ]
     },
     "source": {
-      "address": "1.1.1.1",
-      "ip": "1.1.1.1",
+      "address": "192.0.2.101",
+      "ip": "192.0.2.101",
       "user": {
         "name": "admin"
       }

--- a/Fortinet/fortigate/tests/event_incident_detection.STANDARD.json
+++ b/Fortinet/fortigate/tests/event_incident_detection.STANDARD.json
@@ -42,7 +42,6 @@
         "log_version": "25",
         "loghost": "collector01",
         "operation": "Close_Port",
-        "password": "REDACTED",
         "tag": {
           "id": "0",
           "key": "198.51.100.42:61230:203.0.113.86:80:1158648005tag t231899233-9216901844840843855"

--- a/Fortinet/fortigate/tests/event_log_system_subtype.CEF.json
+++ b/Fortinet/fortigate/tests/event_log_system_subtype.CEF.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|32002|event:system login failed|7|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0100032002 cat=event:system FTNTFGTsubtype=system FTNTFGTlevel=alert FTNTFGTvd=vdom1 FTNTFGTeventtime=1545938140 FTNTFGTlogdesc=Admin login failed FTNTFGTsn=0 duser=user1 sproc=https(172.16.200.254) FTNTFGTmethod=https src=172.16.200.254 dst=172.16.200.1 act=login outcome=failed reason=name_invalid msg=Administrator user1 login failed from https(172.16.200.254) because of invalid user name"
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|32002|event:system login failed|7|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0100032002 cat=event:system FTNTFGTsubtype=system FTNTFGTlevel=alert FTNTFGTvd=vdom1 FTNTFGTeventtime=1545938140 FTNTFGTlogdesc=Admin login failed FTNTFGTsn=0 duser=user1 sproc=https(203.0.113.254) FTNTFGTmethod=https src=203.0.113.254 dst=203.0.113.1 act=login outcome=failed reason=name_invalid msg=Administrator user1 login failed from https(203.0.113.254) because of invalid user name"
   },
   "expected": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|32002|event:system login failed|7|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0100032002 cat=event:system FTNTFGTsubtype=system FTNTFGTlevel=alert FTNTFGTvd=vdom1 FTNTFGTeventtime=1545938140 FTNTFGTlogdesc=Admin login failed FTNTFGTsn=0 duser=user1 sproc=https(172.16.200.254) FTNTFGTmethod=https src=172.16.200.254 dst=172.16.200.1 act=login outcome=failed reason=name_invalid msg=Administrator user1 login failed from https(172.16.200.254) because of invalid user name",
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|32002|event:system login failed|7|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0100032002 cat=event:system FTNTFGTsubtype=system FTNTFGTlevel=alert FTNTFGTvd=vdom1 FTNTFGTeventtime=1545938140 FTNTFGTlogdesc=Admin login failed FTNTFGTsn=0 duser=user1 sproc=https(203.0.113.254) FTNTFGTmethod=https src=203.0.113.254 dst=203.0.113.1 act=login outcome=failed reason=name_invalid msg=Administrator user1 login failed from https(203.0.113.254) because of invalid user name",
     "event": {
       "action": "login",
       "category": "event",
@@ -17,13 +17,13 @@
     "action": {
       "name": "login",
       "outcome": "failure",
-      "outcome_reason": "Administrator user1 login failed from https(172.16.200.254) because of invalid user name",
+      "outcome_reason": "Administrator user1 login failed from https(203.0.113.254) because of invalid user name",
       "target": "network-traffic",
       "type": "system"
     },
     "destination": {
-      "address": "172.16.200.1",
-      "ip": "172.16.200.1",
+      "address": "203.0.113.1",
+      "ip": "203.0.113.1",
       "user": {
         "name": "user1"
       }
@@ -49,16 +49,16 @@
     },
     "related": {
       "ip": [
-        "172.16.200.1",
-        "172.16.200.254"
+        "203.0.113.1",
+        "203.0.113.254"
       ],
       "user": [
         "user1"
       ]
     },
     "source": {
-      "address": "172.16.200.254",
-      "ip": "172.16.200.254"
+      "address": "203.0.113.254",
+      "ip": "203.0.113.254"
     }
   }
 }

--- a/Fortinet/fortigate/tests/event_log_user_subtype.CEF.json
+++ b/Fortinet/fortigate/tests/event_log_user_subtype.CEF.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|43008|event:user authentication success|3|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0102043008 cat=event:user FTNTFGTsubtype=user FTNTFGTlevel=notice FTNTFGTvd=vdom1 FTNTFGTeventtime=1545938255 FTNTFGTlogdesc=Authentication success src=10.1.100.11 dst=172.16.200.55 FTNTFGTpolicyid=1 deviceInboundInterface=port12 duser=bob FTNTFGTgroup=N/A FTNTFGTauthproto=TELNET(10.1.100.11) act=authentication outcome=success reason=N/A msg=User bob succeeded in authentication"
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|43008|event:user authentication success|3|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0102043008 cat=event:user FTNTFGTsubtype=user FTNTFGTlevel=notice FTNTFGTvd=vdom1 FTNTFGTeventtime=1545938255 FTNTFGTlogdesc=Authentication success src=198.51.100.11 dst=203.0.113.55 FTNTFGTpolicyid=1 deviceInboundInterface=port12 duser=bob FTNTFGTgroup=N/A FTNTFGTauthproto=TELNET(198.51.100.11) act=authentication outcome=success reason=N/A msg=User bob succeeded in authentication"
   },
   "expected": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|43008|event:user authentication success|3|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0102043008 cat=event:user FTNTFGTsubtype=user FTNTFGTlevel=notice FTNTFGTvd=vdom1 FTNTFGTeventtime=1545938255 FTNTFGTlogdesc=Authentication success src=10.1.100.11 dst=172.16.200.55 FTNTFGTpolicyid=1 deviceInboundInterface=port12 duser=bob FTNTFGTgroup=N/A FTNTFGTauthproto=TELNET(10.1.100.11) act=authentication outcome=success reason=N/A msg=User bob succeeded in authentication",
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|43008|event:user authentication success|3|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0102043008 cat=event:user FTNTFGTsubtype=user FTNTFGTlevel=notice FTNTFGTvd=vdom1 FTNTFGTeventtime=1545938255 FTNTFGTlogdesc=Authentication success src=198.51.100.11 dst=203.0.113.55 FTNTFGTpolicyid=1 deviceInboundInterface=port12 duser=bob FTNTFGTgroup=N/A FTNTFGTauthproto=TELNET(198.51.100.11) act=authentication outcome=success reason=N/A msg=User bob succeeded in authentication",
     "event": {
       "action": "authentication",
       "category": "event",
@@ -21,8 +21,8 @@
       "type": "user"
     },
     "destination": {
-      "address": "172.16.200.55",
-      "ip": "172.16.200.55",
+      "address": "203.0.113.55",
+      "ip": "203.0.113.55",
       "user": {
         "name": "bob"
       }
@@ -50,16 +50,16 @@
     },
     "related": {
       "ip": [
-        "10.1.100.11",
-        "172.16.200.55"
+        "198.51.100.11",
+        "203.0.113.55"
       ],
       "user": [
         "bob"
       ]
     },
     "source": {
-      "address": "10.1.100.11",
-      "ip": "10.1.100.11"
+      "address": "198.51.100.11",
+      "ip": "198.51.100.11"
     }
   }
 }

--- a/Fortinet/fortigate/tests/forwadedfor.json
+++ b/Fortinet/fortigate/tests/forwadedfor.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "time=10:59:48 devname=\"FW-001\" devid=\"xxxxxxxxxx\" eventtime=1720429188081127405 tz=\"+0200\" logid=\"0000000\" type=\"utm\" subtype=\"webfilter\" eventtype=\"ftgd_allow\" level=\"notice\" vd=\"root\" policyid=00000 poluuid=\"xxxxxx-xxxx-xxxx-xxxxxx\" policytype=\"policy\" sessionid=111111111 srcip=192.0.2.1 srcport=1000 srccountry=\"France\" srcintf=\"aaaaaaaaa\" srcintfrole=\"wan\" srcuuid=\"xxxxxx-xxxx-xxxx-xxxxxxxxxxx\" dstip=10.0.0.1 dstport=80 dstcountry=\"Reserved\" dstintf=\"aaaaaaaa\" dstintfrole=\"lan\" dstuuid=\"xxxxxxx-xxxx-xxxx-xxxxxxxxxxxx\" proto=6 service=\"HTTP\" hostname=\"example.com\" forwardedfor=\"1.2.3.4\" profile=\"monitor-all\" action=\"passthrough\" reqtype=\"direct\" url=\"http://example.com/\" sentbyte=270 rcvdbyte=0 direction=\"outgoing\" msg=\"URL belongs to an allowed category in policy\" method=\"domain\" cat=51 catdesc=\"Government and Legal Organizations\""
+    "message": "time=10:59:48 devname=\"FW-001\" devid=\"xxxxxxxxxx\" eventtime=1720429188081127405 tz=\"+0200\" logid=\"0000000\" type=\"utm\" subtype=\"webfilter\" eventtype=\"ftgd_allow\" level=\"notice\" vd=\"root\" policyid=00000 poluuid=\"xxxxxx-xxxx-xxxx-xxxxxx\" policytype=\"policy\" sessionid=111111111 srcip=192.0.2.1 srcport=1000 srccountry=\"France\" srcintf=\"aaaaaaaaa\" srcintfrole=\"wan\" srcuuid=\"xxxxxx-xxxx-xxxx-xxxxxxxxxxx\" dstip=198.51.100.1 dstport=80 dstcountry=\"Reserved\" dstintf=\"aaaaaaaa\" dstintfrole=\"lan\" dstuuid=\"xxxxxxx-xxxx-xxxx-xxxxxxxxxxxx\" proto=6 service=\"HTTP\" hostname=\"example.com\" forwardedfor=\"198.51.100.4\" profile=\"monitor-all\" action=\"passthrough\" reqtype=\"direct\" url=\"http://example.com/\" sentbyte=270 rcvdbyte=0 direction=\"outgoing\" msg=\"URL belongs to an allowed category in policy\" method=\"domain\" cat=51 catdesc=\"Government and Legal Organizations\""
   },
   "expected": {
-    "message": "time=10:59:48 devname=\"FW-001\" devid=\"xxxxxxxxxx\" eventtime=1720429188081127405 tz=\"+0200\" logid=\"0000000\" type=\"utm\" subtype=\"webfilter\" eventtype=\"ftgd_allow\" level=\"notice\" vd=\"root\" policyid=00000 poluuid=\"xxxxxx-xxxx-xxxx-xxxxxx\" policytype=\"policy\" sessionid=111111111 srcip=192.0.2.1 srcport=1000 srccountry=\"France\" srcintf=\"aaaaaaaaa\" srcintfrole=\"wan\" srcuuid=\"xxxxxx-xxxx-xxxx-xxxxxxxxxxx\" dstip=10.0.0.1 dstport=80 dstcountry=\"Reserved\" dstintf=\"aaaaaaaa\" dstintfrole=\"lan\" dstuuid=\"xxxxxxx-xxxx-xxxx-xxxxxxxxxxxx\" proto=6 service=\"HTTP\" hostname=\"example.com\" forwardedfor=\"1.2.3.4\" profile=\"monitor-all\" action=\"passthrough\" reqtype=\"direct\" url=\"http://example.com/\" sentbyte=270 rcvdbyte=0 direction=\"outgoing\" msg=\"URL belongs to an allowed category in policy\" method=\"domain\" cat=51 catdesc=\"Government and Legal Organizations\"",
+    "message": "time=10:59:48 devname=\"FW-001\" devid=\"xxxxxxxxxx\" eventtime=1720429188081127405 tz=\"+0200\" logid=\"0000000\" type=\"utm\" subtype=\"webfilter\" eventtype=\"ftgd_allow\" level=\"notice\" vd=\"root\" policyid=00000 poluuid=\"xxxxxx-xxxx-xxxx-xxxxxx\" policytype=\"policy\" sessionid=111111111 srcip=192.0.2.1 srcport=1000 srccountry=\"France\" srcintf=\"aaaaaaaaa\" srcintfrole=\"wan\" srcuuid=\"xxxxxx-xxxx-xxxx-xxxxxxxxxxx\" dstip=198.51.100.1 dstport=80 dstcountry=\"Reserved\" dstintf=\"aaaaaaaa\" dstintfrole=\"lan\" dstuuid=\"xxxxxxx-xxxx-xxxx-xxxxxxxxxxxx\" proto=6 service=\"HTTP\" hostname=\"example.com\" forwardedfor=\"198.51.100.4\" profile=\"monitor-all\" action=\"passthrough\" reqtype=\"direct\" url=\"http://example.com/\" sentbyte=270 rcvdbyte=0 direction=\"outgoing\" msg=\"URL belongs to an allowed category in policy\" method=\"domain\" cat=51 catdesc=\"Government and Legal Organizations\"",
     "event": {
       "action": "passthrough",
       "category": "utm",
@@ -22,10 +22,10 @@
       "type": "webfilter"
     },
     "destination": {
-      "address": "10.0.0.1",
+      "address": "198.51.100.1",
       "bytes": 0,
       "domain": "example.com",
-      "ip": "10.0.0.1",
+      "ip": "198.51.100.1",
       "port": 80
     },
     "fortinet": {
@@ -49,7 +49,7 @@
     "network": {
       "bytes": 270,
       "direction": "outbound",
-      "forwarded_ip": "1.2.3.4",
+      "forwarded_ip": "198.51.100.4",
       "protocol": "http",
       "transport": "tcp"
     },
@@ -75,8 +75,8 @@
         "example.com"
       ],
       "ip": [
-        "10.0.0.1",
-        "192.0.2.1"
+        "192.0.2.1",
+        "198.51.100.1"
       ]
     },
     "rule": {

--- a/Fortinet/fortigate/tests/hostname.STANDARD.1.json
+++ b/Fortinet/fortigate/tests/hostname.STANDARD.1.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "timestamp=1746183115 devname=\"devName1\" devid=\"devId\" vd=\"root\" date=2025-05-02 time=10:51:55 eventtime=1746175915421843994 tz=\"+0200\" logid=\"1000000000\" type=\"utm\" subtype=\"app-ctrl\" eventtype=\"signature\" level=\"information\" appid=15893 srcip=1.2.3.4 srccountry=\"Spain\" dstip=3.4.5.6 dstcountry=\"Reserved\" srcport=39972 dstport=80 srcintf=\"port2\" srcintfrole=\"wan\" dstintf=\"port3\" dstintfrole=\"dmz\" proto=6 service=\"HTTP\" direction=\"outgoing\" policyid=120 poluuid=\"5187b416-87fa-51ec-c830-268b6371a3ac\" policytype=\"policy\" sessionid=11111111 applist=\"block-high-risk\" action=\"pass\" appcat=\"Web.Client\" app=\"HTTP.BROWSER\" hostname=\"example.com\" incidentserialno=10101 url=\"/test/version_test_v2.php\" httpmethod=\"GET\" msg=\"Web.Client: HTTP.BROWSER\" apprisk=\"medium\" forwardedfor=\"5.6.7.8,6.7.8.9\""
+    "message": "timestamp=1746183115 devname=\"devName1\" devid=\"devId\" vd=\"root\" date=2025-05-02 time=10:51:55 eventtime=1746175915421843994 tz=\"+0200\" logid=\"1000000000\" type=\"utm\" subtype=\"app-ctrl\" eventtype=\"signature\" level=\"information\" appid=15893 srcip=198.51.100.4 srccountry=\"Spain\" dstip=203.0.113.6 dstcountry=\"Reserved\" srcport=39972 dstport=80 srcintf=\"port2\" srcintfrole=\"wan\" dstintf=\"port3\" dstintfrole=\"dmz\" proto=6 service=\"HTTP\" direction=\"outgoing\" policyid=120 poluuid=\"5187b416-87fa-51ec-c830-268b6371a3ac\" policytype=\"policy\" sessionid=11111111 applist=\"block-high-risk\" action=\"pass\" appcat=\"Web.Client\" app=\"HTTP.BROWSER\" hostname=\"example.com\" incidentserialno=10101 url=\"/test/version_test_v2.php\" httpmethod=\"GET\" msg=\"Web.Client: HTTP.BROWSER\" apprisk=\"medium\" forwardedfor=\"203.0.113.8,203.0.113.69\""
   },
   "expected": {
-    "message": "timestamp=1746183115 devname=\"devName1\" devid=\"devId\" vd=\"root\" date=2025-05-02 time=10:51:55 eventtime=1746175915421843994 tz=\"+0200\" logid=\"1000000000\" type=\"utm\" subtype=\"app-ctrl\" eventtype=\"signature\" level=\"information\" appid=15893 srcip=1.2.3.4 srccountry=\"Spain\" dstip=3.4.5.6 dstcountry=\"Reserved\" srcport=39972 dstport=80 srcintf=\"port2\" srcintfrole=\"wan\" dstintf=\"port3\" dstintfrole=\"dmz\" proto=6 service=\"HTTP\" direction=\"outgoing\" policyid=120 poluuid=\"5187b416-87fa-51ec-c830-268b6371a3ac\" policytype=\"policy\" sessionid=11111111 applist=\"block-high-risk\" action=\"pass\" appcat=\"Web.Client\" app=\"HTTP.BROWSER\" hostname=\"example.com\" incidentserialno=10101 url=\"/test/version_test_v2.php\" httpmethod=\"GET\" msg=\"Web.Client: HTTP.BROWSER\" apprisk=\"medium\" forwardedfor=\"5.6.7.8,6.7.8.9\"",
+    "message": "timestamp=1746183115 devname=\"devName1\" devid=\"devId\" vd=\"root\" date=2025-05-02 time=10:51:55 eventtime=1746175915421843994 tz=\"+0200\" logid=\"1000000000\" type=\"utm\" subtype=\"app-ctrl\" eventtype=\"signature\" level=\"information\" appid=15893 srcip=198.51.100.4 srccountry=\"Spain\" dstip=203.0.113.6 dstcountry=\"Reserved\" srcport=39972 dstport=80 srcintf=\"port2\" srcintfrole=\"wan\" dstintf=\"port3\" dstintfrole=\"dmz\" proto=6 service=\"HTTP\" direction=\"outgoing\" policyid=120 poluuid=\"5187b416-87fa-51ec-c830-268b6371a3ac\" policytype=\"policy\" sessionid=11111111 applist=\"block-high-risk\" action=\"pass\" appcat=\"Web.Client\" app=\"HTTP.BROWSER\" hostname=\"example.com\" incidentserialno=10101 url=\"/test/version_test_v2.php\" httpmethod=\"GET\" msg=\"Web.Client: HTTP.BROWSER\" apprisk=\"medium\" forwardedfor=\"203.0.113.8,203.0.113.69\"",
     "event": {
       "action": "pass",
       "category": "utm",
@@ -22,9 +22,9 @@
       "type": "app-ctrl"
     },
     "destination": {
-      "address": "3.4.5.6",
+      "address": "203.0.113.6",
       "domain": "example.com",
-      "ip": "3.4.5.6",
+      "ip": "203.0.113.6",
       "port": 80
     },
     "file": {
@@ -57,8 +57,8 @@
       "application": "HTTP.BROWSER",
       "direction": "outbound",
       "forwarded_ip": [
-        "5.6.7.8",
-        "6.7.8.9"
+        "203.0.113.69",
+        "203.0.113.8"
       ],
       "protocol": "http",
       "transport": "tcp"
@@ -85,8 +85,8 @@
         "example.com"
       ],
       "ip": [
-        "1.2.3.4",
-        "3.4.5.6"
+        "198.51.100.4",
+        "203.0.113.6"
       ]
     },
     "rule": {
@@ -95,11 +95,11 @@
       "ruleset": "block-high-risk"
     },
     "source": {
-      "address": "1.2.3.4",
+      "address": "198.51.100.4",
       "geo": {
         "country_name": "Spain"
       },
-      "ip": "1.2.3.4",
+      "ip": "198.51.100.4",
       "port": 39972
     },
     "url": {

--- a/Fortinet/fortigate/tests/hostname.STANDARD.json
+++ b/Fortinet/fortigate/tests/hostname.STANDARD.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "time=11:09:50 devname=\"abc\" devid=\"1\" logid=\"1059028704\" type=\"utm\" subtype=\"app-ctrl\" eventtype=\"app-ctrl-all\" level=\"information\" vd=\"root\" eventtime=1579860590 appid=40568 srcip=1.1.1.1 dstip=192.0.2.1 srcport=33345 dstport=443 srcintf=\"test\" srcintfrole=\"undefined\" dstintf=\"port1\" dstintfrole=\"undefined\" proto=6 service=\"HTTPS\" direction=\"outgoing\" policyid=1 sessionid=1508480438 applist=\"default\" appcat=\"Web.Client\" app=\"HTTPS.BROWSER\" action=\"pass\" hostname=\"example.com\" incidentserialno=455926217 url=\"/\" msg=\"Web.Client: HTTPS.BROWSER,\" apprisk=\"medium\""
+    "message": "time=11:09:50 devname=\"abc\" devid=\"1\" logid=\"1059028704\" type=\"utm\" subtype=\"app-ctrl\" eventtype=\"app-ctrl-all\" level=\"information\" vd=\"root\" eventtime=1579860590 appid=40568 srcip=192.0.2.101 dstip=192.0.2.1 srcport=33345 dstport=443 srcintf=\"test\" srcintfrole=\"undefined\" dstintf=\"port1\" dstintfrole=\"undefined\" proto=6 service=\"HTTPS\" direction=\"outgoing\" policyid=1 sessionid=1508480438 applist=\"default\" appcat=\"Web.Client\" app=\"HTTPS.BROWSER\" action=\"pass\" hostname=\"example.com\" incidentserialno=455926217 url=\"/\" msg=\"Web.Client: HTTPS.BROWSER,\" apprisk=\"medium\""
   },
   "expected": {
-    "message": "time=11:09:50 devname=\"abc\" devid=\"1\" logid=\"1059028704\" type=\"utm\" subtype=\"app-ctrl\" eventtype=\"app-ctrl-all\" level=\"information\" vd=\"root\" eventtime=1579860590 appid=40568 srcip=1.1.1.1 dstip=192.0.2.1 srcport=33345 dstport=443 srcintf=\"test\" srcintfrole=\"undefined\" dstintf=\"port1\" dstintfrole=\"undefined\" proto=6 service=\"HTTPS\" direction=\"outgoing\" policyid=1 sessionid=1508480438 applist=\"default\" appcat=\"Web.Client\" app=\"HTTPS.BROWSER\" action=\"pass\" hostname=\"example.com\" incidentserialno=455926217 url=\"/\" msg=\"Web.Client: HTTPS.BROWSER,\" apprisk=\"medium\"",
+    "message": "time=11:09:50 devname=\"abc\" devid=\"1\" logid=\"1059028704\" type=\"utm\" subtype=\"app-ctrl\" eventtype=\"app-ctrl-all\" level=\"information\" vd=\"root\" eventtime=1579860590 appid=40568 srcip=192.0.2.101 dstip=192.0.2.1 srcport=33345 dstport=443 srcintf=\"test\" srcintfrole=\"undefined\" dstintf=\"port1\" dstintfrole=\"undefined\" proto=6 service=\"HTTPS\" direction=\"outgoing\" policyid=1 sessionid=1508480438 applist=\"default\" appcat=\"Web.Client\" app=\"HTTPS.BROWSER\" action=\"pass\" hostname=\"example.com\" incidentserialno=455926217 url=\"/\" msg=\"Web.Client: HTTPS.BROWSER,\" apprisk=\"medium\"",
     "event": {
       "action": "pass",
       "category": "utm",
@@ -68,8 +68,8 @@
         "example.com"
       ],
       "ip": [
-        "1.1.1.1",
-        "192.0.2.1"
+        "192.0.2.1",
+        "192.0.2.101"
       ]
     },
     "rule": {
@@ -78,8 +78,8 @@
       "ruleset": "default"
     },
     "source": {
-      "address": "1.1.1.1",
-      "ip": "1.1.1.1",
+      "address": "192.0.2.101",
+      "ip": "192.0.2.101",
       "port": 33345
     },
     "url": {

--- a/Fortinet/fortigate/tests/icmp.json
+++ b/Fortinet/fortigate/tests/icmp.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": " time=15:22:43 devname=\"abc\" devid=\"1\" logid=\"0000000011\" type=\"traffic\" subtype=\"forward\" level=\"warning\" vd=\"root\" eventtime=1602591763587868496 tz=\"+0300\" srcip=1.1.1.1 identifier=256 srcintf=\"internal\" srcintfrole=\"lan\" dstip=192.0.2.1 dstintf=\"wan1\" dstintfrole=\"wan\" srcuuid=\"b22e6ef4-2e38-51ea-72c9-53b2da2e20f5\" dstuuid=\"052bdbce-823a-51e9-eb23-7a3e819fea4f\" poluuid=\"1520e1aa-823a-51e9-984f-a55e1f39b3c7\" sessionid=706677975 proto=1 action=\"ip-conn\" policyid=1 policytype=\"policy\" service=\"icmp/0/8\" dstcountry=\"Netherlands\" srccountry=\"Reserved\" appcat=\"unscanned\" crscore=5 craction=262144 crlevel=\"low\""
+    "message": " time=15:22:43 devname=\"abc\" devid=\"1\" logid=\"0000000011\" type=\"traffic\" subtype=\"forward\" level=\"warning\" vd=\"root\" eventtime=1602591763587868496 tz=\"+0300\" srcip=192.0.2.101 identifier=256 srcintf=\"internal\" srcintfrole=\"lan\" dstip=192.0.2.1 dstintf=\"wan1\" dstintfrole=\"wan\" srcuuid=\"b22e6ef4-2e38-51ea-72c9-53b2da2e20f5\" dstuuid=\"052bdbce-823a-51e9-eb23-7a3e819fea4f\" poluuid=\"1520e1aa-823a-51e9-984f-a55e1f39b3c7\" sessionid=706677975 proto=1 action=\"ip-conn\" policyid=1 policytype=\"policy\" service=\"icmp/0/8\" dstcountry=\"Netherlands\" srccountry=\"Reserved\" appcat=\"unscanned\" crscore=5 craction=262144 crlevel=\"low\""
   },
   "expected": {
-    "message": " time=15:22:43 devname=\"abc\" devid=\"1\" logid=\"0000000011\" type=\"traffic\" subtype=\"forward\" level=\"warning\" vd=\"root\" eventtime=1602591763587868496 tz=\"+0300\" srcip=1.1.1.1 identifier=256 srcintf=\"internal\" srcintfrole=\"lan\" dstip=192.0.2.1 dstintf=\"wan1\" dstintfrole=\"wan\" srcuuid=\"b22e6ef4-2e38-51ea-72c9-53b2da2e20f5\" dstuuid=\"052bdbce-823a-51e9-eb23-7a3e819fea4f\" poluuid=\"1520e1aa-823a-51e9-984f-a55e1f39b3c7\" sessionid=706677975 proto=1 action=\"ip-conn\" policyid=1 policytype=\"policy\" service=\"icmp/0/8\" dstcountry=\"Netherlands\" srccountry=\"Reserved\" appcat=\"unscanned\" crscore=5 craction=262144 crlevel=\"low\"",
+    "message": " time=15:22:43 devname=\"abc\" devid=\"1\" logid=\"0000000011\" type=\"traffic\" subtype=\"forward\" level=\"warning\" vd=\"root\" eventtime=1602591763587868496 tz=\"+0300\" srcip=192.0.2.101 identifier=256 srcintf=\"internal\" srcintfrole=\"lan\" dstip=192.0.2.1 dstintf=\"wan1\" dstintfrole=\"wan\" srcuuid=\"b22e6ef4-2e38-51ea-72c9-53b2da2e20f5\" dstuuid=\"052bdbce-823a-51e9-eb23-7a3e819fea4f\" poluuid=\"1520e1aa-823a-51e9-984f-a55e1f39b3c7\" sessionid=706677975 proto=1 action=\"ip-conn\" policyid=1 policytype=\"policy\" service=\"icmp/0/8\" dstcountry=\"Netherlands\" srccountry=\"Reserved\" appcat=\"unscanned\" crscore=5 craction=262144 crlevel=\"low\"",
     "event": {
       "action": "ip-conn",
       "category": "traffic",
@@ -72,8 +72,8 @@
         "abc"
       ],
       "ip": [
-        "1.1.1.1",
-        "192.0.2.1"
+        "192.0.2.1",
+        "192.0.2.101"
       ]
     },
     "rule": {
@@ -81,8 +81,8 @@
       "ruleset": "policy"
     },
     "source": {
-      "address": "1.1.1.1",
-      "ip": "1.1.1.1"
+      "address": "192.0.2.101",
+      "ip": "192.0.2.101"
     }
   }
 }

--- a/Fortinet/fortigate/tests/icmp_CEF.json
+++ b/Fortinet/fortigate/tests/icmp_CEF.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.10|00014|traffic:local accept|3|deviceExternalId=FGVM2V0000171868 FortinetFortiGatelogid=0001000014 cat=traffic:local FortinetFortiGatesubtype=local FortinetFortiGatelevel=notice FortinetFortiGatevd=root FortinetFortiGateeventtime=1602663098 src=1.1.1.1 deviceInboundInterface=port1 FortinetFortiGatesrcintfrole=undefined dst=192.0.2.1 deviceOutboundInterface=root FortinetFortiGatedstintfrole=undefined externalId=4887198 proto=1 FortinetFortiGateaction=accept FortinetFortiGatepolicyid=0 FortinetFortiGatepolicytype=local-in-policy app=icmp/8/0 FortinetFortiGatedstcountry=Reserved FortinetFortiGatesrccountry=China FortinetFortiGatetrandisp=noop FortinetFortiGateapp=icmp/8/0 FortinetFortiGateduration=61 out=84 in=84 FortinetFortiGatesentpkt=1 FortinetFortiGatercvdpkt=1 FortinetFortiGateappcat=unscanned"
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.10|00014|traffic:local accept|3|deviceExternalId=FGVM2V0000171868 FortinetFortiGatelogid=0001000014 cat=traffic:local FortinetFortiGatesubtype=local FortinetFortiGatelevel=notice FortinetFortiGatevd=root FortinetFortiGateeventtime=1602663098 src=192.0.2.101 deviceInboundInterface=port1 FortinetFortiGatesrcintfrole=undefined dst=192.0.2.1 deviceOutboundInterface=root FortinetFortiGatedstintfrole=undefined externalId=4887198 proto=1 FortinetFortiGateaction=accept FortinetFortiGatepolicyid=0 FortinetFortiGatepolicytype=local-in-policy app=icmp/8/0 FortinetFortiGatedstcountry=Reserved FortinetFortiGatesrccountry=China FortinetFortiGatetrandisp=noop FortinetFortiGateapp=icmp/8/0 FortinetFortiGateduration=61 out=84 in=84 FortinetFortiGatesentpkt=1 FortinetFortiGatercvdpkt=1 FortinetFortiGateappcat=unscanned"
   },
   "expected": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.10|00014|traffic:local accept|3|deviceExternalId=FGVM2V0000171868 FortinetFortiGatelogid=0001000014 cat=traffic:local FortinetFortiGatesubtype=local FortinetFortiGatelevel=notice FortinetFortiGatevd=root FortinetFortiGateeventtime=1602663098 src=1.1.1.1 deviceInboundInterface=port1 FortinetFortiGatesrcintfrole=undefined dst=192.0.2.1 deviceOutboundInterface=root FortinetFortiGatedstintfrole=undefined externalId=4887198 proto=1 FortinetFortiGateaction=accept FortinetFortiGatepolicyid=0 FortinetFortiGatepolicytype=local-in-policy app=icmp/8/0 FortinetFortiGatedstcountry=Reserved FortinetFortiGatesrccountry=China FortinetFortiGatetrandisp=noop FortinetFortiGateapp=icmp/8/0 FortinetFortiGateduration=61 out=84 in=84 FortinetFortiGatesentpkt=1 FortinetFortiGatercvdpkt=1 FortinetFortiGateappcat=unscanned",
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.10|00014|traffic:local accept|3|deviceExternalId=FGVM2V0000171868 FortinetFortiGatelogid=0001000014 cat=traffic:local FortinetFortiGatesubtype=local FortinetFortiGatelevel=notice FortinetFortiGatevd=root FortinetFortiGateeventtime=1602663098 src=192.0.2.101 deviceInboundInterface=port1 FortinetFortiGatesrcintfrole=undefined dst=192.0.2.1 deviceOutboundInterface=root FortinetFortiGatedstintfrole=undefined externalId=4887198 proto=1 FortinetFortiGateaction=accept FortinetFortiGatepolicyid=0 FortinetFortiGatepolicytype=local-in-policy app=icmp/8/0 FortinetFortiGatedstcountry=Reserved FortinetFortiGatesrccountry=China FortinetFortiGatetrandisp=noop FortinetFortiGateapp=icmp/8/0 FortinetFortiGateduration=61 out=84 in=84 FortinetFortiGatesentpkt=1 FortinetFortiGatercvdpkt=1 FortinetFortiGateappcat=unscanned",
     "event": {
       "action": "accept",
       "category": "traffic",
@@ -60,8 +60,8 @@
     },
     "related": {
       "ip": [
-        "1.1.1.1",
-        "192.0.2.1"
+        "192.0.2.1",
+        "192.0.2.101"
       ]
     },
     "rule": {
@@ -69,12 +69,12 @@
       "ruleset": "local-in-policy"
     },
     "source": {
-      "address": "1.1.1.1",
+      "address": "192.0.2.101",
       "bytes": 84,
       "geo": {
         "country_name": "China"
       },
-      "ip": "1.1.1.1",
+      "ip": "192.0.2.101",
       "packets": 1
     }
   }

--- a/Fortinet/fortigate/tests/malicious_url_blocked.json
+++ b/Fortinet/fortigate/tests/malicious_url_blocked.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "message": "time=18:58:47 devname=\"NAME_1\" devid=\"ABCDEFG123456789\" eventtime=1746291526925867188 tz=\"+0200\" logid=\"0123456789\" type=\"utm\" subtype=\"ips\" eventtype=\"malicious-url\" level=\"warning\" vd=\"Cristal\" severity=\"high\" srcip=1.2.3.4 srccountry=\"Reserved\" dstip=5.6.7.8 dstcountry=\"Reserved\" srcintf=\"Vlan15\" srcintfrole=\"lan\" dstintf=\"Vlan15\" dstintfrole=\"lan\" sessionid=1234567890 action=\"dropped\" proto=6 service=\"HTTP\" policyid=23 poluuid=\"11111111-1111-1111-1111-111111111111\" policytype=\"policy\" srcport=53335 dstport=8001 attack=\"malicious-url\" direction=\"outgoing\" msg=\"URL blocked by malicious-url-list\" profile=\"IPS_Block_Profile\" crscore=30 craction=8192 crlevel=\"high\" hostname=\"example.com\" url=\"/\" agent=\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36 Edg/136.0.0.0\" httpmethod=\"CONNECT\"",
+    "message": "time=18:58:47 devname=\"NAME_1\" devid=\"ABCDEFG123456789\" eventtime=1746291526925867188 tz=\"+0200\" logid=\"0123456789\" type=\"utm\" subtype=\"ips\" eventtype=\"malicious-url\" level=\"warning\" vd=\"Cristal\" severity=\"high\" srcip=198.51.100.4 srccountry=\"Reserved\" dstip=203.0.113.8 dstcountry=\"Reserved\" srcintf=\"Vlan15\" srcintfrole=\"lan\" dstintf=\"Vlan15\" dstintfrole=\"lan\" sessionid=1234567890 action=\"dropped\" proto=6 service=\"HTTP\" policyid=23 poluuid=\"11111111-1111-1111-1111-111111111111\" policytype=\"policy\" srcport=53335 dstport=8001 attack=\"malicious-url\" direction=\"outgoing\" msg=\"URL blocked by malicious-url-list\" profile=\"IPS_Block_Profile\" crscore=30 craction=8192 crlevel=\"high\" hostname=\"example.com\" url=\"/\" agent=\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/192.0.2.136 Safari/537.36 Edg/192.0.2.136\" httpmethod=\"CONNECT\"",
     "sekoiaio": {
       "intake": {
         "dialect": "Fortinet FortiGate",
@@ -9,7 +9,7 @@
     }
   },
   "expected": {
-    "message": "time=18:58:47 devname=\"NAME_1\" devid=\"ABCDEFG123456789\" eventtime=1746291526925867188 tz=\"+0200\" logid=\"0123456789\" type=\"utm\" subtype=\"ips\" eventtype=\"malicious-url\" level=\"warning\" vd=\"Cristal\" severity=\"high\" srcip=1.2.3.4 srccountry=\"Reserved\" dstip=5.6.7.8 dstcountry=\"Reserved\" srcintf=\"Vlan15\" srcintfrole=\"lan\" dstintf=\"Vlan15\" dstintfrole=\"lan\" sessionid=1234567890 action=\"dropped\" proto=6 service=\"HTTP\" policyid=23 poluuid=\"11111111-1111-1111-1111-111111111111\" policytype=\"policy\" srcport=53335 dstport=8001 attack=\"malicious-url\" direction=\"outgoing\" msg=\"URL blocked by malicious-url-list\" profile=\"IPS_Block_Profile\" crscore=30 craction=8192 crlevel=\"high\" hostname=\"example.com\" url=\"/\" agent=\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36 Edg/136.0.0.0\" httpmethod=\"CONNECT\"",
+    "message": "time=18:58:47 devname=\"NAME_1\" devid=\"ABCDEFG123456789\" eventtime=1746291526925867188 tz=\"+0200\" logid=\"0123456789\" type=\"utm\" subtype=\"ips\" eventtype=\"malicious-url\" level=\"warning\" vd=\"Cristal\" severity=\"high\" srcip=198.51.100.4 srccountry=\"Reserved\" dstip=203.0.113.8 dstcountry=\"Reserved\" srcintf=\"Vlan15\" srcintfrole=\"lan\" dstintf=\"Vlan15\" dstintfrole=\"lan\" sessionid=1234567890 action=\"dropped\" proto=6 service=\"HTTP\" policyid=23 poluuid=\"11111111-1111-1111-1111-111111111111\" policytype=\"policy\" srcport=53335 dstport=8001 attack=\"malicious-url\" direction=\"outgoing\" msg=\"URL blocked by malicious-url-list\" profile=\"IPS_Block_Profile\" crscore=30 craction=8192 crlevel=\"high\" hostname=\"example.com\" url=\"/\" agent=\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/192.0.2.136 Safari/537.36 Edg/192.0.2.136\" httpmethod=\"CONNECT\"",
     "event": {
       "action": "dropped",
       "category": "utm",
@@ -27,9 +27,9 @@
       "type": "ips"
     },
     "destination": {
-      "address": "5.6.7.8",
+      "address": "203.0.113.8",
       "domain": "example.com",
-      "ip": "5.6.7.8",
+      "ip": "203.0.113.8",
       "port": 8001
     },
     "fortinet": {
@@ -90,16 +90,16 @@
         "example.com"
       ],
       "ip": [
-        "1.2.3.4",
-        "5.6.7.8"
+        "198.51.100.4",
+        "203.0.113.8"
       ]
     },
     "rule": {
       "ruleset": "policy"
     },
     "source": {
-      "address": "1.2.3.4",
-      "ip": "1.2.3.4",
+      "address": "198.51.100.4",
+      "ip": "198.51.100.4",
       "port": 53335
     },
     "url": {
@@ -111,12 +111,12 @@
         "name": "Other"
       },
       "name": "Edge",
-      "original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36 Edg/136.0.0.0",
+      "original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/192.0.2.136 Safari/537.36 Edg/192.0.2.136",
       "os": {
         "name": "Windows",
         "version": "10"
       },
-      "version": "136.0.0"
+      "version": "192.0.2"
     }
   }
 }

--- a/Fortinet/fortigate/tests/ping.json
+++ b/Fortinet/fortigate/tests/ping.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": " time=14:22:37 devname=\"abc\" devid=\"1\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"ROUTER\" eventtime=1602591758311908837 tz=\"+0200\" srcip=1.1.1.1 identifier=29027 srcintf=\"test1\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstintf=\"test\" dstintfrole=\"undefined\" sessionid=3558919660 proto=1 action=\"accept\" policyid=637 policytype=\"policy\" poluuid=\"b23818a6-8f49-51ea-9db7-4e4965a3483c\" service=\"PING\" dstcountry=\"Reserved\" srccountry=\"Reserved\" trandisp=\"noop\" duration=64 sentbyte=420 rcvdbyte=420 sentpkt=5 rcvdpkt=5 appcat=\"unscanned\""
+    "message": " time=14:22:37 devname=\"abc\" devid=\"1\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"ROUTER\" eventtime=1602591758311908837 tz=\"+0200\" srcip=192.0.2.101 identifier=29027 srcintf=\"test1\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstintf=\"test\" dstintfrole=\"undefined\" sessionid=3558919660 proto=1 action=\"accept\" policyid=637 policytype=\"policy\" poluuid=\"b23818a6-8f49-51ea-9db7-4e4965a3483c\" service=\"PING\" dstcountry=\"Reserved\" srccountry=\"Reserved\" trandisp=\"noop\" duration=64 sentbyte=420 rcvdbyte=420 sentpkt=5 rcvdpkt=5 appcat=\"unscanned\""
   },
   "expected": {
-    "message": " time=14:22:37 devname=\"abc\" devid=\"1\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"ROUTER\" eventtime=1602591758311908837 tz=\"+0200\" srcip=1.1.1.1 identifier=29027 srcintf=\"test1\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstintf=\"test\" dstintfrole=\"undefined\" sessionid=3558919660 proto=1 action=\"accept\" policyid=637 policytype=\"policy\" poluuid=\"b23818a6-8f49-51ea-9db7-4e4965a3483c\" service=\"PING\" dstcountry=\"Reserved\" srccountry=\"Reserved\" trandisp=\"noop\" duration=64 sentbyte=420 rcvdbyte=420 sentpkt=5 rcvdpkt=5 appcat=\"unscanned\"",
+    "message": " time=14:22:37 devname=\"abc\" devid=\"1\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"ROUTER\" eventtime=1602591758311908837 tz=\"+0200\" srcip=192.0.2.101 identifier=29027 srcintf=\"test1\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstintf=\"test\" dstintfrole=\"undefined\" sessionid=3558919660 proto=1 action=\"accept\" policyid=637 policytype=\"policy\" poluuid=\"b23818a6-8f49-51ea-9db7-4e4965a3483c\" service=\"PING\" dstcountry=\"Reserved\" srccountry=\"Reserved\" trandisp=\"noop\" duration=64 sentbyte=420 rcvdbyte=420 sentpkt=5 rcvdpkt=5 appcat=\"unscanned\"",
     "event": {
       "action": "accept",
       "category": "traffic",
@@ -67,8 +67,8 @@
         "abc"
       ],
       "ip": [
-        "1.1.1.1",
-        "192.0.2.1"
+        "192.0.2.1",
+        "192.0.2.101"
       ]
     },
     "rule": {
@@ -76,9 +76,9 @@
       "ruleset": "policy"
     },
     "source": {
-      "address": "1.1.1.1",
+      "address": "192.0.2.101",
       "bytes": 420,
-      "ip": "1.1.1.1",
+      "ip": "192.0.2.101",
       "packets": 5
     }
   }

--- a/Fortinet/fortigate/tests/rest_api.json
+++ b/Fortinet/fortigate/tests/rest_api.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "eventtime=1741264760483566820 tz=\"+0100\" logid=\"0116047301\" type=\"event\" subtype=\"rest-api\" level=\"information\" vd=\"root\" logdesc=\"REST API request success\" user=\"user1\" ui=\"GUI(1.2.3.4)\" method=\"GET\" path=\"system.usb-log\" status=\"200\" url=\"/api/v2/monitor/system/usb-log?https://example.com/\""
+    "message": "eventtime=1741264760483566820 tz=\"+0100\" logid=\"0116047301\" type=\"event\" subtype=\"rest-api\" level=\"information\" vd=\"root\" logdesc=\"REST API request success\" user=\"user1\" ui=\"GUI(198.51.100.4)\" method=\"GET\" path=\"system.usb-log\" status=\"200\" url=\"/api/v2/monitor/system/usb-log?https://example.com/\""
   },
   "expected": {
-    "message": "eventtime=1741264760483566820 tz=\"+0100\" logid=\"0116047301\" type=\"event\" subtype=\"rest-api\" level=\"information\" vd=\"root\" logdesc=\"REST API request success\" user=\"user1\" ui=\"GUI(1.2.3.4)\" method=\"GET\" path=\"system.usb-log\" status=\"200\" url=\"/api/v2/monitor/system/usb-log?https://example.com/\"",
+    "message": "eventtime=1741264760483566820 tz=\"+0100\" logid=\"0116047301\" type=\"event\" subtype=\"rest-api\" level=\"information\" vd=\"root\" logdesc=\"REST API request success\" user=\"user1\" ui=\"GUI(198.51.100.4)\" method=\"GET\" path=\"system.usb-log\" status=\"200\" url=\"/api/v2/monitor/system/usb-log?https://example.com/\"",
     "event": {
       "category": "event",
       "code": "0116047301",
@@ -35,15 +35,15 @@
     },
     "related": {
       "ip": [
-        "1.2.3.4"
+        "198.51.100.4"
       ],
       "user": [
         "user1"
       ]
     },
     "source": {
-      "address": "1.2.3.4",
-      "ip": "1.2.3.4",
+      "address": "198.51.100.4",
+      "ip": "198.51.100.4",
       "user": {
         "name": "user1"
       }

--- a/Fortinet/fortigate/tests/ssh_access.CEF.json
+++ b/Fortinet/fortigate/tests/ssh_access.CEF.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.4|32021|event:system login failed|7|deviceExternalId=FGVM2V0000171868 FortinetFortiGatelogid=0100032021 cat=event:system FortinetFortiGatesubtype=system FortinetFortiGatelevel=alert FortinetFortiGatevd=root FortinetFortiGateeventtime=1579172447 FortinetFortiGatelogdesc=Admin login disabled sproc=1.1.1.1 FortinetFortiGateaction=login outcome=failed reason=exceed_limit msg=Login disabled from IP 1.1.1.1 for 60 seconds because of 3 bad attempts"
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.4|32021|event:system login failed|7|deviceExternalId=FGVM2V0000171868 FortinetFortiGatelogid=0100032021 cat=event:system FortinetFortiGatesubtype=system FortinetFortiGatelevel=alert FortinetFortiGatevd=root FortinetFortiGateeventtime=1579172447 FortinetFortiGatelogdesc=Admin login disabled sproc=192.0.2.101 FortinetFortiGateaction=login outcome=failed reason=exceed_limit msg=Login disabled from IP 192.0.2.101 for 60 seconds because of 3 bad attempts"
   },
   "expected": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.4|32021|event:system login failed|7|deviceExternalId=FGVM2V0000171868 FortinetFortiGatelogid=0100032021 cat=event:system FortinetFortiGatesubtype=system FortinetFortiGatelevel=alert FortinetFortiGatevd=root FortinetFortiGateeventtime=1579172447 FortinetFortiGatelogdesc=Admin login disabled sproc=1.1.1.1 FortinetFortiGateaction=login outcome=failed reason=exceed_limit msg=Login disabled from IP 1.1.1.1 for 60 seconds because of 3 bad attempts",
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.4|32021|event:system login failed|7|deviceExternalId=FGVM2V0000171868 FortinetFortiGatelogid=0100032021 cat=event:system FortinetFortiGatesubtype=system FortinetFortiGatelevel=alert FortinetFortiGatevd=root FortinetFortiGateeventtime=1579172447 FortinetFortiGatelogdesc=Admin login disabled sproc=192.0.2.101 FortinetFortiGateaction=login outcome=failed reason=exceed_limit msg=Login disabled from IP 192.0.2.101 for 60 seconds because of 3 bad attempts",
     "event": {
       "action": "login",
       "category": "event",
@@ -16,7 +16,7 @@
     "action": {
       "name": "login",
       "outcome": "failure",
-      "outcome_reason": "Login disabled from IP 1.1.1.1 for 60 seconds because of 3 bad attempts",
+      "outcome_reason": "Login disabled from IP 192.0.2.101 for 60 seconds because of 3 bad attempts",
       "type": "system"
     },
     "fortinet": {
@@ -36,12 +36,12 @@
     },
     "related": {
       "ip": [
-        "1.1.1.1"
+        "192.0.2.101"
       ]
     },
     "source": {
-      "address": "1.1.1.1",
-      "ip": "1.1.1.1"
+      "address": "192.0.2.101",
+      "ip": "192.0.2.101"
     }
   }
 }

--- a/Fortinet/fortigate/tests/system_event.CEF.1.json
+++ b/Fortinet/fortigate/tests/system_event.CEF.1.json
@@ -18,7 +18,7 @@
       "outcome": "success",
       "provider": "ssh",
       "reason": "none",
-      "timezone": "+0100"
+      "timezone": "+0000"
     },
     "@timestamp": "2025-03-06T12:38:52.502104Z",
     "action": {

--- a/Fortinet/fortigate/tests/system_event.CEF.1.json
+++ b/Fortinet/fortigate/tests/system_event.CEF.1.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "message": "0|Fortinet|FortiGate-100F|7.2.8,build1639 (GA)|0100032001|system event login|4|start=Mar 06 2025 13:38:52 logver=1111111 deviceExternalId=devExtID dvchost=TESTHOST vd=root eventtime=1741264732502103430 tz=+0100 logid=0100032001 cat=event subtype=system deviceSeverity=information logdesc=Admin login successful sn=1741264732 duser=admin sproc=ssh(1.2.3.4) method=ssh src=1.2.3.4 dst=192.0.2.1 act=login status=success reason=none profile=super_admin msg=Administrator admin logged in successfully from ssh(1.2.3.4) tz=\"+0000\"",
+    "message": "0|Fortinet|FortiGate-100F|7.2.8,build1639 (GA)|0100032001|system event login|4|start=Mar 06 2025 13:38:52 logver=1111111 deviceExternalId=devExtID dvchost=TESTHOST vd=root eventtime=1741264732502103430 tz=+0100 logid=0100032001 cat=event subtype=system deviceSeverity=information logdesc=Admin login successful sn=1741264732 duser=admin sproc=ssh(198.51.100.4) method=ssh src=198.51.100.4 dst=192.0.2.1 act=login status=success reason=none profile=super_admin msg=Administrator admin logged in successfully from ssh(198.51.100.4) tz=\"+0000\"",
     "sekoiaio": {
       "intake": {
         "dialect": "Fortinet FortiGate",
@@ -9,7 +9,7 @@
     }
   },
   "expected": {
-    "message": "0|Fortinet|FortiGate-100F|7.2.8,build1639 (GA)|0100032001|system event login|4|start=Mar 06 2025 13:38:52 logver=1111111 deviceExternalId=devExtID dvchost=TESTHOST vd=root eventtime=1741264732502103430 tz=+0100 logid=0100032001 cat=event subtype=system deviceSeverity=information logdesc=Admin login successful sn=1741264732 duser=admin sproc=ssh(1.2.3.4) method=ssh src=1.2.3.4 dst=192.0.2.1 act=login status=success reason=none profile=super_admin msg=Administrator admin logged in successfully from ssh(1.2.3.4) tz=\"+0000\"",
+    "message": "0|Fortinet|FortiGate-100F|7.2.8,build1639 (GA)|0100032001|system event login|4|start=Mar 06 2025 13:38:52 logver=1111111 deviceExternalId=devExtID dvchost=TESTHOST vd=root eventtime=1741264732502103430 tz=+0100 logid=0100032001 cat=event subtype=system deviceSeverity=information logdesc=Admin login successful sn=1741264732 duser=admin sproc=ssh(198.51.100.4) method=ssh src=198.51.100.4 dst=192.0.2.1 act=login status=success reason=none profile=super_admin msg=Administrator admin logged in successfully from ssh(198.51.100.4) tz=\"+0000\"",
     "event": {
       "action": "login",
       "category": "event",
@@ -24,7 +24,7 @@
     "action": {
       "name": "login",
       "outcome": "success",
-      "outcome_reason": "Administrator admin logged in successfully from ssh(1.2.3.4)",
+      "outcome_reason": "Administrator admin logged in successfully from ssh(198.51.100.4)",
       "target": "network-traffic",
       "type": "system"
     },
@@ -57,16 +57,16 @@
     },
     "related": {
       "ip": [
-        "1.2.3.4",
-        "192.0.2.1"
+        "192.0.2.1",
+        "198.51.100.4"
       ],
       "user": [
         "admin"
       ]
     },
     "source": {
-      "address": "1.2.3.4",
-      "ip": "1.2.3.4"
+      "address": "198.51.100.4",
+      "ip": "198.51.100.4"
     }
   }
 }

--- a/Fortinet/fortigate/tests/system_event.CEF.json
+++ b/Fortinet/fortigate/tests/system_event.CEF.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "message": "0|Fortinet|FortiGate-100F|7.2.8,build1639 (GA)|0100032001|system event login|4|start=Mar 06 2025 13:38:52 logver=702081639 deviceExternalId=FGTESTID dvchost=FGTESTHOST vd=root eventtime=1741264732502103430 tz=+0100 logid=0100032001 cat=event subtype=system deviceSeverity=information logdesc=Admin login successful sn=1741264732 duser=test sproc=ssh(1.2.3.4) method=ssh src=1.2.3.4 dst=3.4.5.6 act=login status=success reason=none profile=super_admin msg=Administrator test logged in successfully from ssh(1.2.3.4) tz=\"+0000\"\ntime=13:39:08 devname=\"testHost\" devid=\"testSerialNumber\" eventtime=1741264747895826299 tz=\"+0100\" logid=\"0100032003\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Admin logout successful\" sn=\"1741264747\" user=\"user1\" ui=\"https(5.6.7.8)\" method=\"https\" srcip=5.6.7.8 dstip=4.5.6.7 action=\"logout\" status=\"success\" duration=0 reason=\"exit\" msg=\"Administrator user1 logged out from https(5.6.7.8)\"",
+    "message": "0|Fortinet|FortiGate-100F|7.2.8,build1639 (GA)|0100032001|system event login|4|start=Mar 06 2025 13:38:52 logver=702081639 deviceExternalId=FGTESTID dvchost=FGTESTHOST vd=root eventtime=1741264732502103430 tz=+0100 logid=0100032001 cat=event subtype=system deviceSeverity=information logdesc=Admin login successful sn=1741264732 duser=test sproc=ssh(198.51.100.4) method=ssh src=198.51.100.4 dst=203.0.113.6 act=login status=success reason=none profile=super_admin msg=Administrator test logged in successfully from ssh(198.51.100.4) tz=\"+0000\"\ntime=13:39:08 devname=\"testHost\" devid=\"testSerialNumber\" eventtime=1741264747895826299 tz=\"+0100\" logid=\"0100032003\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Admin logout successful\" sn=\"1741264747\" user=\"user1\" ui=\"https(203.0.113.8)\" method=\"https\" srcip=203.0.113.8 dstip=203.0.113.7 action=\"logout\" status=\"success\" duration=0 reason=\"exit\" msg=\"Administrator user1 logged out from https(203.0.113.8)\"",
     "sekoiaio": {
       "intake": {
         "dialect": "Fortinet FortiGate",
@@ -9,7 +9,7 @@
     }
   },
   "expected": {
-    "message": "0|Fortinet|FortiGate-100F|7.2.8,build1639 (GA)|0100032001|system event login|4|start=Mar 06 2025 13:38:52 logver=702081639 deviceExternalId=FGTESTID dvchost=FGTESTHOST vd=root eventtime=1741264732502103430 tz=+0100 logid=0100032001 cat=event subtype=system deviceSeverity=information logdesc=Admin login successful sn=1741264732 duser=test sproc=ssh(1.2.3.4) method=ssh src=1.2.3.4 dst=3.4.5.6 act=login status=success reason=none profile=super_admin msg=Administrator test logged in successfully from ssh(1.2.3.4) tz=\"+0000\"\ntime=13:39:08 devname=\"testHost\" devid=\"testSerialNumber\" eventtime=1741264747895826299 tz=\"+0100\" logid=\"0100032003\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Admin logout successful\" sn=\"1741264747\" user=\"user1\" ui=\"https(5.6.7.8)\" method=\"https\" srcip=5.6.7.8 dstip=4.5.6.7 action=\"logout\" status=\"success\" duration=0 reason=\"exit\" msg=\"Administrator user1 logged out from https(5.6.7.8)\"",
+    "message": "0|Fortinet|FortiGate-100F|7.2.8,build1639 (GA)|0100032001|system event login|4|start=Mar 06 2025 13:38:52 logver=702081639 deviceExternalId=FGTESTID dvchost=FGTESTHOST vd=root eventtime=1741264732502103430 tz=+0100 logid=0100032001 cat=event subtype=system deviceSeverity=information logdesc=Admin login successful sn=1741264732 duser=test sproc=ssh(198.51.100.4) method=ssh src=198.51.100.4 dst=203.0.113.6 act=login status=success reason=none profile=super_admin msg=Administrator test logged in successfully from ssh(198.51.100.4) tz=\"+0000\"\ntime=13:39:08 devname=\"testHost\" devid=\"testSerialNumber\" eventtime=1741264747895826299 tz=\"+0100\" logid=\"0100032003\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Admin logout successful\" sn=\"1741264747\" user=\"user1\" ui=\"https(203.0.113.8)\" method=\"https\" srcip=203.0.113.8 dstip=203.0.113.7 action=\"logout\" status=\"success\" duration=0 reason=\"exit\" msg=\"Administrator user1 logged out from https(203.0.113.8)\"",
     "event": {
       "action": "login",
       "category": "event",
@@ -24,13 +24,13 @@
     "action": {
       "name": "login",
       "outcome": "success",
-      "outcome_reason": "Administrator user1 logged out from https(5.6.7.8)",
+      "outcome_reason": "Administrator user1 logged out from https(203.0.113.8)",
       "target": "network-traffic",
       "type": "system"
     },
     "destination": {
-      "address": "4.5.6.7",
-      "ip": "3.4.5.6",
+      "address": "203.0.113.7",
+      "ip": "203.0.113.6",
       "user": {
         "name": "test"
       }
@@ -66,8 +66,8 @@
         "testHost"
       ],
       "ip": [
-        "1.2.3.4",
-        "3.4.5.6"
+        "198.51.100.4",
+        "203.0.113.6"
       ],
       "user": [
         "test",
@@ -75,8 +75,8 @@
       ]
     },
     "source": {
-      "address": "1.2.3.4",
-      "ip": "1.2.3.4",
+      "address": "198.51.100.4",
+      "ip": "198.51.100.4",
       "user": {
         "name": "user1"
       }

--- a/Fortinet/fortigate/tests/system_event.CEF.json
+++ b/Fortinet/fortigate/tests/system_event.CEF.json
@@ -13,18 +13,18 @@
     "event": {
       "action": "login",
       "category": "event",
-      "code": "0100032001",
+      "code": "0100032003",
       "dataset": "event:system",
       "outcome": "success",
-      "provider": "ssh",
-      "reason": "none",
+      "provider": "https",
+      "reason": "exit",
       "timezone": "+0100"
     },
-    "@timestamp": "2025-03-06T12:38:52.502104Z",
+    "@timestamp": "2025-03-06T12:39:07.895826Z",
     "action": {
       "name": "login",
       "outcome": "success",
-      "outcome_reason": "Administrator test logged in successfully from ssh(1.2.3.4)",
+      "outcome_reason": "Administrator user1 logged out from https(5.6.7.8)",
       "target": "network-traffic",
       "type": "system"
     },
@@ -42,17 +42,17 @@
         },
         "log_version": "702081639",
         "security_profile": "super_admin",
-        "sn": "1741264732",
+        "sn": "1741264747",
         "virtual_domain": "root"
       }
     },
     "log": {
-      "description": "Admin login successful",
+      "description": "Admin logout successful",
       "hostname": "testHost",
       "level": "information"
     },
     "network": {
-      "protocol": "ssh"
+      "protocol": "https"
     },
     "observer": {
       "hostname": "testHost",

--- a/Fortinet/fortigate/tests/system_event.json
+++ b/Fortinet/fortigate/tests/system_event.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "message": "time=13:39:08 devname=\"testHostname\" devid=\"testSerialNumber\" eventtime=1741264747895826299 tz=\"+0100\" logid=\"0100032003\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Admin logout successful\" sn=\"1741264747\" user=\"testUser\" ui=\"https(3.4.5.6)\" method=\"https\" srcip=3.4.5.6 dstip=1.2.3.4 action=\"logout\" status=\"success\" duration=0 reason=\"exit\" msg=\"Administrator testUser logged out from https(3.4.5.6)\"",
+    "message": "time=13:39:08 devname=\"testHostname\" devid=\"testSerialNumber\" eventtime=1741264747895826299 tz=\"+0100\" logid=\"0100032003\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Admin logout successful\" sn=\"1741264747\" user=\"testUser\" ui=\"https(203.0.113.6)\" method=\"https\" srcip=203.0.113.6 dstip=198.51.100.4 action=\"logout\" status=\"success\" duration=0 reason=\"exit\" msg=\"Administrator testUser logged out from https(203.0.113.6)\"",
     "sekoiaio": {
       "intake": {
         "dialect": "Fortinet FortiGate",
@@ -9,7 +9,7 @@
     }
   },
   "expected": {
-    "message": "time=13:39:08 devname=\"testHostname\" devid=\"testSerialNumber\" eventtime=1741264747895826299 tz=\"+0100\" logid=\"0100032003\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Admin logout successful\" sn=\"1741264747\" user=\"testUser\" ui=\"https(3.4.5.6)\" method=\"https\" srcip=3.4.5.6 dstip=1.2.3.4 action=\"logout\" status=\"success\" duration=0 reason=\"exit\" msg=\"Administrator testUser logged out from https(3.4.5.6)\"",
+    "message": "time=13:39:08 devname=\"testHostname\" devid=\"testSerialNumber\" eventtime=1741264747895826299 tz=\"+0100\" logid=\"0100032003\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Admin logout successful\" sn=\"1741264747\" user=\"testUser\" ui=\"https(203.0.113.6)\" method=\"https\" srcip=203.0.113.6 dstip=198.51.100.4 action=\"logout\" status=\"success\" duration=0 reason=\"exit\" msg=\"Administrator testUser logged out from https(203.0.113.6)\"",
     "event": {
       "action": "logout",
       "category": "event",
@@ -24,13 +24,13 @@
     "action": {
       "name": "logout",
       "outcome": "success",
-      "outcome_reason": "Administrator testUser logged out from https(3.4.5.6)",
+      "outcome_reason": "Administrator testUser logged out from https(203.0.113.6)",
       "target": "network-traffic",
       "type": "system"
     },
     "destination": {
-      "address": "1.2.3.4",
-      "ip": "1.2.3.4"
+      "address": "198.51.100.4",
+      "ip": "198.51.100.4"
     },
     "fortinet": {
       "fortigate": {
@@ -58,16 +58,16 @@
         "testHostname"
       ],
       "ip": [
-        "1.2.3.4",
-        "3.4.5.6"
+        "198.51.100.4",
+        "203.0.113.6"
       ],
       "user": [
         "testUser"
       ]
     },
     "source": {
-      "address": "3.4.5.6",
-      "ip": "3.4.5.6",
+      "address": "203.0.113.6",
+      "ip": "203.0.113.6",
       "user": {
         "name": "testUser"
       }

--- a/Fortinet/fortigate/tests/system_event_1.json
+++ b/Fortinet/fortigate/tests/system_event_1.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "message": "time=13:39:08 devname=\"TESTDEVNAME\" devid=\"TESTDEVID\" eventtime=1741264747895826299 tz=\"+0100\" logid=\"0100032003\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Admin logout successful\" sn=\"1741264747\" user=\"user1\" ui=\"https(1.2.3.4)\" method=\"https\" srcip=1.2.3.4 dstip=192.0.2.1 action=\"logout\" status=\"success\" duration=0 reason=\"exit\" msg=\"Administrator user1 logged out from https(1.2.3.4)\"",
+    "message": "time=13:39:08 devname=\"TESTDEVNAME\" devid=\"TESTDEVID\" eventtime=1741264747895826299 tz=\"+0100\" logid=\"0100032003\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Admin logout successful\" sn=\"1741264747\" user=\"user1\" ui=\"https(198.51.100.4)\" method=\"https\" srcip=198.51.100.4 dstip=192.0.2.1 action=\"logout\" status=\"success\" duration=0 reason=\"exit\" msg=\"Administrator user1 logged out from https(198.51.100.4)\"",
     "sekoiaio": {
       "intake": {
         "dialect": "Fortinet FortiGate",
@@ -9,7 +9,7 @@
     }
   },
   "expected": {
-    "message": "time=13:39:08 devname=\"TESTDEVNAME\" devid=\"TESTDEVID\" eventtime=1741264747895826299 tz=\"+0100\" logid=\"0100032003\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Admin logout successful\" sn=\"1741264747\" user=\"user1\" ui=\"https(1.2.3.4)\" method=\"https\" srcip=1.2.3.4 dstip=192.0.2.1 action=\"logout\" status=\"success\" duration=0 reason=\"exit\" msg=\"Administrator user1 logged out from https(1.2.3.4)\"",
+    "message": "time=13:39:08 devname=\"TESTDEVNAME\" devid=\"TESTDEVID\" eventtime=1741264747895826299 tz=\"+0100\" logid=\"0100032003\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Admin logout successful\" sn=\"1741264747\" user=\"user1\" ui=\"https(198.51.100.4)\" method=\"https\" srcip=198.51.100.4 dstip=192.0.2.1 action=\"logout\" status=\"success\" duration=0 reason=\"exit\" msg=\"Administrator user1 logged out from https(198.51.100.4)\"",
     "event": {
       "action": "logout",
       "category": "event",
@@ -24,7 +24,7 @@
     "action": {
       "name": "logout",
       "outcome": "success",
-      "outcome_reason": "Administrator user1 logged out from https(1.2.3.4)",
+      "outcome_reason": "Administrator user1 logged out from https(198.51.100.4)",
       "target": "network-traffic",
       "type": "system"
     },
@@ -58,16 +58,16 @@
         "TESTDEVNAME"
       ],
       "ip": [
-        "1.2.3.4",
-        "192.0.2.1"
+        "192.0.2.1",
+        "198.51.100.4"
       ],
       "user": [
         "user1"
       ]
     },
     "source": {
-      "address": "1.2.3.4",
-      "ip": "1.2.3.4",
+      "address": "198.51.100.4",
+      "ip": "198.51.100.4",
       "user": {
         "name": "user1"
       }

--- a/Fortinet/fortigate/tests/system_event_2.json
+++ b/Fortinet/fortigate/tests/system_event_2.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "message": "time=12:35:04 devname=\"DEVNAME01\" devid=\"FGT123456ABCDEF\" eventtime=1748601303656994360 tz=\"+0200\" logid=\"0123456789\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Attribute configured\" user=\"admin\" ui=\"jsconsole(1.2.3.4)\" action=\"Edit\" cfgtid=987654321 cfgpath=\"system.settings\" cfgattr=\"gui-sslvpn[disable->enable]\" msg=\"Edit system.settings \"",
+    "message": "time=12:35:04 devname=\"DEVNAME01\" devid=\"FGT123456ABCDEF\" eventtime=1748601303656994360 tz=\"+0200\" logid=\"0123456789\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Attribute configured\" user=\"admin\" ui=\"jsconsole(198.51.100.4)\" action=\"Edit\" cfgtid=987654321 cfgpath=\"system.settings\" cfgattr=\"gui-sslvpn[disable->enable]\" msg=\"Edit system.settings \"",
     "sekoiaio": {
       "intake": {
         "dialect": "Fortinet FortiGate",
@@ -9,7 +9,7 @@
     }
   },
   "expected": {
-    "message": "time=12:35:04 devname=\"DEVNAME01\" devid=\"FGT123456ABCDEF\" eventtime=1748601303656994360 tz=\"+0200\" logid=\"0123456789\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Attribute configured\" user=\"admin\" ui=\"jsconsole(1.2.3.4)\" action=\"Edit\" cfgtid=987654321 cfgpath=\"system.settings\" cfgattr=\"gui-sslvpn[disable->enable]\" msg=\"Edit system.settings \"",
+    "message": "time=12:35:04 devname=\"DEVNAME01\" devid=\"FGT123456ABCDEF\" eventtime=1748601303656994360 tz=\"+0200\" logid=\"0123456789\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Attribute configured\" user=\"admin\" ui=\"jsconsole(198.51.100.4)\" action=\"Edit\" cfgtid=987654321 cfgpath=\"system.settings\" cfgattr=\"gui-sslvpn[disable->enable]\" msg=\"Edit system.settings \"",
     "event": {
       "action": "Edit",
       "category": "event",
@@ -51,15 +51,15 @@
         "DEVNAME01"
       ],
       "ip": [
-        "1.2.3.4"
+        "198.51.100.4"
       ],
       "user": [
         "admin"
       ]
     },
     "source": {
-      "address": "1.2.3.4",
-      "ip": "1.2.3.4",
+      "address": "198.51.100.4",
+      "ip": "198.51.100.4",
       "user": {
         "name": "admin"
       }

--- a/Fortinet/fortigate/tests/system_event_3.json
+++ b/Fortinet/fortigate/tests/system_event_3.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "message": "time=12:35:04 devname=\"TESTDEVNAME\" devid=\"TESTDEVID\" eventtime=1748601303656994360 tz=\"+0200\" logid=\"0100044546\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Attribute configured\" user=\"admin\" ui=\"jsconsole(1.2.3.4)\" action=\"Edit\" cfgtid=153616384 cfgpath=\"system.settings\" cfgattr=\"gui-sslvpn[disable->enable]\" msg=\"Edit system.settings \"",
+    "message": "time=12:35:04 devname=\"TESTDEVNAME\" devid=\"TESTDEVID\" eventtime=1748601303656994360 tz=\"+0200\" logid=\"0100044546\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Attribute configured\" user=\"admin\" ui=\"jsconsole(198.51.100.4)\" action=\"Edit\" cfgtid=153616384 cfgpath=\"system.settings\" cfgattr=\"gui-sslvpn[disable->enable]\" msg=\"Edit system.settings \"",
     "sekoiaio": {
       "intake": {
         "dialect": "Fortinet FortiGate",
@@ -9,7 +9,7 @@
     }
   },
   "expected": {
-    "message": "time=12:35:04 devname=\"TESTDEVNAME\" devid=\"TESTDEVID\" eventtime=1748601303656994360 tz=\"+0200\" logid=\"0100044546\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Attribute configured\" user=\"admin\" ui=\"jsconsole(1.2.3.4)\" action=\"Edit\" cfgtid=153616384 cfgpath=\"system.settings\" cfgattr=\"gui-sslvpn[disable->enable]\" msg=\"Edit system.settings \"",
+    "message": "time=12:35:04 devname=\"TESTDEVNAME\" devid=\"TESTDEVID\" eventtime=1748601303656994360 tz=\"+0200\" logid=\"0100044546\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Attribute configured\" user=\"admin\" ui=\"jsconsole(198.51.100.4)\" action=\"Edit\" cfgtid=153616384 cfgpath=\"system.settings\" cfgattr=\"gui-sslvpn[disable->enable]\" msg=\"Edit system.settings \"",
     "event": {
       "action": "Edit",
       "category": "event",
@@ -51,15 +51,15 @@
         "TESTDEVNAME"
       ],
       "ip": [
-        "1.2.3.4"
+        "198.51.100.4"
       ],
       "user": [
         "admin"
       ]
     },
     "source": {
-      "address": "1.2.3.4",
-      "ip": "1.2.3.4",
+      "address": "198.51.100.4",
+      "ip": "198.51.100.4",
       "user": {
         "name": "admin"
       }

--- a/Fortinet/fortigate/tests/test_event_login_1.json
+++ b/Fortinet/fortigate/tests/test_event_login_1.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "time=16:22:20 timestamp=1762528940 devname=\"FortiAuthenticator\" devid=\"TEST_DEV_ID\" vd=\"root\" itime=1762528940 faclogindex=\"111111111\" logid=\"20320\" logdesc=\"AUTH_FAIL_USER_TEST_EVENT_DAT\" type=\"event\" subtype=\"Authentication\" level=\"information\" user=\"user1\" nas=\"1.2.3.4\" userip=192.0.2.1 action=\"Authentication\" status=\"Failed\" msg=\"User authentication from 192.0.2.1 (mschap) with no token failed: user not found\" tz=\"+0100\""
+    "message": "time=16:22:20 timestamp=1762528940 devname=\"FortiAuthenticator\" devid=\"TEST_DEV_ID\" vd=\"root\" itime=1762528940 faclogindex=\"111111111\" logid=\"20320\" logdesc=\"AUTH_FAIL_USER_TEST_EVENT_DAT\" type=\"event\" subtype=\"Authentication\" level=\"information\" user=\"user1\" nas=\"198.51.100.4\" userip=192.0.2.1 action=\"Authentication\" status=\"Failed\" msg=\"User authentication from 192.0.2.1 (mschap) with no token failed: user not found\" tz=\"+0100\""
   },
   "expected": {
-    "message": "time=16:22:20 timestamp=1762528940 devname=\"FortiAuthenticator\" devid=\"TEST_DEV_ID\" vd=\"root\" itime=1762528940 faclogindex=\"111111111\" logid=\"20320\" logdesc=\"AUTH_FAIL_USER_TEST_EVENT_DAT\" type=\"event\" subtype=\"Authentication\" level=\"information\" user=\"user1\" nas=\"1.2.3.4\" userip=192.0.2.1 action=\"Authentication\" status=\"Failed\" msg=\"User authentication from 192.0.2.1 (mschap) with no token failed: user not found\" tz=\"+0100\"",
+    "message": "time=16:22:20 timestamp=1762528940 devname=\"FortiAuthenticator\" devid=\"TEST_DEV_ID\" vd=\"root\" itime=1762528940 faclogindex=\"111111111\" logid=\"20320\" logdesc=\"AUTH_FAIL_USER_TEST_EVENT_DAT\" type=\"event\" subtype=\"Authentication\" level=\"information\" user=\"user1\" nas=\"198.51.100.4\" userip=192.0.2.1 action=\"Authentication\" status=\"Failed\" msg=\"User authentication from 192.0.2.1 (mschap) with no token failed: user not found\" tz=\"+0100\"",
     "event": {
       "action": "Authentication",
       "category": "event",

--- a/Fortinet/fortigate/tests/test_event_login_2.json
+++ b/Fortinet/fortigate/tests/test_event_login_2.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "time=16:22:20 timestamp=1762528940 devname=\"FortiAuthenticator\" devid=\"TEST_DEVICE_ID\" vd=\"root\" itime=1762528940 faclogindex=\"8321046\" logid=\"20320\" logdesc=\"AUTH_FAIL_USER_TEST_EVENT\" type=\"event\" subtype=\"Authentication\" level=\"information\" user=\"user1\" nas=\"2.3.4.5\" userip=192.0.2.1 action=\"Authentication\" status=\"Failed\" msg=\"User authentication from 192.0.2.1 (mschap) with no token failed: user not found\" tz=\"+0100\""
+    "message": "time=16:22:20 timestamp=1762528940 devname=\"FortiAuthenticator\" devid=\"TEST_DEVICE_ID\" vd=\"root\" itime=1762528940 faclogindex=\"8321046\" logid=\"20320\" logdesc=\"AUTH_FAIL_USER_TEST_EVENT\" type=\"event\" subtype=\"Authentication\" level=\"information\" user=\"user1\" nas=\"198.51.100.35\" userip=192.0.2.1 action=\"Authentication\" status=\"Failed\" msg=\"User authentication from 192.0.2.1 (mschap) with no token failed: user not found\" tz=\"+0100\""
   },
   "expected": {
-    "message": "time=16:22:20 timestamp=1762528940 devname=\"FortiAuthenticator\" devid=\"TEST_DEVICE_ID\" vd=\"root\" itime=1762528940 faclogindex=\"8321046\" logid=\"20320\" logdesc=\"AUTH_FAIL_USER_TEST_EVENT\" type=\"event\" subtype=\"Authentication\" level=\"information\" user=\"user1\" nas=\"2.3.4.5\" userip=192.0.2.1 action=\"Authentication\" status=\"Failed\" msg=\"User authentication from 192.0.2.1 (mschap) with no token failed: user not found\" tz=\"+0100\"",
+    "message": "time=16:22:20 timestamp=1762528940 devname=\"FortiAuthenticator\" devid=\"TEST_DEVICE_ID\" vd=\"root\" itime=1762528940 faclogindex=\"8321046\" logid=\"20320\" logdesc=\"AUTH_FAIL_USER_TEST_EVENT\" type=\"event\" subtype=\"Authentication\" level=\"information\" user=\"user1\" nas=\"198.51.100.35\" userip=192.0.2.1 action=\"Authentication\" status=\"Failed\" msg=\"User authentication from 192.0.2.1 (mschap) with no token failed: user not found\" tz=\"+0100\"",
     "event": {
       "action": "Authentication",
       "category": "event",

--- a/Fortinet/fortigate/tests/test_event_login_3.json
+++ b/Fortinet/fortigate/tests/test_event_login_3.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "time=16:22:20 timestamp=1762528940 devname=\"FortiAuthenticator\" devid=\"TEST_DEVICE_ID\" vd=\"root\" itime=1762528941 faclogindex=\"8321052\" logid=\"20320\" logdesc=\"AUTH_FAIL_USER_TEST_EVENT\" type=\"event\" subtype=\"Authentication\" level=\"information\" user=\"user1\" nas=\"2.3.4.5\" userip=192.0.2.1 action=\"Authentication\" status=\"Failed\" msg=\"User authentication from 192.0.2.1 (chap) with no token failed: user not found\" tz=\"+0100\""
+    "message": "time=16:22:20 timestamp=1762528940 devname=\"FortiAuthenticator\" devid=\"TEST_DEVICE_ID\" vd=\"root\" itime=1762528941 faclogindex=\"8321052\" logid=\"20320\" logdesc=\"AUTH_FAIL_USER_TEST_EVENT\" type=\"event\" subtype=\"Authentication\" level=\"information\" user=\"user1\" nas=\"198.51.100.35\" userip=192.0.2.1 action=\"Authentication\" status=\"Failed\" msg=\"User authentication from 192.0.2.1 (chap) with no token failed: user not found\" tz=\"+0100\""
   },
   "expected": {
-    "message": "time=16:22:20 timestamp=1762528940 devname=\"FortiAuthenticator\" devid=\"TEST_DEVICE_ID\" vd=\"root\" itime=1762528941 faclogindex=\"8321052\" logid=\"20320\" logdesc=\"AUTH_FAIL_USER_TEST_EVENT\" type=\"event\" subtype=\"Authentication\" level=\"information\" user=\"user1\" nas=\"2.3.4.5\" userip=192.0.2.1 action=\"Authentication\" status=\"Failed\" msg=\"User authentication from 192.0.2.1 (chap) with no token failed: user not found\" tz=\"+0100\"",
+    "message": "time=16:22:20 timestamp=1762528940 devname=\"FortiAuthenticator\" devid=\"TEST_DEVICE_ID\" vd=\"root\" itime=1762528941 faclogindex=\"8321052\" logid=\"20320\" logdesc=\"AUTH_FAIL_USER_TEST_EVENT\" type=\"event\" subtype=\"Authentication\" level=\"information\" user=\"user1\" nas=\"198.51.100.35\" userip=192.0.2.1 action=\"Authentication\" status=\"Failed\" msg=\"User authentication from 192.0.2.1 (chap) with no token failed: user not found\" tz=\"+0100\"",
     "event": {
       "action": "Authentication",
       "category": "event",

--- a/Fortinet/fortigate/tests/test_event_source_ip_1.json
+++ b/Fortinet/fortigate/tests/test_event_source_ip_1.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "message": "time=13:53:24 devname=\"TEST_DEV_NAME\" devid=\"DEVID1111111\" eventtime=1749038004142040029 tz=\"+0200\" logid=\"0100044547\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Object attribute configured\" user=\"admin\" ui=\"GUI(1.1.1.1)\" action=\"Add\" cfgtid=1231232131 uuid=\"0000000-413a-51f0-3994-9f8f05c1432f\" cfgpath=\"firewall.policy\" cfgobj=\"6\" cfgattr=\"name[vpn_remote_0]srcintf[TestTest]dstintf[internal]action[accept]srcaddr[TestTest]dstaddr[TestTest]schedule[always]service[ALL]comments[VPN: TestTest (Created by VPN wizard)]\" msg=\"Add firewall.policy 6\"",
+    "message": "time=13:53:24 devname=\"TEST_DEV_NAME\" devid=\"DEVID1111111\" eventtime=1749038004142040029 tz=\"+0200\" logid=\"0100044547\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Object attribute configured\" user=\"admin\" ui=\"GUI(192.0.2.101)\" action=\"Add\" cfgtid=1231232131 uuid=\"0000000-413a-51f0-3994-9f8f05c1432f\" cfgpath=\"firewall.policy\" cfgobj=\"6\" cfgattr=\"name[vpn_remote_0]srcintf[TestTest]dstintf[internal]action[accept]srcaddr[TestTest]dstaddr[TestTest]schedule[always]service[ALL]comments[VPN: TestTest (Created by VPN wizard)]\" msg=\"Add firewall.policy 6\"",
     "sekoiaio": {
       "intake": {
         "dialect": "Fortinet FortiGate",
@@ -9,7 +9,7 @@
     }
   },
   "expected": {
-    "message": "time=13:53:24 devname=\"TEST_DEV_NAME\" devid=\"DEVID1111111\" eventtime=1749038004142040029 tz=\"+0200\" logid=\"0100044547\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Object attribute configured\" user=\"admin\" ui=\"GUI(1.1.1.1)\" action=\"Add\" cfgtid=1231232131 uuid=\"0000000-413a-51f0-3994-9f8f05c1432f\" cfgpath=\"firewall.policy\" cfgobj=\"6\" cfgattr=\"name[vpn_remote_0]srcintf[TestTest]dstintf[internal]action[accept]srcaddr[TestTest]dstaddr[TestTest]schedule[always]service[ALL]comments[VPN: TestTest (Created by VPN wizard)]\" msg=\"Add firewall.policy 6\"",
+    "message": "time=13:53:24 devname=\"TEST_DEV_NAME\" devid=\"DEVID1111111\" eventtime=1749038004142040029 tz=\"+0200\" logid=\"0100044547\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" logdesc=\"Object attribute configured\" user=\"admin\" ui=\"GUI(192.0.2.101)\" action=\"Add\" cfgtid=1231232131 uuid=\"0000000-413a-51f0-3994-9f8f05c1432f\" cfgpath=\"firewall.policy\" cfgobj=\"6\" cfgattr=\"name[vpn_remote_0]srcintf[TestTest]dstintf[internal]action[accept]srcaddr[TestTest]dstaddr[TestTest]schedule[always]service[ALL]comments[VPN: TestTest (Created by VPN wizard)]\" msg=\"Add firewall.policy 6\"",
     "event": {
       "action": "Add",
       "category": "event",
@@ -52,15 +52,15 @@
         "TEST_DEV_NAME"
       ],
       "ip": [
-        "1.1.1.1"
+        "192.0.2.101"
       ],
       "user": [
         "admin"
       ]
     },
     "source": {
-      "address": "1.1.1.1",
-      "ip": "1.1.1.1",
+      "address": "192.0.2.101",
+      "ip": "192.0.2.101",
       "user": {
         "name": "admin"
       }

--- a/Fortinet/fortigate/tests/test_event_source_ip_3.json
+++ b/Fortinet/fortigate/tests/test_event_source_ip_3.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "message": "time=10:33:11 devname=\"FW-TTTTTTTT-1\" devid=\"TESTDEV21111111\" eventtime=1693557190787280122 tz=\"+0200\" logid=\"0100044547\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"TEST-APP\" logdesc=\"Object attribute configured\" user=\"admin\" ui=\"RESTAPI(1.1.1.1)\" action=\"Add\" cfgtid=111111111 cfgpath=\"firewall.policy\" cfgobj=\"95\" cfgattr=\"uuid[0000000000-48a2-51ee-9a4e-d49ca8f62bfb]srcintf[Z_INTERCO]dstintf[Z_APP]action[accept]srcaddr[Nw-3.3.3.3-AdministrateursDN]dstaddr[Host-2.2.2.2-VIP_PROD]schedule[always]service[HTTPS PING]utm-status[enable]ssl-ssh-profile[certificate-inspection]ips-sensor[Sensor_Web]logtraffic[all]\" msg=\"Add firewall.policy 95\"",
+    "message": "time=10:33:11 devname=\"FW-TTTTTTTT-1\" devid=\"TESTDEV21111111\" eventtime=1693557190787280122 tz=\"+0200\" logid=\"0100044547\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"TEST-APP\" logdesc=\"Object attribute configured\" user=\"admin\" ui=\"RESTAPI(192.0.2.101)\" action=\"Add\" cfgtid=111111111 cfgpath=\"firewall.policy\" cfgobj=\"95\" cfgattr=\"uuid[0000000000-48a2-51ee-9a4e-d49ca8f62bfb]srcintf[Z_INTERCO]dstintf[Z_APP]action[accept]srcaddr[Nw-198.51.100.33-AdministrateursDN]dstaddr[Host-198.51.100.32-VIP_PROD]schedule[always]service[HTTPS PING]utm-status[enable]ssl-ssh-profile[certificate-inspection]ips-sensor[Sensor_Web]logtraffic[all]\" msg=\"Add firewall.policy 95\"",
     "sekoiaio": {
       "intake": {
         "dialect": "Fortinet FortiGate",
@@ -9,7 +9,7 @@
     }
   },
   "expected": {
-    "message": "time=10:33:11 devname=\"FW-TTTTTTTT-1\" devid=\"TESTDEV21111111\" eventtime=1693557190787280122 tz=\"+0200\" logid=\"0100044547\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"TEST-APP\" logdesc=\"Object attribute configured\" user=\"admin\" ui=\"RESTAPI(1.1.1.1)\" action=\"Add\" cfgtid=111111111 cfgpath=\"firewall.policy\" cfgobj=\"95\" cfgattr=\"uuid[0000000000-48a2-51ee-9a4e-d49ca8f62bfb]srcintf[Z_INTERCO]dstintf[Z_APP]action[accept]srcaddr[Nw-3.3.3.3-AdministrateursDN]dstaddr[Host-2.2.2.2-VIP_PROD]schedule[always]service[HTTPS PING]utm-status[enable]ssl-ssh-profile[certificate-inspection]ips-sensor[Sensor_Web]logtraffic[all]\" msg=\"Add firewall.policy 95\"",
+    "message": "time=10:33:11 devname=\"FW-TTTTTTTT-1\" devid=\"TESTDEV21111111\" eventtime=1693557190787280122 tz=\"+0200\" logid=\"0100044547\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"TEST-APP\" logdesc=\"Object attribute configured\" user=\"admin\" ui=\"RESTAPI(192.0.2.101)\" action=\"Add\" cfgtid=111111111 cfgpath=\"firewall.policy\" cfgobj=\"95\" cfgattr=\"uuid[0000000000-48a2-51ee-9a4e-d49ca8f62bfb]srcintf[Z_INTERCO]dstintf[Z_APP]action[accept]srcaddr[Nw-198.51.100.33-AdministrateursDN]dstaddr[Host-198.51.100.32-VIP_PROD]schedule[always]service[HTTPS PING]utm-status[enable]ssl-ssh-profile[certificate-inspection]ips-sensor[Sensor_Web]logtraffic[all]\" msg=\"Add firewall.policy 95\"",
     "event": {
       "action": "Add",
       "category": "event",
@@ -28,7 +28,7 @@
     },
     "fortinet": {
       "fortigate": {
-        "cfgattr": "uuid[0000000000-48a2-51ee-9a4e-d49ca8f62bfb]srcintf[Z_INTERCO]dstintf[Z_APP]action[accept]srcaddr[Nw-3.3.3.3-AdministrateursDN]dstaddr[Host-2.2.2.2-VIP_PROD]schedule[always]service[HTTPS PING]utm-status[enable]ssl-ssh-profile[certificate-inspection]ips-sensor[Sensor_Web]logtraffic[all]",
+        "cfgattr": "uuid[0000000000-48a2-51ee-9a4e-d49ca8f62bfb]srcintf[Z_INTERCO]dstintf[Z_APP]action[accept]srcaddr[Nw-198.51.100.33-AdministrateursDN]dstaddr[Host-198.51.100.32-VIP_PROD]schedule[always]service[HTTPS PING]utm-status[enable]ssl-ssh-profile[certificate-inspection]ips-sensor[Sensor_Web]logtraffic[all]",
         "cfgpath": "firewall.policy",
         "cfgtid": "111111111",
         "event": {
@@ -51,15 +51,15 @@
         "FW-TTTTTTTT-1"
       ],
       "ip": [
-        "1.1.1.1"
+        "192.0.2.101"
       ],
       "user": [
         "admin"
       ]
     },
     "source": {
-      "address": "1.1.1.1",
-      "ip": "1.1.1.1",
+      "address": "192.0.2.101",
+      "ip": "192.0.2.101",
       "user": {
         "name": "admin"
       }

--- a/Fortinet/fortigate/tests/test_event_source_ip_4.json
+++ b/Fortinet/fortigate/tests/test_event_source_ip_4.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "message": "time=09:47:39 devname=\"TESTDEVNAME\" devid=\"TESTDEVID01\" logid=\"0100044547\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"Part\" eventtime=1645001259 logdesc=\"Object attribute configured\" user=\"user1\" ui=\"fgfm_tunnel\" action=\"Add\" cfgtid=1623130112 cfgpath=\"firewall.address\" cfgobj=\"TEST1.1.1.1\" cfgattr=\"uuid[00000000-8f03-51ec-de75-17ef43f88c98]subnet[2.1.1.1 255.255.255.255]\" msg=\"Add firewall.address B2.1.1.1\"",
+    "message": "time=09:47:39 devname=\"TESTDEVNAME\" devid=\"TESTDEVID01\" logid=\"0100044547\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"Part\" eventtime=1645001259 logdesc=\"Object attribute configured\" user=\"user1\" ui=\"fgfm_tunnel\" action=\"Add\" cfgtid=1623130112 cfgpath=\"firewall.address\" cfgobj=\"TEST1.1.1.1\" cfgattr=\"uuid[00000000-8f03-51ec-de75-17ef43f88c98]subnet[198.51.100.31 255.255.255.255]\" msg=\"Add firewall.address B2.1.1.1\"",
     "sekoiaio": {
       "intake": {
         "dialect": "Fortinet FortiGate",
@@ -9,7 +9,7 @@
     }
   },
   "expected": {
-    "message": "time=09:47:39 devname=\"TESTDEVNAME\" devid=\"TESTDEVID01\" logid=\"0100044547\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"Part\" eventtime=1645001259 logdesc=\"Object attribute configured\" user=\"user1\" ui=\"fgfm_tunnel\" action=\"Add\" cfgtid=1623130112 cfgpath=\"firewall.address\" cfgobj=\"TEST1.1.1.1\" cfgattr=\"uuid[00000000-8f03-51ec-de75-17ef43f88c98]subnet[2.1.1.1 255.255.255.255]\" msg=\"Add firewall.address B2.1.1.1\"",
+    "message": "time=09:47:39 devname=\"TESTDEVNAME\" devid=\"TESTDEVID01\" logid=\"0100044547\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"Part\" eventtime=1645001259 logdesc=\"Object attribute configured\" user=\"user1\" ui=\"fgfm_tunnel\" action=\"Add\" cfgtid=1623130112 cfgpath=\"firewall.address\" cfgobj=\"TEST1.1.1.1\" cfgattr=\"uuid[00000000-8f03-51ec-de75-17ef43f88c98]subnet[198.51.100.31 255.255.255.255]\" msg=\"Add firewall.address B2.1.1.1\"",
     "event": {
       "action": "Add",
       "category": "event",
@@ -27,7 +27,7 @@
     },
     "fortinet": {
       "fortigate": {
-        "cfgattr": "uuid[00000000-8f03-51ec-de75-17ef43f88c98]subnet[2.1.1.1 255.255.255.255]",
+        "cfgattr": "uuid[00000000-8f03-51ec-de75-17ef43f88c98]subnet[198.51.100.31 255.255.255.255]",
         "cfgpath": "firewall.address",
         "cfgtid": "1623130112",
         "event": {

--- a/Fortinet/fortigate/tests/test_event_source_ip_5.json
+++ b/Fortinet/fortigate/tests/test_event_source_ip_5.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "message": "time=15:27:40 devname=\"TEST_DEV_NAME\" devid=\"TEST_DEV_ID\" logid=\"0100044546\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" eventtime=1647440860 logdesc=\"Attribute configured\" user=\"user1\" ui=\"ssh(192.0.2.1)\" action=\"Edit\" cfgtid=613613570 cfgpath=\"log.syslogd.setting\" cfgattr=\"server[1.2.1.1->1.2.2.2]\" msg=\"Edit log.syslogd.setting \"",
+    "message": "time=15:27:40 devname=\"TEST_DEV_NAME\" devid=\"TEST_DEV_ID\" logid=\"0100044546\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" eventtime=1647440860 logdesc=\"Attribute configured\" user=\"user1\" ui=\"ssh(192.0.2.1)\" action=\"Edit\" cfgtid=613613570 cfgpath=\"log.syslogd.setting\" cfgattr=\"server[198.51.100.21->198.51.100.22]\" msg=\"Edit log.syslogd.setting \"",
     "sekoiaio": {
       "intake": {
         "dialect": "Fortinet FortiGate",
@@ -9,7 +9,7 @@
     }
   },
   "expected": {
-    "message": "time=15:27:40 devname=\"TEST_DEV_NAME\" devid=\"TEST_DEV_ID\" logid=\"0100044546\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" eventtime=1647440860 logdesc=\"Attribute configured\" user=\"user1\" ui=\"ssh(192.0.2.1)\" action=\"Edit\" cfgtid=613613570 cfgpath=\"log.syslogd.setting\" cfgattr=\"server[1.2.1.1->1.2.2.2]\" msg=\"Edit log.syslogd.setting \"",
+    "message": "time=15:27:40 devname=\"TEST_DEV_NAME\" devid=\"TEST_DEV_ID\" logid=\"0100044546\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" eventtime=1647440860 logdesc=\"Attribute configured\" user=\"user1\" ui=\"ssh(192.0.2.1)\" action=\"Edit\" cfgtid=613613570 cfgpath=\"log.syslogd.setting\" cfgattr=\"server[198.51.100.21->198.51.100.22]\" msg=\"Edit log.syslogd.setting \"",
     "event": {
       "action": "Edit",
       "category": "event",
@@ -27,7 +27,7 @@
     },
     "fortinet": {
       "fortigate": {
-        "cfgattr": "server[1.2.1.1->1.2.2.2]",
+        "cfgattr": "server[198.51.100.21->198.51.100.22]",
         "cfgpath": "log.syslogd.setting",
         "cfgtid": "613613570",
         "event": {

--- a/Fortinet/fortigate/tests/test_event_source_ip_7.json
+++ b/Fortinet/fortigate/tests/test_event_source_ip_7.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "message": "time=15:27:41 devname=\"TEST_DEV_NAME\" devid=\"TEST_DEV_ID\" logid=\"0100044546\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" eventtime=1647440861 logdesc=\"Attribute configured\" user=\"testuser\" ui=\"ha_daemon\" action=\"Edit\" cfgtid=17898414 cfgpath=\"log.syslogd.setting\" cfgattr=\"server[1.2.1.1->1.2.2.2]\" msg=\"Edit log.syslogd.setting \"",
+    "message": "time=15:27:41 devname=\"TEST_DEV_NAME\" devid=\"TEST_DEV_ID\" logid=\"0100044546\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" eventtime=1647440861 logdesc=\"Attribute configured\" user=\"testuser\" ui=\"ha_daemon\" action=\"Edit\" cfgtid=17898414 cfgpath=\"log.syslogd.setting\" cfgattr=\"server[198.51.100.21->198.51.100.22]\" msg=\"Edit log.syslogd.setting \"",
     "sekoiaio": {
       "intake": {
         "dialect": "Fortinet FortiGate",
@@ -9,7 +9,7 @@
     }
   },
   "expected": {
-    "message": "time=15:27:41 devname=\"TEST_DEV_NAME\" devid=\"TEST_DEV_ID\" logid=\"0100044546\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" eventtime=1647440861 logdesc=\"Attribute configured\" user=\"testuser\" ui=\"ha_daemon\" action=\"Edit\" cfgtid=17898414 cfgpath=\"log.syslogd.setting\" cfgattr=\"server[1.2.1.1->1.2.2.2]\" msg=\"Edit log.syslogd.setting \"",
+    "message": "time=15:27:41 devname=\"TEST_DEV_NAME\" devid=\"TEST_DEV_ID\" logid=\"0100044546\" type=\"event\" subtype=\"system\" level=\"information\" vd=\"root\" eventtime=1647440861 logdesc=\"Attribute configured\" user=\"testuser\" ui=\"ha_daemon\" action=\"Edit\" cfgtid=17898414 cfgpath=\"log.syslogd.setting\" cfgattr=\"server[198.51.100.21->198.51.100.22]\" msg=\"Edit log.syslogd.setting \"",
     "event": {
       "action": "Edit",
       "category": "event",
@@ -27,7 +27,7 @@
     },
     "fortinet": {
       "fortigate": {
-        "cfgattr": "server[1.2.1.1->1.2.2.2]",
+        "cfgattr": "server[198.51.100.21->198.51.100.22]",
         "cfgpath": "log.syslogd.setting",
         "cfgtid": "17898414",
         "event": {

--- a/Fortinet/fortigate/tests/test_group_field.json
+++ b/Fortinet/fortigate/tests/test_group_field.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "message": "time=09:35:30 devname=\"eee-111-111-ff-11\" devid=\"FG00000000000000\" eventtime=1735202130361752831 tz=\"+0100\" logid=\"0000000011\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"EFF\" srcip=1.2.3.4 srcport=10000 srcintf=\"EFF-WAN-0000\" srcintfrole=\"lan\" dstip=5.6.7.8 dstport=443 dstintf=\"EFF-DMZ-0000\" dstintfrole=\"lan\" srccountry=\"France\" dstcountry=\"France\" sessionid=400190000 proto=6 action=\"client-rst\" policyid=1018 policytype=\"policy\" poluuid=\"38fa6456-a819-51ef-3c99-000000000000000000\" service=\"HTTPS\" trandisp=\"dnat\" tranip=1.2.3.4 tranport=443 duration=6 sentbyte=100 rcvdbyte=52 sentpkt=2 rcvdpkt=1 appcat=\"unscanned\"",
+    "message": "time=09:35:30 devname=\"eee-111-111-ff-11\" devid=\"FG00000000000000\" eventtime=1735202130361752831 tz=\"+0100\" logid=\"0000000011\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"EFF\" srcip=198.51.100.4 srcport=10000 srcintf=\"EFF-WAN-0000\" srcintfrole=\"lan\" dstip=203.0.113.8 dstport=443 dstintf=\"EFF-DMZ-0000\" dstintfrole=\"lan\" srccountry=\"France\" dstcountry=\"France\" sessionid=400190000 proto=6 action=\"client-rst\" policyid=1018 policytype=\"policy\" poluuid=\"38fa6456-a819-51ef-3c99-000000000000000000\" service=\"HTTPS\" trandisp=\"dnat\" tranip=198.51.100.4 tranport=443 duration=6 sentbyte=100 rcvdbyte=52 sentpkt=2 rcvdpkt=1 appcat=\"unscanned\"",
     "sekoiaio": {
       "intake": {
         "dialect": "Fortinet FortiGate",
@@ -9,7 +9,7 @@
     }
   },
   "expected": {
-    "message": "time=09:35:30 devname=\"eee-111-111-ff-11\" devid=\"FG00000000000000\" eventtime=1735202130361752831 tz=\"+0100\" logid=\"0000000011\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"EFF\" srcip=1.2.3.4 srcport=10000 srcintf=\"EFF-WAN-0000\" srcintfrole=\"lan\" dstip=5.6.7.8 dstport=443 dstintf=\"EFF-DMZ-0000\" dstintfrole=\"lan\" srccountry=\"France\" dstcountry=\"France\" sessionid=400190000 proto=6 action=\"client-rst\" policyid=1018 policytype=\"policy\" poluuid=\"38fa6456-a819-51ef-3c99-000000000000000000\" service=\"HTTPS\" trandisp=\"dnat\" tranip=1.2.3.4 tranport=443 duration=6 sentbyte=100 rcvdbyte=52 sentpkt=2 rcvdpkt=1 appcat=\"unscanned\"",
+    "message": "time=09:35:30 devname=\"eee-111-111-ff-11\" devid=\"FG00000000000000\" eventtime=1735202130361752831 tz=\"+0100\" logid=\"0000000011\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"EFF\" srcip=198.51.100.4 srcport=10000 srcintf=\"EFF-WAN-0000\" srcintfrole=\"lan\" dstip=203.0.113.8 dstport=443 dstintf=\"EFF-DMZ-0000\" dstintfrole=\"lan\" srccountry=\"France\" dstcountry=\"France\" sessionid=400190000 proto=6 action=\"client-rst\" policyid=1018 policytype=\"policy\" poluuid=\"38fa6456-a819-51ef-3c99-000000000000000000\" service=\"HTTPS\" trandisp=\"dnat\" tranip=198.51.100.4 tranport=443 duration=6 sentbyte=100 rcvdbyte=52 sentpkt=2 rcvdpkt=1 appcat=\"unscanned\"",
     "event": {
       "action": "client-rst",
       "category": "traffic",
@@ -27,14 +27,14 @@
       "type": "forward"
     },
     "destination": {
-      "address": "5.6.7.8",
+      "address": "203.0.113.8",
       "bytes": 52,
       "geo": {
         "country_name": "France"
       },
-      "ip": "5.6.7.8",
+      "ip": "203.0.113.8",
       "nat": {
-        "ip": "1.2.3.4"
+        "ip": "198.51.100.4"
       },
       "packets": 1,
       "port": 443
@@ -82,8 +82,8 @@
         "eee-111-111-ff-11"
       ],
       "ip": [
-        "1.2.3.4",
-        "5.6.7.8"
+        "198.51.100.4",
+        "203.0.113.8"
       ]
     },
     "rule": {
@@ -91,12 +91,12 @@
       "ruleset": "policy"
     },
     "source": {
-      "address": "1.2.3.4",
+      "address": "198.51.100.4",
       "bytes": 100,
       "geo": {
         "country_name": "France"
       },
-      "ip": "1.2.3.4",
+      "ip": "198.51.100.4",
       "packets": 2,
       "port": 10000
     }

--- a/Fortinet/fortigate/tests/test_group_field_1.json
+++ b/Fortinet/fortigate/tests/test_group_field_1.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "message": "time=14:53:11 devname=\"FFF00D_TEST02\" devid=\"FGT3HD300000000\" eventtime=1735000001620000000 tz=\"+0100\" logid=\"0000000010\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"root\" srcip=1.2.3.4 srcport=50000 srcintf=\"ssl.root\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstport=80 dstintf=\"VPNM-TEST\" dstintfrole=\"undefined\" srccountry=\"Reserved\" dstcountry=\"Reserved\" sessionid=100100046 proto=6 action=\"close\" policyid=274 policytype=\"policy\" poluuid=\"ac8ed64c-54e7-51eb-3525-d610000000000\" user=\"user1\" group=\"TEST-SAML\" authserver=\"azure-saml\" service=\"HTTP\" trandisp=\"snat\" transip=192.0.2.1 transport=50066 duration=7 sentbyte=18800 rcvdbyte=7900 sentpkt=30 rcvdpkt=29 vpn=\"VPNM-TEST\" vpntype=\"ipsec-static\" appcat=\"unscanned\"",
+    "message": "time=14:53:11 devname=\"FFF00D_TEST02\" devid=\"FGT3HD300000000\" eventtime=1735000001620000000 tz=\"+0100\" logid=\"0000000010\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"root\" srcip=198.51.100.4 srcport=50000 srcintf=\"ssl.root\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstport=80 dstintf=\"VPNM-TEST\" dstintfrole=\"undefined\" srccountry=\"Reserved\" dstcountry=\"Reserved\" sessionid=100100046 proto=6 action=\"close\" policyid=274 policytype=\"policy\" poluuid=\"ac8ed64c-54e7-51eb-3525-d610000000000\" user=\"user1\" group=\"TEST-SAML\" authserver=\"azure-saml\" service=\"HTTP\" trandisp=\"snat\" transip=192.0.2.1 transport=50066 duration=7 sentbyte=18800 rcvdbyte=7900 sentpkt=30 rcvdpkt=29 vpn=\"VPNM-TEST\" vpntype=\"ipsec-static\" appcat=\"unscanned\"",
     "sekoiaio": {
       "intake": {
         "dialect": "Fortinet FortiGate",
@@ -9,7 +9,7 @@
     }
   },
   "expected": {
-    "message": "time=14:53:11 devname=\"FFF00D_TEST02\" devid=\"FGT3HD300000000\" eventtime=1735000001620000000 tz=\"+0100\" logid=\"0000000010\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"root\" srcip=1.2.3.4 srcport=50000 srcintf=\"ssl.root\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstport=80 dstintf=\"VPNM-TEST\" dstintfrole=\"undefined\" srccountry=\"Reserved\" dstcountry=\"Reserved\" sessionid=100100046 proto=6 action=\"close\" policyid=274 policytype=\"policy\" poluuid=\"ac8ed64c-54e7-51eb-3525-d610000000000\" user=\"user1\" group=\"TEST-SAML\" authserver=\"azure-saml\" service=\"HTTP\" trandisp=\"snat\" transip=192.0.2.1 transport=50066 duration=7 sentbyte=18800 rcvdbyte=7900 sentpkt=30 rcvdpkt=29 vpn=\"VPNM-TEST\" vpntype=\"ipsec-static\" appcat=\"unscanned\"",
+    "message": "time=14:53:11 devname=\"FFF00D_TEST02\" devid=\"FGT3HD300000000\" eventtime=1735000001620000000 tz=\"+0100\" logid=\"0000000010\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"root\" srcip=198.51.100.4 srcport=50000 srcintf=\"ssl.root\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstport=80 dstintf=\"VPNM-TEST\" dstintfrole=\"undefined\" srccountry=\"Reserved\" dstcountry=\"Reserved\" sessionid=100100046 proto=6 action=\"close\" policyid=274 policytype=\"policy\" poluuid=\"ac8ed64c-54e7-51eb-3525-d610000000000\" user=\"user1\" group=\"TEST-SAML\" authserver=\"azure-saml\" service=\"HTTP\" trandisp=\"snat\" transip=192.0.2.1 transport=50066 duration=7 sentbyte=18800 rcvdbyte=7900 sentpkt=30 rcvdpkt=29 vpn=\"VPNM-TEST\" vpntype=\"ipsec-static\" appcat=\"unscanned\"",
     "event": {
       "action": "close",
       "category": "traffic",
@@ -78,8 +78,8 @@
         "FFF00D_TEST02"
       ],
       "ip": [
-        "1.2.3.4",
-        "192.0.2.1"
+        "192.0.2.1",
+        "198.51.100.4"
       ],
       "user": [
         "user1"
@@ -90,9 +90,9 @@
       "ruleset": "policy"
     },
     "source": {
-      "address": "1.2.3.4",
+      "address": "198.51.100.4",
       "bytes": 18800,
-      "ip": "1.2.3.4",
+      "ip": "198.51.100.4",
       "nat": {
         "ip": "192.0.2.1"
       },

--- a/Fortinet/fortigate/tests/test_ips.STANDARD.json
+++ b/Fortinet/fortigate/tests/test_ips.STANDARD.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "timestamp=1698046849 devname=\"abc\" devid=\"1\" vd=\"root\" date=2023-10-23 time=00:40:49 eventtime=1698046849852012802 tz=\"-0700\" logid=\"0101037130\" type=\"utm\" subtype=\"ips\" eventtype=\"signature\" level=\"alert\" severity=\"low\" srcip=1.2.3.4 srccountry=\"Reserved\" dstip=192.0.2.1 dstcountry=\"Reserved\" srcintf=\"port2\" srcintfrole=\"undefined\" dstintf=\"port2\" dstintfrole=\"undefined\" sessionid=1234567890 action=\"detected\" proto=6 service=\"HTTP\" policyid=494 poluuid=\"aecacfaf-8d3f-4809-a60f-bf873e0fcab3\" policytype=\"policy\" attack=\"Qualys.Vulnerability.Scanner\" srcport=37364 dstport=80 hostname=\"example.com\" url=\"/cgi/rocket.pl?https://example.com/\" direction=\"outgoing\" attackid=45660 profile=\"Example_IPS\" ref=\"http://www.fortinet.com/ids/VID45660\" incidentserialno=1234567 msg=\"tools: Qualys.Vulnerability.Scanner\" crscore=5 craction=32768 crlevel=\"low\"\n"
+    "message": "timestamp=1698046849 devname=\"abc\" devid=\"1\" vd=\"root\" date=2023-10-23 time=00:40:49 eventtime=1698046849852012802 tz=\"-0700\" logid=\"0101037130\" type=\"utm\" subtype=\"ips\" eventtype=\"signature\" level=\"alert\" severity=\"low\" srcip=198.51.100.4 srccountry=\"Reserved\" dstip=192.0.2.1 dstcountry=\"Reserved\" srcintf=\"port2\" srcintfrole=\"undefined\" dstintf=\"port2\" dstintfrole=\"undefined\" sessionid=1234567890 action=\"detected\" proto=6 service=\"HTTP\" policyid=494 poluuid=\"aecacfaf-8d3f-4809-a60f-bf873e0fcab3\" policytype=\"policy\" attack=\"Qualys.Vulnerability.Scanner\" srcport=37364 dstport=80 hostname=\"example.com\" url=\"/cgi/rocket.pl?https://example.com/\" direction=\"outgoing\" attackid=45660 profile=\"Example_IPS\" ref=\"http://www.fortinet.com/ids/VID45660\" incidentserialno=1234567 msg=\"tools: Qualys.Vulnerability.Scanner\" crscore=5 craction=32768 crlevel=\"low\"\n"
   },
   "expected": {
-    "message": "timestamp=1698046849 devname=\"abc\" devid=\"1\" vd=\"root\" date=2023-10-23 time=00:40:49 eventtime=1698046849852012802 tz=\"-0700\" logid=\"0101037130\" type=\"utm\" subtype=\"ips\" eventtype=\"signature\" level=\"alert\" severity=\"low\" srcip=1.2.3.4 srccountry=\"Reserved\" dstip=192.0.2.1 dstcountry=\"Reserved\" srcintf=\"port2\" srcintfrole=\"undefined\" dstintf=\"port2\" dstintfrole=\"undefined\" sessionid=1234567890 action=\"detected\" proto=6 service=\"HTTP\" policyid=494 poluuid=\"aecacfaf-8d3f-4809-a60f-bf873e0fcab3\" policytype=\"policy\" attack=\"Qualys.Vulnerability.Scanner\" srcport=37364 dstport=80 hostname=\"example.com\" url=\"/cgi/rocket.pl?https://example.com/\" direction=\"outgoing\" attackid=45660 profile=\"Example_IPS\" ref=\"http://www.fortinet.com/ids/VID45660\" incidentserialno=1234567 msg=\"tools: Qualys.Vulnerability.Scanner\" crscore=5 craction=32768 crlevel=\"low\"\n",
+    "message": "timestamp=1698046849 devname=\"abc\" devid=\"1\" vd=\"root\" date=2023-10-23 time=00:40:49 eventtime=1698046849852012802 tz=\"-0700\" logid=\"0101037130\" type=\"utm\" subtype=\"ips\" eventtype=\"signature\" level=\"alert\" severity=\"low\" srcip=198.51.100.4 srccountry=\"Reserved\" dstip=192.0.2.1 dstcountry=\"Reserved\" srcintf=\"port2\" srcintfrole=\"undefined\" dstintf=\"port2\" dstintfrole=\"undefined\" sessionid=1234567890 action=\"detected\" proto=6 service=\"HTTP\" policyid=494 poluuid=\"aecacfaf-8d3f-4809-a60f-bf873e0fcab3\" policytype=\"policy\" attack=\"Qualys.Vulnerability.Scanner\" srcport=37364 dstport=80 hostname=\"example.com\" url=\"/cgi/rocket.pl?https://example.com/\" direction=\"outgoing\" attackid=45660 profile=\"Example_IPS\" ref=\"http://www.fortinet.com/ids/VID45660\" incidentserialno=1234567 msg=\"tools: Qualys.Vulnerability.Scanner\" crscore=5 craction=32768 crlevel=\"low\"\n",
     "event": {
       "action": "detected",
       "category": "utm",
@@ -78,16 +78,16 @@
         "example.com"
       ],
       "ip": [
-        "1.2.3.4",
-        "192.0.2.1"
+        "192.0.2.1",
+        "198.51.100.4"
       ]
     },
     "rule": {
       "ruleset": "policy"
     },
     "source": {
-      "address": "1.2.3.4",
-      "ip": "1.2.3.4",
+      "address": "198.51.100.4",
+      "ip": "198.51.100.4",
       "port": 37364
     },
     "url": {

--- a/Fortinet/fortigate/tests/test_long_lived_session.json
+++ b/Fortinet/fortigate/tests/test_long_lived_session.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "message": "time=08:32:58 devname=\"NAME_1\" devid=\"ABCDEFG123456789\" eventtime=1746599578550052585 tz=\"+0200\" logid=\"0000000020\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"Cristal\" srcip=1.2.3.4 srcport=57974 srcintf=\"Vlan15\" srcintfrole=\"lan\" dstip=5.6.7.8 dstport=7224 dstintf=\"Vlan3200\" dstintfrole=\"lan\" srccountry=\"Reserved\" dstcountry=\"Reserved\" sessionid=1234567890 proto=6 action=\"accept\" policyid=4 policytype=\"policy\" poluuid=\"11111111-1111-1111-1111-111111111111\" policyname=\"Cristal6 vers interne\" service=\"tcp/7224\" trandisp=\"noop\" duration=1697591 sentbyte=12604185928 rcvdbyte=24366746607 sentpkt=133755826 rcvdpkt=115991007 appcat=\"unscanned\" sentdelta=771825 rcvddelta=4330052",
+    "message": "time=08:32:58 devname=\"NAME_1\" devid=\"ABCDEFG123456789\" eventtime=1746599578550052585 tz=\"+0200\" logid=\"0000000020\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"Cristal\" srcip=198.51.100.4 srcport=57974 srcintf=\"Vlan15\" srcintfrole=\"lan\" dstip=203.0.113.8 dstport=7224 dstintf=\"Vlan3200\" dstintfrole=\"lan\" srccountry=\"Reserved\" dstcountry=\"Reserved\" sessionid=1234567890 proto=6 action=\"accept\" policyid=4 policytype=\"policy\" poluuid=\"11111111-1111-1111-1111-111111111111\" policyname=\"Cristal6 vers interne\" service=\"tcp/7224\" trandisp=\"noop\" duration=1697591 sentbyte=12604185928 rcvdbyte=24366746607 sentpkt=133755826 rcvdpkt=115991007 appcat=\"unscanned\" sentdelta=771825 rcvddelta=4330052",
     "sekoiaio": {
       "intake": {
         "dialect": "Fortinet FortiGate",
@@ -9,7 +9,7 @@
     }
   },
   "expected": {
-    "message": "time=08:32:58 devname=\"NAME_1\" devid=\"ABCDEFG123456789\" eventtime=1746599578550052585 tz=\"+0200\" logid=\"0000000020\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"Cristal\" srcip=1.2.3.4 srcport=57974 srcintf=\"Vlan15\" srcintfrole=\"lan\" dstip=5.6.7.8 dstport=7224 dstintf=\"Vlan3200\" dstintfrole=\"lan\" srccountry=\"Reserved\" dstcountry=\"Reserved\" sessionid=1234567890 proto=6 action=\"accept\" policyid=4 policytype=\"policy\" poluuid=\"11111111-1111-1111-1111-111111111111\" policyname=\"Cristal6 vers interne\" service=\"tcp/7224\" trandisp=\"noop\" duration=1697591 sentbyte=12604185928 rcvdbyte=24366746607 sentpkt=133755826 rcvdpkt=115991007 appcat=\"unscanned\" sentdelta=771825 rcvddelta=4330052",
+    "message": "time=08:32:58 devname=\"NAME_1\" devid=\"ABCDEFG123456789\" eventtime=1746599578550052585 tz=\"+0200\" logid=\"0000000020\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"Cristal\" srcip=198.51.100.4 srcport=57974 srcintf=\"Vlan15\" srcintfrole=\"lan\" dstip=203.0.113.8 dstport=7224 dstintf=\"Vlan3200\" dstintfrole=\"lan\" srccountry=\"Reserved\" dstcountry=\"Reserved\" sessionid=1234567890 proto=6 action=\"accept\" policyid=4 policytype=\"policy\" poluuid=\"11111111-1111-1111-1111-111111111111\" policyname=\"Cristal6 vers interne\" service=\"tcp/7224\" trandisp=\"noop\" duration=1697591 sentbyte=12604185928 rcvdbyte=24366746607 sentpkt=133755826 rcvdpkt=115991007 appcat=\"unscanned\" sentdelta=771825 rcvddelta=4330052",
     "event": {
       "action": "accept",
       "category": "traffic",
@@ -27,9 +27,9 @@
       "type": "forward"
     },
     "destination": {
-      "address": "5.6.7.8",
+      "address": "203.0.113.8",
       "bytes": 4330052,
-      "ip": "5.6.7.8",
+      "ip": "203.0.113.8",
       "packets": 115991007,
       "port": 7224
     },
@@ -83,8 +83,8 @@
         "NAME_1"
       ],
       "ip": [
-        "1.2.3.4",
-        "5.6.7.8"
+        "198.51.100.4",
+        "203.0.113.8"
       ]
     },
     "rule": {
@@ -92,9 +92,9 @@
       "ruleset": "policy"
     },
     "source": {
-      "address": "1.2.3.4",
+      "address": "198.51.100.4",
       "bytes": 771825,
-      "ip": "1.2.3.4",
+      "ip": "198.51.100.4",
       "packets": 133755826,
       "port": 57974
     }

--- a/Fortinet/fortigate/tests/test_sql_injection.json
+++ b/Fortinet/fortigate/tests/test_sql_injection.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "time=15:15:29 devname=\"TESTDEVNAME\" devid=\"TESTDEVIT\" eventtime=1758287729906413196 tz=\"+0200\" logid=\"0123456789\" type=\"utm\" subtype=\"ips\" eventtype=\"signature\" level=\"alert\" vd=\"VIRTUALDOMAIN\" severity=\"medium\" srcip=1.2.3.4 srccountry=\"Reserved\" dstip=5.6.7.8 dstcountry=\"Reserved\" srcintf=\"INTF_1\" srcintfrole=\"undefined\" dstintf=\"INTF_2\" dstintfrole=\"undefined\" sessionid=234567890 action=\"dropped\" proto=6 service=\"HTTP\" policyid=49 poluuid=\"3eee479c-acfe-4861-941a-291eb6d1360d\" policytype=\"policy\" attack=\"HTTP.Referer.Header.SQL.Injection\" srcport=57561 dstport=80 hostname=\"example.com\" url=\"/\" agent=\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.0 Safari/537.36\" httpmethod=\"GET\" referralurl=\"https://example.com/\" direction=\"outgoing\" attackid=12345 profile=\"Sensor_Web\" ref=\"http://www.fortinet.com/ids/VID12345\" incidentserialno=11223344 msg=\"web_misc: HTTP.Referer.Header.SQL.Injection\" forwardedfor=\"9.10.11.12\" crscore=10 craction=16384 crlevel=\"medium\""
+    "message": "time=15:15:29 devname=\"TESTDEVNAME\" devid=\"TESTDEVIT\" eventtime=1758287729906413196 tz=\"+0200\" logid=\"0123456789\" type=\"utm\" subtype=\"ips\" eventtype=\"signature\" level=\"alert\" vd=\"VIRTUALDOMAIN\" severity=\"medium\" srcip=198.51.100.4 srccountry=\"Reserved\" dstip=203.0.113.8 dstcountry=\"Reserved\" srcintf=\"INTF_1\" srcintfrole=\"undefined\" dstintf=\"INTF_2\" dstintfrole=\"undefined\" sessionid=234567890 action=\"dropped\" proto=6 service=\"HTTP\" policyid=49 poluuid=\"3eee479c-acfe-4861-941a-291eb6d1360d\" policytype=\"policy\" attack=\"HTTP.Referer.Header.SQL.Injection\" srcport=57561 dstport=80 hostname=\"example.com\" url=\"/\" agent=\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.0 Safari/537.36\" httpmethod=\"GET\" referralurl=\"https://example.com/\" direction=\"outgoing\" attackid=12345 profile=\"Sensor_Web\" ref=\"http://www.fortinet.com/ids/VID12345\" incidentserialno=11223344 msg=\"web_misc: HTTP.Referer.Header.SQL.Injection\" forwardedfor=\"203.0.113.12\" crscore=10 craction=16384 crlevel=\"medium\""
   },
   "expected": {
-    "message": "time=15:15:29 devname=\"TESTDEVNAME\" devid=\"TESTDEVIT\" eventtime=1758287729906413196 tz=\"+0200\" logid=\"0123456789\" type=\"utm\" subtype=\"ips\" eventtype=\"signature\" level=\"alert\" vd=\"VIRTUALDOMAIN\" severity=\"medium\" srcip=1.2.3.4 srccountry=\"Reserved\" dstip=5.6.7.8 dstcountry=\"Reserved\" srcintf=\"INTF_1\" srcintfrole=\"undefined\" dstintf=\"INTF_2\" dstintfrole=\"undefined\" sessionid=234567890 action=\"dropped\" proto=6 service=\"HTTP\" policyid=49 poluuid=\"3eee479c-acfe-4861-941a-291eb6d1360d\" policytype=\"policy\" attack=\"HTTP.Referer.Header.SQL.Injection\" srcport=57561 dstport=80 hostname=\"example.com\" url=\"/\" agent=\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.0 Safari/537.36\" httpmethod=\"GET\" referralurl=\"https://example.com/\" direction=\"outgoing\" attackid=12345 profile=\"Sensor_Web\" ref=\"http://www.fortinet.com/ids/VID12345\" incidentserialno=11223344 msg=\"web_misc: HTTP.Referer.Header.SQL.Injection\" forwardedfor=\"9.10.11.12\" crscore=10 craction=16384 crlevel=\"medium\"",
+    "message": "time=15:15:29 devname=\"TESTDEVNAME\" devid=\"TESTDEVIT\" eventtime=1758287729906413196 tz=\"+0200\" logid=\"0123456789\" type=\"utm\" subtype=\"ips\" eventtype=\"signature\" level=\"alert\" vd=\"VIRTUALDOMAIN\" severity=\"medium\" srcip=198.51.100.4 srccountry=\"Reserved\" dstip=203.0.113.8 dstcountry=\"Reserved\" srcintf=\"INTF_1\" srcintfrole=\"undefined\" dstintf=\"INTF_2\" dstintfrole=\"undefined\" sessionid=234567890 action=\"dropped\" proto=6 service=\"HTTP\" policyid=49 poluuid=\"3eee479c-acfe-4861-941a-291eb6d1360d\" policytype=\"policy\" attack=\"HTTP.Referer.Header.SQL.Injection\" srcport=57561 dstport=80 hostname=\"example.com\" url=\"/\" agent=\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.0 Safari/537.36\" httpmethod=\"GET\" referralurl=\"https://example.com/\" direction=\"outgoing\" attackid=12345 profile=\"Sensor_Web\" ref=\"http://www.fortinet.com/ids/VID12345\" incidentserialno=11223344 msg=\"web_misc: HTTP.Referer.Header.SQL.Injection\" forwardedfor=\"203.0.113.12\" crscore=10 craction=16384 crlevel=\"medium\"",
     "event": {
       "action": "dropped",
       "category": "utm",
@@ -21,9 +21,9 @@
       "type": "ips"
     },
     "destination": {
-      "address": "5.6.7.8",
+      "address": "203.0.113.8",
       "domain": "example.com",
-      "ip": "5.6.7.8",
+      "ip": "203.0.113.8",
       "port": 80
     },
     "fortinet": {
@@ -61,7 +61,7 @@
     },
     "network": {
       "direction": "outbound",
-      "forwarded_ip": "9.10.11.12",
+      "forwarded_ip": "203.0.113.12",
       "protocol": "http",
       "transport": "tcp"
     },
@@ -85,16 +85,16 @@
         "example.com"
       ],
       "ip": [
-        "1.2.3.4",
-        "5.6.7.8"
+        "198.51.100.4",
+        "203.0.113.8"
       ]
     },
     "rule": {
       "ruleset": "policy"
     },
     "source": {
-      "address": "1.2.3.4",
-      "ip": "1.2.3.4",
+      "address": "198.51.100.4",
+      "ip": "198.51.100.4",
       "port": 57561
     },
     "url": {

--- a/Fortinet/fortigate/tests/test_standard.json
+++ b/Fortinet/fortigate/tests/test_standard.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "message": "time=14:01:16 devname=\"NAME_1\" devid=\"ABCDEFG123456789\" eventtime=1746446476968701953 tz=\"+0200\" logid=\"1234567890\" type=\"utm\" subtype=\"ips\" eventtype=\"signature\" level=\"alert\" vd=\"VD_Int\" severity=\"critical\" srcip=1.2.3.4 srccountry=\"France\" dstip=5.6.7.8 dstcountry=\"Reserved\" srcintf=\"port24\" srcintfrole=\"undefined\" dstintf=\"Vlan3194\" dstintfrole=\"lan\" sessionid=3017954790 action=\"dropped\" proto=6 service=\"SSL\" policyid=41 poluuid=\"11111111-1111-1111-1111-111111111111\" policytype=\"policy\" attack=\"OpenSSL.Heartbleed.Attack\" srcport=61087 dstport=443 hostname=\"example.com\" url=\"/\" direction=\"outgoing\" attackid=38315 profile=\"IPS_Block_Profile\" ref=\"http://www.fortinet.com/ids/VID38315\" incidentserialno=261102216 msg=\"applications: OpenSSL.Heartbleed.Attack, OpenSSL Heartbleed\" crscore=50 craction=4096 crlevel=\"critical\"",
+    "message": "time=14:01:16 devname=\"NAME_1\" devid=\"ABCDEFG123456789\" eventtime=1746446476968701953 tz=\"+0200\" logid=\"1234567890\" type=\"utm\" subtype=\"ips\" eventtype=\"signature\" level=\"alert\" vd=\"VD_Int\" severity=\"critical\" srcip=198.51.100.4 srccountry=\"France\" dstip=203.0.113.8 dstcountry=\"Reserved\" srcintf=\"port24\" srcintfrole=\"undefined\" dstintf=\"Vlan3194\" dstintfrole=\"lan\" sessionid=3017954790 action=\"dropped\" proto=6 service=\"SSL\" policyid=41 poluuid=\"11111111-1111-1111-1111-111111111111\" policytype=\"policy\" attack=\"OpenSSL.Heartbleed.Attack\" srcport=61087 dstport=443 hostname=\"example.com\" url=\"/\" direction=\"outgoing\" attackid=38315 profile=\"IPS_Block_Profile\" ref=\"http://www.fortinet.com/ids/VID38315\" incidentserialno=261102216 msg=\"applications: OpenSSL.Heartbleed.Attack, OpenSSL Heartbleed\" crscore=50 craction=4096 crlevel=\"critical\"",
     "sekoiaio": {
       "intake": {
         "dialect": "Fortinet FortiGate",
@@ -9,7 +9,7 @@
     }
   },
   "expected": {
-    "message": "time=14:01:16 devname=\"NAME_1\" devid=\"ABCDEFG123456789\" eventtime=1746446476968701953 tz=\"+0200\" logid=\"1234567890\" type=\"utm\" subtype=\"ips\" eventtype=\"signature\" level=\"alert\" vd=\"VD_Int\" severity=\"critical\" srcip=1.2.3.4 srccountry=\"France\" dstip=5.6.7.8 dstcountry=\"Reserved\" srcintf=\"port24\" srcintfrole=\"undefined\" dstintf=\"Vlan3194\" dstintfrole=\"lan\" sessionid=3017954790 action=\"dropped\" proto=6 service=\"SSL\" policyid=41 poluuid=\"11111111-1111-1111-1111-111111111111\" policytype=\"policy\" attack=\"OpenSSL.Heartbleed.Attack\" srcport=61087 dstport=443 hostname=\"example.com\" url=\"/\" direction=\"outgoing\" attackid=38315 profile=\"IPS_Block_Profile\" ref=\"http://www.fortinet.com/ids/VID38315\" incidentserialno=261102216 msg=\"applications: OpenSSL.Heartbleed.Attack, OpenSSL Heartbleed\" crscore=50 craction=4096 crlevel=\"critical\"",
+    "message": "time=14:01:16 devname=\"NAME_1\" devid=\"ABCDEFG123456789\" eventtime=1746446476968701953 tz=\"+0200\" logid=\"1234567890\" type=\"utm\" subtype=\"ips\" eventtype=\"signature\" level=\"alert\" vd=\"VD_Int\" severity=\"critical\" srcip=198.51.100.4 srccountry=\"France\" dstip=203.0.113.8 dstcountry=\"Reserved\" srcintf=\"port24\" srcintfrole=\"undefined\" dstintf=\"Vlan3194\" dstintfrole=\"lan\" sessionid=3017954790 action=\"dropped\" proto=6 service=\"SSL\" policyid=41 poluuid=\"11111111-1111-1111-1111-111111111111\" policytype=\"policy\" attack=\"OpenSSL.Heartbleed.Attack\" srcport=61087 dstport=443 hostname=\"example.com\" url=\"/\" direction=\"outgoing\" attackid=38315 profile=\"IPS_Block_Profile\" ref=\"http://www.fortinet.com/ids/VID38315\" incidentserialno=261102216 msg=\"applications: OpenSSL.Heartbleed.Attack, OpenSSL Heartbleed\" crscore=50 craction=4096 crlevel=\"critical\"",
     "event": {
       "action": "dropped",
       "category": "utm",
@@ -27,9 +27,9 @@
       "type": "ips"
     },
     "destination": {
-      "address": "5.6.7.8",
+      "address": "203.0.113.8",
       "domain": "example.com",
-      "ip": "5.6.7.8",
+      "ip": "203.0.113.8",
       "port": 443
     },
     "fortinet": {
@@ -85,19 +85,19 @@
         "example.com"
       ],
       "ip": [
-        "1.2.3.4",
-        "5.6.7.8"
+        "198.51.100.4",
+        "203.0.113.8"
       ]
     },
     "rule": {
       "ruleset": "policy"
     },
     "source": {
-      "address": "1.2.3.4",
+      "address": "198.51.100.4",
       "geo": {
         "country_name": "France"
       },
-      "ip": "1.2.3.4",
+      "ip": "198.51.100.4",
       "port": 61087
     },
     "url": {

--- a/Fortinet/fortigate/tests/test_unauthuser.json
+++ b/Fortinet/fortigate/tests/test_unauthuser.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "time=08:20:44 devname=\"computer-039482\" devid=\"C10382849\" eventtime=1669620044749365658 tz=\"+0100\" logid=\"0000000020\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"root\" srcip=1.2.3.4 srcname=\"example.com\" srcport=52272 srcintf=\"ID102\" srcintfrole=\"lan\" dstip=5.6.7.8 dstport=443 dstintf=\"ID015\" dstintfrole=\"wan\" srcuuid=\"ccd49675-9207-46cf-9c4b-8d522c2b977e\" srccountry=\"Reserved\" dstinetsvc=\"Microsoft-Office365.Published\" dstcountry=\"France\" dstregion=\"Ile-de-France\" dstcity=\"Paris\" dstreputation=5 sessionid=111111111 proto=6 action=\"accept\" policyid=37 policytype=\"policy\" poluuid=\"6a8f76d0-1459-4ddb-948a-62700ddbf241\" service=\"Microsoft-Office365.Published\" trandisp=\"snat\" transip=4.3.2.1 transport=52272 duration=258 sentbyte=160972 rcvdbyte=58449 sentpkt=333 rcvdpkt=192 vwlid=8 vwlquality=\"Seq_num(13 ID015), alive, custom1: 78.211: 0.000% 7.754 0.067 897379Kbps, selected\" vwlname=\"TO-INTERNET\" appcat=\"unscanned\" sentdelta=31328 rcvddelta=10476 srchwvendor=\"Dell\" devtype=\"Home & Office\" srcfamily=\"Computer\" osname=\"Windows\" srcswversion=\"10\" unauthuser=\"example.com\\jdoe\" unauthusersource=\"kerberos\" mastersrcmac=\"02:00:00:00:00:00\" srcmac=\"02:00:00:00:00:00\" srcserver=0"
+    "message": "time=08:20:44 devname=\"computer-039482\" devid=\"C10382849\" eventtime=1669620044749365658 tz=\"+0100\" logid=\"0000000020\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"root\" srcip=198.51.100.4 srcname=\"example.com\" srcport=52272 srcintf=\"ID102\" srcintfrole=\"lan\" dstip=203.0.113.8 dstport=443 dstintf=\"ID015\" dstintfrole=\"wan\" srcuuid=\"ccd49675-9207-46cf-9c4b-8d522c2b977e\" srccountry=\"Reserved\" dstinetsvc=\"Microsoft-Office365.Published\" dstcountry=\"France\" dstregion=\"Ile-de-France\" dstcity=\"Paris\" dstreputation=5 sessionid=111111111 proto=6 action=\"accept\" policyid=37 policytype=\"policy\" poluuid=\"6a8f76d0-1459-4ddb-948a-62700ddbf241\" service=\"Microsoft-Office365.Published\" trandisp=\"snat\" transip=203.0.113.43 transport=52272 duration=258 sentbyte=160972 rcvdbyte=58449 sentpkt=333 rcvdpkt=192 vwlid=8 vwlquality=\"Seq_num(13 ID015), alive, custom1: 78.211: 0.000% 7.754 0.067 897379Kbps, selected\" vwlname=\"TO-INTERNET\" appcat=\"unscanned\" sentdelta=31328 rcvddelta=10476 srchwvendor=\"Dell\" devtype=\"Home & Office\" srcfamily=\"Computer\" osname=\"Windows\" srcswversion=\"10\" unauthuser=\"example.com\\jdoe\" unauthusersource=\"kerberos\" mastersrcmac=\"02:00:00:00:00:00\" srcmac=\"02:00:00:00:00:00\" srcserver=0"
   },
   "expected": {
-    "message": "time=08:20:44 devname=\"computer-039482\" devid=\"C10382849\" eventtime=1669620044749365658 tz=\"+0100\" logid=\"0000000020\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"root\" srcip=1.2.3.4 srcname=\"example.com\" srcport=52272 srcintf=\"ID102\" srcintfrole=\"lan\" dstip=5.6.7.8 dstport=443 dstintf=\"ID015\" dstintfrole=\"wan\" srcuuid=\"ccd49675-9207-46cf-9c4b-8d522c2b977e\" srccountry=\"Reserved\" dstinetsvc=\"Microsoft-Office365.Published\" dstcountry=\"France\" dstregion=\"Ile-de-France\" dstcity=\"Paris\" dstreputation=5 sessionid=111111111 proto=6 action=\"accept\" policyid=37 policytype=\"policy\" poluuid=\"6a8f76d0-1459-4ddb-948a-62700ddbf241\" service=\"Microsoft-Office365.Published\" trandisp=\"snat\" transip=4.3.2.1 transport=52272 duration=258 sentbyte=160972 rcvdbyte=58449 sentpkt=333 rcvdpkt=192 vwlid=8 vwlquality=\"Seq_num(13 ID015), alive, custom1: 78.211: 0.000% 7.754 0.067 897379Kbps, selected\" vwlname=\"TO-INTERNET\" appcat=\"unscanned\" sentdelta=31328 rcvddelta=10476 srchwvendor=\"Dell\" devtype=\"Home & Office\" srcfamily=\"Computer\" osname=\"Windows\" srcswversion=\"10\" unauthuser=\"example.com\\jdoe\" unauthusersource=\"kerberos\" mastersrcmac=\"02:00:00:00:00:00\" srcmac=\"02:00:00:00:00:00\" srcserver=0",
+    "message": "time=08:20:44 devname=\"computer-039482\" devid=\"C10382849\" eventtime=1669620044749365658 tz=\"+0100\" logid=\"0000000020\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"root\" srcip=198.51.100.4 srcname=\"example.com\" srcport=52272 srcintf=\"ID102\" srcintfrole=\"lan\" dstip=203.0.113.8 dstport=443 dstintf=\"ID015\" dstintfrole=\"wan\" srcuuid=\"ccd49675-9207-46cf-9c4b-8d522c2b977e\" srccountry=\"Reserved\" dstinetsvc=\"Microsoft-Office365.Published\" dstcountry=\"France\" dstregion=\"Ile-de-France\" dstcity=\"Paris\" dstreputation=5 sessionid=111111111 proto=6 action=\"accept\" policyid=37 policytype=\"policy\" poluuid=\"6a8f76d0-1459-4ddb-948a-62700ddbf241\" service=\"Microsoft-Office365.Published\" trandisp=\"snat\" transip=203.0.113.43 transport=52272 duration=258 sentbyte=160972 rcvdbyte=58449 sentpkt=333 rcvdpkt=192 vwlid=8 vwlquality=\"Seq_num(13 ID015), alive, custom1: 78.211: 0.000% 7.754 0.067 897379Kbps, selected\" vwlname=\"TO-INTERNET\" appcat=\"unscanned\" sentdelta=31328 rcvddelta=10476 srchwvendor=\"Dell\" devtype=\"Home & Office\" srcfamily=\"Computer\" osname=\"Windows\" srcswversion=\"10\" unauthuser=\"example.com\\jdoe\" unauthusersource=\"kerberos\" mastersrcmac=\"02:00:00:00:00:00\" srcmac=\"02:00:00:00:00:00\" srcserver=0",
     "event": {
       "action": "accept",
       "category": "traffic",
@@ -21,14 +21,14 @@
       "type": "forward"
     },
     "destination": {
-      "address": "5.6.7.8",
+      "address": "203.0.113.8",
       "bytes": 10476,
       "geo": {
         "city_name": "Paris",
         "country_name": "France",
         "region_name": "Ile-de-France"
       },
-      "ip": "5.6.7.8",
+      "ip": "203.0.113.8",
       "packets": 192,
       "port": 443
     },
@@ -92,9 +92,9 @@
         "computer-039482"
       ],
       "ip": [
-        "1.2.3.4",
-        "4.3.2.1",
-        "5.6.7.8"
+        "198.51.100.4",
+        "203.0.113.43",
+        "203.0.113.8"
       ],
       "user": [
         "jdoe"
@@ -105,12 +105,12 @@
       "ruleset": "policy"
     },
     "source": {
-      "address": "1.2.3.4",
+      "address": "198.51.100.4",
       "bytes": 31328,
-      "ip": "1.2.3.4",
+      "ip": "198.51.100.4",
       "mac": "02:00:00:00:00:00",
       "nat": {
-        "ip": "4.3.2.1"
+        "ip": "203.0.113.43"
       },
       "packets": 333,
       "port": 52272

--- a/Fortinet/fortigate/tests/test_xss_blocked.json
+++ b/Fortinet/fortigate/tests/test_xss_blocked.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "timestamp=1759197338 devname=\"my-device\" devid=\"1111111111111111\" vd=\"root\" itime=1759186539 logver=0704072731 date=2025-09-30 time=00:55:38 eventtime=\"1759186539261872875\" tz=\"+0200\" logid=\"1500054000\" type=\"utm\" subtype=\"ips\" eventtype=signature level=\"alert\" severity=\"high\" srcip=192.168.2.1 srccountry=\"Reserved\" dstip=1.2.3.4 dstcountry=\"Reserved\" srcintf=\"x8\" srcintfrole=\"dmz\" dstintf=\"INTF-2\" dstintfrole=\"lan\" sessionid=123456789 action=\"dropped\" proto=6 service=\"HTTPS\" policyid=84 poluuid=\"46e3c770-bcb4-4ba5-a98e-0873f6023aae\" policytype=\"policy\" attack=\"Adobe.ColdFusion.CVE-2023-44352.Reflected.XSS\" srcport=53369 dstport=443 hostname=\"example.com\" url=\"/8tlck5A7%22%3E%3Cscript%3Ealert(document.domain)%3C/script%3E/..CFIDE/wizards/common/_authenticatewizarduser.cfm\" agent=\"Mozilla/5.0 (Knoppix; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36\" httpmethod=GET direction=outgoing attackid=54356 profile=default ref=http://www.fortinet.com/ids/VID54356 incidentserialno=201043218 msg=\"applications3: Adobe.ColdFusion.CVE-2023-44352.Reflected.XSS\" forwardedfor=5.6.7.8:51912 crscore=30 craction=8192 crlevel=\"high\""
+    "message": "timestamp=1759197338 devname=\"my-device\" devid=\"1111111111111111\" vd=\"root\" itime=1759186539 logver=0704072731 date=2025-09-30 time=00:55:38 eventtime=\"1759186539261872875\" tz=\"+0200\" logid=\"1500054000\" type=\"utm\" subtype=\"ips\" eventtype=signature level=\"alert\" severity=\"high\" srcip=192.0.2.21 srccountry=\"Reserved\" dstip=198.51.100.4 dstcountry=\"Reserved\" srcintf=\"x8\" srcintfrole=\"dmz\" dstintf=\"INTF-2\" dstintfrole=\"lan\" sessionid=123456789 action=\"dropped\" proto=6 service=\"HTTPS\" policyid=84 poluuid=\"46e3c770-bcb4-4ba5-a98e-0873f6023aae\" policytype=\"policy\" attack=\"Adobe.ColdFusion.CVE-2023-44352.Reflected.XSS\" srcport=53369 dstport=443 hostname=\"example.com\" url=\"/8tlck5A7%22%3E%3Cscript%3Ealert(document.domain)%3C/script%3E/..CFIDE/wizards/common/_authenticatewizarduser.cfm\" agent=\"Mozilla/5.0 (Knoppix; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/192.0.2.120 Safari/537.36\" httpmethod=GET direction=outgoing attackid=54356 profile=default ref=http://www.fortinet.com/ids/VID54356 incidentserialno=201043218 msg=\"applications3: Adobe.ColdFusion.CVE-2023-44352.Reflected.XSS\" forwardedfor=203.0.113.8:51912 crscore=30 craction=8192 crlevel=\"high\""
   },
   "expected": {
-    "message": "timestamp=1759197338 devname=\"my-device\" devid=\"1111111111111111\" vd=\"root\" itime=1759186539 logver=0704072731 date=2025-09-30 time=00:55:38 eventtime=\"1759186539261872875\" tz=\"+0200\" logid=\"1500054000\" type=\"utm\" subtype=\"ips\" eventtype=signature level=\"alert\" severity=\"high\" srcip=192.168.2.1 srccountry=\"Reserved\" dstip=1.2.3.4 dstcountry=\"Reserved\" srcintf=\"x8\" srcintfrole=\"dmz\" dstintf=\"INTF-2\" dstintfrole=\"lan\" sessionid=123456789 action=\"dropped\" proto=6 service=\"HTTPS\" policyid=84 poluuid=\"46e3c770-bcb4-4ba5-a98e-0873f6023aae\" policytype=\"policy\" attack=\"Adobe.ColdFusion.CVE-2023-44352.Reflected.XSS\" srcport=53369 dstport=443 hostname=\"example.com\" url=\"/8tlck5A7%22%3E%3Cscript%3Ealert(document.domain)%3C/script%3E/..CFIDE/wizards/common/_authenticatewizarduser.cfm\" agent=\"Mozilla/5.0 (Knoppix; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36\" httpmethod=GET direction=outgoing attackid=54356 profile=default ref=http://www.fortinet.com/ids/VID54356 incidentserialno=201043218 msg=\"applications3: Adobe.ColdFusion.CVE-2023-44352.Reflected.XSS\" forwardedfor=5.6.7.8:51912 crscore=30 craction=8192 crlevel=\"high\"",
+    "message": "timestamp=1759197338 devname=\"my-device\" devid=\"1111111111111111\" vd=\"root\" itime=1759186539 logver=0704072731 date=2025-09-30 time=00:55:38 eventtime=\"1759186539261872875\" tz=\"+0200\" logid=\"1500054000\" type=\"utm\" subtype=\"ips\" eventtype=signature level=\"alert\" severity=\"high\" srcip=192.0.2.21 srccountry=\"Reserved\" dstip=198.51.100.4 dstcountry=\"Reserved\" srcintf=\"x8\" srcintfrole=\"dmz\" dstintf=\"INTF-2\" dstintfrole=\"lan\" sessionid=123456789 action=\"dropped\" proto=6 service=\"HTTPS\" policyid=84 poluuid=\"46e3c770-bcb4-4ba5-a98e-0873f6023aae\" policytype=\"policy\" attack=\"Adobe.ColdFusion.CVE-2023-44352.Reflected.XSS\" srcport=53369 dstport=443 hostname=\"example.com\" url=\"/8tlck5A7%22%3E%3Cscript%3Ealert(document.domain)%3C/script%3E/..CFIDE/wizards/common/_authenticatewizarduser.cfm\" agent=\"Mozilla/5.0 (Knoppix; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/192.0.2.120 Safari/537.36\" httpmethod=GET direction=outgoing attackid=54356 profile=default ref=http://www.fortinet.com/ids/VID54356 incidentserialno=201043218 msg=\"applications3: Adobe.ColdFusion.CVE-2023-44352.Reflected.XSS\" forwardedfor=203.0.113.8:51912 crscore=30 craction=8192 crlevel=\"high\"",
     "event": {
       "action": "dropped",
       "category": "utm",
@@ -22,9 +22,9 @@
       "type": "ips"
     },
     "destination": {
-      "address": "1.2.3.4",
+      "address": "198.51.100.4",
       "domain": "example.com",
-      "ip": "1.2.3.4",
+      "ip": "198.51.100.4",
       "port": 443
     },
     "fortinet": {
@@ -62,7 +62,7 @@
     },
     "network": {
       "direction": "outbound",
-      "forwarded_ip": "5.6.7.8",
+      "forwarded_ip": "203.0.113.8",
       "protocol": "https",
       "transport": "tcp"
     },
@@ -88,16 +88,16 @@
         "my-device"
       ],
       "ip": [
-        "1.2.3.4",
-        "192.168.2.1"
+        "192.0.2.21",
+        "198.51.100.4"
       ]
     },
     "rule": {
       "ruleset": "policy"
     },
     "source": {
-      "address": "192.168.2.1",
-      "ip": "192.168.2.1",
+      "address": "192.0.2.21",
+      "ip": "192.0.2.21",
       "port": 53369
     },
     "url": {
@@ -109,11 +109,11 @@
         "name": "Other"
       },
       "name": "Chrome",
-      "original": "Mozilla/5.0 (Knoppix; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+      "original": "Mozilla/5.0 (Knoppix; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/192.0.2.120 Safari/537.36",
       "os": {
         "name": "Linux"
       },
-      "version": "120.0.0"
+      "version": "192.0.2"
     }
   }
 }

--- a/Fortinet/fortigate/tests/traffic.json
+++ b/Fortinet/fortigate/tests/traffic.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "timestamp=1742602531 devname=\"XXX\" devid=\"XXX\" vd=\"root\" date=2025-03-22 time=00:15:31 eventtime=1742613330828471629 tz=\"-0300\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" srcip=1.2.3.4 srcport=60568 srcintf=\"port1\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstport=53 dstintf=\"XXX\" dstintfrole=\"undefined\" srccountry=\"Reserved\" dstcountry=\"Japan\" sessionid=496025498 proto=17 action=\"accept\" policyid=398 policytype=\"policy\" poluuid=\"poluuidvalue\" service=\"udp-53\" trandisp=\"noop\" appid=16195 app=\"DNS\" appcat=\"Network.Service\" apprisk=\"elevated\" applist=\"XXX\" duration=180 sentbyte=0 rcvdbyte=0 sentpkt=0 rcvdpkt=0 vpntype=\"ipsecvpn\" utmaction=\"block\" countips=1 crscore=30 craction=8192"
+    "message": "timestamp=1742602531 devname=\"XXX\" devid=\"XXX\" vd=\"root\" date=2025-03-22 time=00:15:31 eventtime=1742613330828471629 tz=\"-0300\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" srcip=198.51.100.4 srcport=60568 srcintf=\"port1\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstport=53 dstintf=\"XXX\" dstintfrole=\"undefined\" srccountry=\"Reserved\" dstcountry=\"Japan\" sessionid=496025498 proto=17 action=\"accept\" policyid=398 policytype=\"policy\" poluuid=\"poluuidvalue\" service=\"udp-53\" trandisp=\"noop\" appid=16195 app=\"DNS\" appcat=\"Network.Service\" apprisk=\"elevated\" applist=\"XXX\" duration=180 sentbyte=0 rcvdbyte=0 sentpkt=0 rcvdpkt=0 vpntype=\"ipsecvpn\" utmaction=\"block\" countips=1 crscore=30 craction=8192"
   },
   "expected": {
-    "message": "timestamp=1742602531 devname=\"XXX\" devid=\"XXX\" vd=\"root\" date=2025-03-22 time=00:15:31 eventtime=1742613330828471629 tz=\"-0300\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" srcip=1.2.3.4 srcport=60568 srcintf=\"port1\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstport=53 dstintf=\"XXX\" dstintfrole=\"undefined\" srccountry=\"Reserved\" dstcountry=\"Japan\" sessionid=496025498 proto=17 action=\"accept\" policyid=398 policytype=\"policy\" poluuid=\"poluuidvalue\" service=\"udp-53\" trandisp=\"noop\" appid=16195 app=\"DNS\" appcat=\"Network.Service\" apprisk=\"elevated\" applist=\"XXX\" duration=180 sentbyte=0 rcvdbyte=0 sentpkt=0 rcvdpkt=0 vpntype=\"ipsecvpn\" utmaction=\"block\" countips=1 crscore=30 craction=8192",
+    "message": "timestamp=1742602531 devname=\"XXX\" devid=\"XXX\" vd=\"root\" date=2025-03-22 time=00:15:31 eventtime=1742613330828471629 tz=\"-0300\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" srcip=198.51.100.4 srcport=60568 srcintf=\"port1\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstport=53 dstintf=\"XXX\" dstintfrole=\"undefined\" srccountry=\"Reserved\" dstcountry=\"Japan\" sessionid=496025498 proto=17 action=\"accept\" policyid=398 policytype=\"policy\" poluuid=\"poluuidvalue\" service=\"udp-53\" trandisp=\"noop\" appid=16195 app=\"DNS\" appcat=\"Network.Service\" apprisk=\"elevated\" applist=\"XXX\" duration=180 sentbyte=0 rcvdbyte=0 sentpkt=0 rcvdpkt=0 vpntype=\"ipsecvpn\" utmaction=\"block\" countips=1 crscore=30 craction=8192",
     "event": {
       "action": "accept",
       "category": "traffic",
@@ -80,8 +80,8 @@
         "XXX"
       ],
       "ip": [
-        "1.2.3.4",
-        "192.0.2.1"
+        "192.0.2.1",
+        "198.51.100.4"
       ]
     },
     "rule": {
@@ -90,9 +90,9 @@
       "ruleset": "XXX"
     },
     "source": {
-      "address": "1.2.3.4",
+      "address": "198.51.100.4",
       "bytes": 0,
-      "ip": "1.2.3.4",
+      "ip": "198.51.100.4",
       "packets": 0,
       "port": 60568
     }

--- a/Fortinet/fortigate/tests/traffic_forward-RDP.CEF.json
+++ b/Fortinet/fortigate/tests/traffic_forward-RDP.CEF.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "CEF:0|Fortinet|FortiGate-1000C|5.6.14,build1727 (GA)|0000000020|forward traffic accept|5|start=Oct 12 2022 12:50:31 logver=506141727 deviceExternalId=FGT123 dvchost=FW-123 ad.vd=root ad.logid=0000000020 cat=traffic ad.subtype=forward deviceSeverity=notice ad.eventtime=1665571831 src=1.1.1.1 spt=55390 deviceInboundInterface=abc ad.srcintfrole=undefined dst=192.0.2.1 dpt=1522 deviceOutboundInterface=efg ad.dstintfrole=lan foo.poluuid=ec6ff8fe-5e41-51ec-bcbe-9e5484033dc8 externalID=3812440508 proto=6 act=accept ad.policyid=185 ad.policytype=policy app=SQLNET-1522 ad.dstcountry=Reserved ad.srccountry=Reserved ad.trandisp=noop ad.duration=268 out=202 in=52 ad.sentpkt=3 ad.rcvdpkt=1 ad.appcat=unscanned ad.sentdelta=0 ad.rcvddelta=0 tz=\"+0200\""
+    "message": "CEF:0|Fortinet|FortiGate-1000C|5.6.14,build1727 (GA)|0000000020|forward traffic accept|5|start=Oct 12 2022 12:50:31 logver=506141727 deviceExternalId=FGT123 dvchost=FW-123 ad.vd=root ad.logid=0000000020 cat=traffic ad.subtype=forward deviceSeverity=notice ad.eventtime=1665571831 src=192.0.2.101 spt=55390 deviceInboundInterface=abc ad.srcintfrole=undefined dst=192.0.2.1 dpt=1522 deviceOutboundInterface=efg ad.dstintfrole=lan foo.poluuid=ec6ff8fe-5e41-51ec-bcbe-9e5484033dc8 externalID=3812440508 proto=6 act=accept ad.policyid=185 ad.policytype=policy app=SQLNET-1522 ad.dstcountry=Reserved ad.srccountry=Reserved ad.trandisp=noop ad.duration=268 out=202 in=52 ad.sentpkt=3 ad.rcvdpkt=1 ad.appcat=unscanned ad.sentdelta=0 ad.rcvddelta=0 tz=\"+0200\""
   },
   "expected": {
-    "message": "CEF:0|Fortinet|FortiGate-1000C|5.6.14,build1727 (GA)|0000000020|forward traffic accept|5|start=Oct 12 2022 12:50:31 logver=506141727 deviceExternalId=FGT123 dvchost=FW-123 ad.vd=root ad.logid=0000000020 cat=traffic ad.subtype=forward deviceSeverity=notice ad.eventtime=1665571831 src=1.1.1.1 spt=55390 deviceInboundInterface=abc ad.srcintfrole=undefined dst=192.0.2.1 dpt=1522 deviceOutboundInterface=efg ad.dstintfrole=lan foo.poluuid=ec6ff8fe-5e41-51ec-bcbe-9e5484033dc8 externalID=3812440508 proto=6 act=accept ad.policyid=185 ad.policytype=policy app=SQLNET-1522 ad.dstcountry=Reserved ad.srccountry=Reserved ad.trandisp=noop ad.duration=268 out=202 in=52 ad.sentpkt=3 ad.rcvdpkt=1 ad.appcat=unscanned ad.sentdelta=0 ad.rcvddelta=0 tz=\"+0200\"",
+    "message": "CEF:0|Fortinet|FortiGate-1000C|5.6.14,build1727 (GA)|0000000020|forward traffic accept|5|start=Oct 12 2022 12:50:31 logver=506141727 deviceExternalId=FGT123 dvchost=FW-123 ad.vd=root ad.logid=0000000020 cat=traffic ad.subtype=forward deviceSeverity=notice ad.eventtime=1665571831 src=192.0.2.101 spt=55390 deviceInboundInterface=abc ad.srcintfrole=undefined dst=192.0.2.1 dpt=1522 deviceOutboundInterface=efg ad.dstintfrole=lan foo.poluuid=ec6ff8fe-5e41-51ec-bcbe-9e5484033dc8 externalID=3812440508 proto=6 act=accept ad.policyid=185 ad.policytype=policy app=SQLNET-1522 ad.dstcountry=Reserved ad.srccountry=Reserved ad.trandisp=noop ad.duration=268 out=202 in=52 ad.sentpkt=3 ad.rcvdpkt=1 ad.appcat=unscanned ad.sentdelta=0 ad.rcvddelta=0 tz=\"+0200\"",
     "event": {
       "action": "accept",
       "category": "traffic",
@@ -53,14 +53,14 @@
     },
     "related": {
       "ip": [
-        "1.1.1.1",
-        "192.0.2.1"
+        "192.0.2.1",
+        "192.0.2.101"
       ]
     },
     "source": {
-      "address": "1.1.1.1",
+      "address": "192.0.2.101",
       "bytes": 202,
-      "ip": "1.1.1.1",
+      "ip": "192.0.2.101",
       "port": 55390
     }
   }

--- a/Fortinet/fortigate/tests/traffic_forward.CEF-2.json
+++ b/Fortinet/fortigate/tests/traffic_forward.CEF-2.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.4|00013|traffic:forward timeout|3|deviceExternalId=FGVM2V0000171868 FortinetFortiGatelogid=0000000013 cat=traffic:forward FortinetFortiGatesubtype=forward FortinetFortiGatelevel=notice FortinetFortiGatevd=root FortinetFortiGateeventtime=1572471876 src=1.1.1.1 spt=49260 deviceInboundInterface=port1 FortinetFortiGatesrcintfrole=undefined dst=192.0.2.1 dpt=80 deviceOutboundInterface=port2 FortinetFortiGatedstintfrole=undefined FortinetFortiGatepoluuid=bafe134e-c0ad-51e8-ed9c-52f798dd69d4 externalId=12812952 proto=6 FortinetFortiGateaction=timeout FortinetFortiGatepolicyid=1 FortinetFortiGatepolicytype=policy app=HTTP FortinetFortiGatedstcountry=Reserved FortinetFortiGatesrccountry=United States FortinetFortiGatetrandisp=dnat destinationTranslatedAddress=192.0.2.1 destinationTranslatedPort=80 FortinetFortiGateduration=20 out=48 in=144 FortinetFortiGatesentpkt=1 FortinetFortiGatercvdpkt=3 FortinetFortiGateappcat=unscanned FortinetFortiGatecrscore=5 FortinetFortiGatecraction=262144 FortinetFortiGatecrlevel=low"
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.4|00013|traffic:forward timeout|3|deviceExternalId=FGVM2V0000171868 FortinetFortiGatelogid=0000000013 cat=traffic:forward FortinetFortiGatesubtype=forward FortinetFortiGatelevel=notice FortinetFortiGatevd=root FortinetFortiGateeventtime=1572471876 src=192.0.2.101 spt=49260 deviceInboundInterface=port1 FortinetFortiGatesrcintfrole=undefined dst=192.0.2.1 dpt=80 deviceOutboundInterface=port2 FortinetFortiGatedstintfrole=undefined FortinetFortiGatepoluuid=bafe134e-c0ad-51e8-ed9c-52f798dd69d4 externalId=12812952 proto=6 FortinetFortiGateaction=timeout FortinetFortiGatepolicyid=1 FortinetFortiGatepolicytype=policy app=HTTP FortinetFortiGatedstcountry=Reserved FortinetFortiGatesrccountry=United States FortinetFortiGatetrandisp=dnat destinationTranslatedAddress=192.0.2.1 destinationTranslatedPort=80 FortinetFortiGateduration=20 out=48 in=144 FortinetFortiGatesentpkt=1 FortinetFortiGatercvdpkt=3 FortinetFortiGateappcat=unscanned FortinetFortiGatecrscore=5 FortinetFortiGatecraction=262144 FortinetFortiGatecrlevel=low"
   },
   "expected": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.4|00013|traffic:forward timeout|3|deviceExternalId=FGVM2V0000171868 FortinetFortiGatelogid=0000000013 cat=traffic:forward FortinetFortiGatesubtype=forward FortinetFortiGatelevel=notice FortinetFortiGatevd=root FortinetFortiGateeventtime=1572471876 src=1.1.1.1 spt=49260 deviceInboundInterface=port1 FortinetFortiGatesrcintfrole=undefined dst=192.0.2.1 dpt=80 deviceOutboundInterface=port2 FortinetFortiGatedstintfrole=undefined FortinetFortiGatepoluuid=bafe134e-c0ad-51e8-ed9c-52f798dd69d4 externalId=12812952 proto=6 FortinetFortiGateaction=timeout FortinetFortiGatepolicyid=1 FortinetFortiGatepolicytype=policy app=HTTP FortinetFortiGatedstcountry=Reserved FortinetFortiGatesrccountry=United States FortinetFortiGatetrandisp=dnat destinationTranslatedAddress=192.0.2.1 destinationTranslatedPort=80 FortinetFortiGateduration=20 out=48 in=144 FortinetFortiGatesentpkt=1 FortinetFortiGatercvdpkt=3 FortinetFortiGateappcat=unscanned FortinetFortiGatecrscore=5 FortinetFortiGatecraction=262144 FortinetFortiGatecrlevel=low",
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.4|00013|traffic:forward timeout|3|deviceExternalId=FGVM2V0000171868 FortinetFortiGatelogid=0000000013 cat=traffic:forward FortinetFortiGatesubtype=forward FortinetFortiGatelevel=notice FortinetFortiGatevd=root FortinetFortiGateeventtime=1572471876 src=192.0.2.101 spt=49260 deviceInboundInterface=port1 FortinetFortiGatesrcintfrole=undefined dst=192.0.2.1 dpt=80 deviceOutboundInterface=port2 FortinetFortiGatedstintfrole=undefined FortinetFortiGatepoluuid=bafe134e-c0ad-51e8-ed9c-52f798dd69d4 externalId=12812952 proto=6 FortinetFortiGateaction=timeout FortinetFortiGatepolicyid=1 FortinetFortiGatepolicytype=policy app=HTTP FortinetFortiGatedstcountry=Reserved FortinetFortiGatesrccountry=United States FortinetFortiGatetrandisp=dnat destinationTranslatedAddress=192.0.2.1 destinationTranslatedPort=80 FortinetFortiGateduration=20 out=48 in=144 FortinetFortiGatesentpkt=1 FortinetFortiGatercvdpkt=3 FortinetFortiGateappcat=unscanned FortinetFortiGatecrscore=5 FortinetFortiGatecraction=262144 FortinetFortiGatecrlevel=low",
     "event": {
       "action": "timeout",
       "category": "traffic",
@@ -71,8 +71,8 @@
     },
     "related": {
       "ip": [
-        "1.1.1.1",
-        "192.0.2.1"
+        "192.0.2.1",
+        "192.0.2.101"
       ]
     },
     "rule": {
@@ -80,12 +80,12 @@
       "ruleset": "policy"
     },
     "source": {
-      "address": "1.1.1.1",
+      "address": "192.0.2.101",
       "bytes": 48,
       "geo": {
         "country_name": "United States"
       },
-      "ip": "1.1.1.1",
+      "ip": "192.0.2.101",
       "packets": 1,
       "port": 49260
     }

--- a/Fortinet/fortigate/tests/traffic_forward.CEF-3.json
+++ b/Fortinet/fortigate/tests/traffic_forward.CEF-3.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|00013|traffic:forward close|3|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0000000013 cat=traffic:forward FTNTFGTsubtype=forward FTNTFGTlevel=notice FTNTFGTvd=vdom1 FTNTFGTeventtime=1545937675 src=10.1.100.11 spt=54190 deviceInboundInterface=port12 FTNTFGTsrcintfrole=undefined dst=192.0.2.1 dpt=443 deviceOutboundInterface=port11 FTNTFGTdstintfrole=undefined FTNTFGTpoluuid=c2d460aa-fe6f-51e8-9505-41b5117dfdd4 externalId=402 proto=6 act=close FTNTFGTpolicyid=1 FTNTFGTpolicytype=policy app=HTTPS FTNTFGTdstcountry=United States FTNTFGTsrccountry=Reserved FTNTFGTtrandisp=snat sourceTranslatedAddress=172.16.200.1 sourceTranslatedPort=54190 FTNTFGTappid=40568 FTNTFGTapp=HTTPS.BROWSER FTNTFGTappcat=Web.Client FTNTFGTapprisk=medium FTNTFGTapplist=g-default FTNTFGTduration=2 out=3652 in=146668 FTNTFGTsentpkt=58 FTNTFGTrcvdpkt=105 FTNTFGTutmaction=allow FTNTFGTcountapp=2"
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|00013|traffic:forward close|3|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0000000013 cat=traffic:forward FTNTFGTsubtype=forward FTNTFGTlevel=notice FTNTFGTvd=vdom1 FTNTFGTeventtime=1545937675 src=198.51.100.11 spt=54190 deviceInboundInterface=port12 FTNTFGTsrcintfrole=undefined dst=192.0.2.1 dpt=443 deviceOutboundInterface=port11 FTNTFGTdstintfrole=undefined FTNTFGTpoluuid=c2d460aa-fe6f-51e8-9505-41b5117dfdd4 externalId=402 proto=6 act=close FTNTFGTpolicyid=1 FTNTFGTpolicytype=policy app=HTTPS FTNTFGTdstcountry=United States FTNTFGTsrccountry=Reserved FTNTFGTtrandisp=snat sourceTranslatedAddress=203.0.113.1 sourceTranslatedPort=54190 FTNTFGTappid=40568 FTNTFGTapp=HTTPS.BROWSER FTNTFGTappcat=Web.Client FTNTFGTapprisk=medium FTNTFGTapplist=g-default FTNTFGTduration=2 out=3652 in=146668 FTNTFGTsentpkt=58 FTNTFGTrcvdpkt=105 FTNTFGTutmaction=allow FTNTFGTcountapp=2"
   },
   "expected": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|00013|traffic:forward close|3|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0000000013 cat=traffic:forward FTNTFGTsubtype=forward FTNTFGTlevel=notice FTNTFGTvd=vdom1 FTNTFGTeventtime=1545937675 src=10.1.100.11 spt=54190 deviceInboundInterface=port12 FTNTFGTsrcintfrole=undefined dst=192.0.2.1 dpt=443 deviceOutboundInterface=port11 FTNTFGTdstintfrole=undefined FTNTFGTpoluuid=c2d460aa-fe6f-51e8-9505-41b5117dfdd4 externalId=402 proto=6 act=close FTNTFGTpolicyid=1 FTNTFGTpolicytype=policy app=HTTPS FTNTFGTdstcountry=United States FTNTFGTsrccountry=Reserved FTNTFGTtrandisp=snat sourceTranslatedAddress=172.16.200.1 sourceTranslatedPort=54190 FTNTFGTappid=40568 FTNTFGTapp=HTTPS.BROWSER FTNTFGTappcat=Web.Client FTNTFGTapprisk=medium FTNTFGTapplist=g-default FTNTFGTduration=2 out=3652 in=146668 FTNTFGTsentpkt=58 FTNTFGTrcvdpkt=105 FTNTFGTutmaction=allow FTNTFGTcountapp=2",
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|00013|traffic:forward close|3|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0000000013 cat=traffic:forward FTNTFGTsubtype=forward FTNTFGTlevel=notice FTNTFGTvd=vdom1 FTNTFGTeventtime=1545937675 src=198.51.100.11 spt=54190 deviceInboundInterface=port12 FTNTFGTsrcintfrole=undefined dst=192.0.2.1 dpt=443 deviceOutboundInterface=port11 FTNTFGTdstintfrole=undefined FTNTFGTpoluuid=c2d460aa-fe6f-51e8-9505-41b5117dfdd4 externalId=402 proto=6 act=close FTNTFGTpolicyid=1 FTNTFGTpolicytype=policy app=HTTPS FTNTFGTdstcountry=United States FTNTFGTsrccountry=Reserved FTNTFGTtrandisp=snat sourceTranslatedAddress=203.0.113.1 sourceTranslatedPort=54190 FTNTFGTappid=40568 FTNTFGTapp=HTTPS.BROWSER FTNTFGTappcat=Web.Client FTNTFGTapprisk=medium FTNTFGTapplist=g-default FTNTFGTduration=2 out=3652 in=146668 FTNTFGTsentpkt=58 FTNTFGTrcvdpkt=105 FTNTFGTutmaction=allow FTNTFGTcountapp=2",
     "event": {
       "action": "close",
       "category": "traffic",
@@ -68,9 +68,9 @@
     },
     "related": {
       "ip": [
-        "10.1.100.11",
-        "172.16.200.1",
-        "192.0.2.1"
+        "192.0.2.1",
+        "198.51.100.11",
+        "203.0.113.1"
       ]
     },
     "rule": {
@@ -79,11 +79,11 @@
       "ruleset": "g-default"
     },
     "source": {
-      "address": "10.1.100.11",
+      "address": "198.51.100.11",
       "bytes": 3652,
-      "ip": "10.1.100.11",
+      "ip": "198.51.100.11",
       "nat": {
-        "ip": "172.16.200.1",
+        "ip": "203.0.113.1",
         "port": 54190
       },
       "packets": 58,

--- a/Fortinet/fortigate/tests/traffic_forward.CEF-3.json
+++ b/Fortinet/fortigate/tests/traffic_forward.CEF-3.json
@@ -45,9 +45,9 @@
       "level": "notice"
     },
     "network": {
-      "application": "HTTPS",
+      "application": "HTTPS.BROWSER",
       "bytes": 150320,
-      "protocol": "https",
+      "protocol": "https.browser",
       "transport": "tcp"
     },
     "observer": {

--- a/Fortinet/fortigate/tests/traffic_forward.CEF-4.json
+++ b/Fortinet/fortigate/tests/traffic_forward.CEF-4.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "message": "CEF:0|Fortinet|Fortigate|v7.2.8|00013|traffic:forward client-rst|3|deviceExternalId=FGTEXAMPLE subtype=forward FTNTFGTlevel=notice FTNTFGTvd=root src=1.2.3.4 shost=example.com spt=59020 deviceInboundInterface=LAN-EX-SRV FTNTFGTsrcintfrole=lan dst=5.6.7.8 dpt=65359 deviceOutboundInterface=CASio-1_0 FTNTFGTdstintfrole=wan FTNTFGTsrccountry=Reserved FTNTFGTdstcountry=Reserved externalId=26368100 proto=6 act=client-rst FTNTFGTpolicyid=353 FTNTFGTpolicytype=policy FTNTFGTpoluuid=2967ec4c-c4d7-51ed-30a5-720dc6023629 FTNTFGTpolicyname=AD-CASio_TO_DC app=tcp/65359 FTNTFGTtrandisp=noop FTNTFGTduration=175 out=3608 in=2571 FTNTFGTsentpkt=15 FTNTFGTrcvdpkt=11 FTNTFGTvpntype=ipsecvpn FTNTFGTvwlid=4 FTNTFGTvwlquality=Seq_num(1 CASIio-1_0), alive, selected FTNTFGTvwlname=TO_JOE FTNTFGTappcat=unscanned FTNTFGTpsrcport=58624 FTNTFGTpdstport=135 FTNTFGTsentdelta=80 FTNTFGTrcvddelta=2519 FTNTFGTsrchwvendor=VMware FTNTFGTosname=Windows FTNTFGTsrcswversion=10 FTNTFGTunauthuser=REDACTED FTNTFGTunauthusersource=kerberos FTNTFGTmastersrcmac=02:00:00:00:00:00 FTNTFGTsrcmac=02:00:00:00:00:00 FTNTFGTsrcserver=0\n",
+    "message": "CEF:0|Fortinet|Fortigate|v7.2.8|00013|traffic:forward client-rst|3|deviceExternalId=FGTEXAMPLE subtype=forward FTNTFGTlevel=notice FTNTFGTvd=root src=198.51.100.4 shost=example.com spt=59020 deviceInboundInterface=LAN-EX-SRV FTNTFGTsrcintfrole=lan dst=203.0.113.8 dpt=65359 deviceOutboundInterface=CASio-1_0 FTNTFGTdstintfrole=wan FTNTFGTsrccountry=Reserved FTNTFGTdstcountry=Reserved externalId=26368100 proto=6 act=client-rst FTNTFGTpolicyid=353 FTNTFGTpolicytype=policy FTNTFGTpoluuid=2967ec4c-c4d7-51ed-30a5-720dc6023629 FTNTFGTpolicyname=AD-CASio_TO_DC app=tcp/65359 FTNTFGTtrandisp=noop FTNTFGTduration=175 out=3608 in=2571 FTNTFGTsentpkt=15 FTNTFGTrcvdpkt=11 FTNTFGTvpntype=ipsecvpn FTNTFGTvwlid=4 FTNTFGTvwlquality=Seq_num(1 CASIio-1_0), alive, selected FTNTFGTvwlname=TO_JOE FTNTFGTappcat=unscanned FTNTFGTpsrcport=58624 FTNTFGTpdstport=135 FTNTFGTsentdelta=80 FTNTFGTrcvddelta=2519 FTNTFGTsrchwvendor=VMware FTNTFGTosname=Windows FTNTFGTsrcswversion=10 FTNTFGTunauthuser=REDACTED FTNTFGTunauthusersource=kerberos FTNTFGTmastersrcmac=02:00:00:00:00:00 FTNTFGTsrcmac=02:00:00:00:00:00 FTNTFGTsrcserver=0\n",
     "sekoiaio": {
       "intake": {
         "dialect": "Fortinet FortiGate",
@@ -9,7 +9,7 @@
     }
   },
   "expected": {
-    "message": "CEF:0|Fortinet|Fortigate|v7.2.8|00013|traffic:forward client-rst|3|deviceExternalId=FGTEXAMPLE subtype=forward FTNTFGTlevel=notice FTNTFGTvd=root src=1.2.3.4 shost=example.com spt=59020 deviceInboundInterface=LAN-EX-SRV FTNTFGTsrcintfrole=lan dst=5.6.7.8 dpt=65359 deviceOutboundInterface=CASio-1_0 FTNTFGTdstintfrole=wan FTNTFGTsrccountry=Reserved FTNTFGTdstcountry=Reserved externalId=26368100 proto=6 act=client-rst FTNTFGTpolicyid=353 FTNTFGTpolicytype=policy FTNTFGTpoluuid=2967ec4c-c4d7-51ed-30a5-720dc6023629 FTNTFGTpolicyname=AD-CASio_TO_DC app=tcp/65359 FTNTFGTtrandisp=noop FTNTFGTduration=175 out=3608 in=2571 FTNTFGTsentpkt=15 FTNTFGTrcvdpkt=11 FTNTFGTvpntype=ipsecvpn FTNTFGTvwlid=4 FTNTFGTvwlquality=Seq_num(1 CASIio-1_0), alive, selected FTNTFGTvwlname=TO_JOE FTNTFGTappcat=unscanned FTNTFGTpsrcport=58624 FTNTFGTpdstport=135 FTNTFGTsentdelta=80 FTNTFGTrcvddelta=2519 FTNTFGTsrchwvendor=VMware FTNTFGTosname=Windows FTNTFGTsrcswversion=10 FTNTFGTunauthuser=REDACTED FTNTFGTunauthusersource=kerberos FTNTFGTmastersrcmac=02:00:00:00:00:00 FTNTFGTsrcmac=02:00:00:00:00:00 FTNTFGTsrcserver=0\n",
+    "message": "CEF:0|Fortinet|Fortigate|v7.2.8|00013|traffic:forward client-rst|3|deviceExternalId=FGTEXAMPLE subtype=forward FTNTFGTlevel=notice FTNTFGTvd=root src=198.51.100.4 shost=example.com spt=59020 deviceInboundInterface=LAN-EX-SRV FTNTFGTsrcintfrole=lan dst=203.0.113.8 dpt=65359 deviceOutboundInterface=CASio-1_0 FTNTFGTdstintfrole=wan FTNTFGTsrccountry=Reserved FTNTFGTdstcountry=Reserved externalId=26368100 proto=6 act=client-rst FTNTFGTpolicyid=353 FTNTFGTpolicytype=policy FTNTFGTpoluuid=2967ec4c-c4d7-51ed-30a5-720dc6023629 FTNTFGTpolicyname=AD-CASio_TO_DC app=tcp/65359 FTNTFGTtrandisp=noop FTNTFGTduration=175 out=3608 in=2571 FTNTFGTsentpkt=15 FTNTFGTrcvdpkt=11 FTNTFGTvpntype=ipsecvpn FTNTFGTvwlid=4 FTNTFGTvwlquality=Seq_num(1 CASIio-1_0), alive, selected FTNTFGTvwlname=TO_JOE FTNTFGTappcat=unscanned FTNTFGTpsrcport=58624 FTNTFGTpdstport=135 FTNTFGTsentdelta=80 FTNTFGTrcvddelta=2519 FTNTFGTsrchwvendor=VMware FTNTFGTosname=Windows FTNTFGTsrcswversion=10 FTNTFGTunauthuser=REDACTED FTNTFGTunauthusersource=kerberos FTNTFGTmastersrcmac=02:00:00:00:00:00 FTNTFGTsrcmac=02:00:00:00:00:00 FTNTFGTsrcserver=0\n",
     "event": {
       "action": "client-rst",
       "category": "traffic",
@@ -25,9 +25,9 @@
       "type": "forward"
     },
     "destination": {
-      "address": "5.6.7.8",
+      "address": "203.0.113.8",
       "bytes": 2571,
-      "ip": "5.6.7.8",
+      "ip": "203.0.113.8",
       "packets": 11,
       "port": 65359
     },
@@ -82,8 +82,8 @@
         "example.com"
       ],
       "ip": [
-        "1.2.3.4",
-        "5.6.7.8"
+        "198.51.100.4",
+        "203.0.113.8"
       ],
       "user": [
         "REDACTED"
@@ -97,7 +97,7 @@
       "address": "example.com",
       "bytes": 3608,
       "domain": "example.com",
-      "ip": "1.2.3.4",
+      "ip": "198.51.100.4",
       "mac": "02:00:00:00:00:00",
       "packets": 15,
       "port": 59020,

--- a/Fortinet/fortigate/tests/traffic_forward.CEF-5.json
+++ b/Fortinet/fortigate/tests/traffic_forward.CEF-5.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "message": "0|Fortinet|Fortigate|v7.2.10|00011|traffic:forward ip-conn|4|deviceExternalId=FGT40FTK23052620 FTNTFGTeventtime=1737553257865429339 FTNTFGTtz=+0100 FTNTFGTlogid=0000000011 cat=traffic:forward FTNTFGTsubtype=forward FTNTFGTlevel=warning FTNTFGTvd=root src=1.2.3.4 shost=example.com spt=53272 deviceInboundInterface=interface_02 FTNTFGTsrcintfrole=lan dst=5.6.7.8 dpt=443 deviceOutboundInterface=interface_01 FTNTFGTdstintfrole=undefined FTNTFGTsrccountry=Reserved FTNTFGTdstcountry=France externalId=1248357 proto=6 act=ip-conn FTNTFGTpolicyid=6 FTNTFGTpolicytype=policy FTNTFGTpoluuid=c2d241ae-2bb9-51ee-e76b-094ea7f446e8 app=HTTPS FTNTFGTappcat=unscanned FTNTFGTcrscore=5 FTNTFGTcraction=262144 FTNTFGTcrlevel=low FTNTFGTosname=Windows FTNTFGTsrcswversion=10 / 2016 FTNTFGTunauthuser=jdoe FTNTFGTunauthusersource=kerberos FTNTFGTmastersrcmac=02:00:00:00:00:00 FTNTFGTsrcmac=02:00:00:00:00:00 FTNTFGTsrcserver=0\n```<br><br><i>(created from <a href=https://sekoia8055.zendesk.com/agent/tickets/5534>Zendesk ticket #5534</a>)<br> gz#5534</i>",
+    "message": "0|Fortinet|Fortigate|v7.2.10|00011|traffic:forward ip-conn|4|deviceExternalId=FGT40FTK23052620 FTNTFGTeventtime=1737553257865429339 FTNTFGTtz=+0100 FTNTFGTlogid=0000000011 cat=traffic:forward FTNTFGTsubtype=forward FTNTFGTlevel=warning FTNTFGTvd=root src=198.51.100.4 shost=example.com spt=53272 deviceInboundInterface=interface_02 FTNTFGTsrcintfrole=lan dst=203.0.113.8 dpt=443 deviceOutboundInterface=interface_01 FTNTFGTdstintfrole=undefined FTNTFGTsrccountry=Reserved FTNTFGTdstcountry=France externalId=1248357 proto=6 act=ip-conn FTNTFGTpolicyid=6 FTNTFGTpolicytype=policy FTNTFGTpoluuid=c2d241ae-2bb9-51ee-e76b-094ea7f446e8 app=HTTPS FTNTFGTappcat=unscanned FTNTFGTcrscore=5 FTNTFGTcraction=262144 FTNTFGTcrlevel=low FTNTFGTosname=Windows FTNTFGTsrcswversion=10 / 2016 FTNTFGTunauthuser=jdoe FTNTFGTunauthusersource=kerberos FTNTFGTmastersrcmac=02:00:00:00:00:00 FTNTFGTsrcmac=02:00:00:00:00:00 FTNTFGTsrcserver=0\n```<br><br><i>(created from <a href=https://sekoia8055.zendesk.com/agent/tickets/5534>Zendesk ticket #5534</a>)<br> gz#5534</i>",
     "sekoiaio": {
       "intake": {
         "dialect": "Fortinet FortiGate",
@@ -9,7 +9,7 @@
     }
   },
   "expected": {
-    "message": "0|Fortinet|Fortigate|v7.2.10|00011|traffic:forward ip-conn|4|deviceExternalId=FGT40FTK23052620 FTNTFGTeventtime=1737553257865429339 FTNTFGTtz=+0100 FTNTFGTlogid=0000000011 cat=traffic:forward FTNTFGTsubtype=forward FTNTFGTlevel=warning FTNTFGTvd=root src=1.2.3.4 shost=example.com spt=53272 deviceInboundInterface=interface_02 FTNTFGTsrcintfrole=lan dst=5.6.7.8 dpt=443 deviceOutboundInterface=interface_01 FTNTFGTdstintfrole=undefined FTNTFGTsrccountry=Reserved FTNTFGTdstcountry=France externalId=1248357 proto=6 act=ip-conn FTNTFGTpolicyid=6 FTNTFGTpolicytype=policy FTNTFGTpoluuid=c2d241ae-2bb9-51ee-e76b-094ea7f446e8 app=HTTPS FTNTFGTappcat=unscanned FTNTFGTcrscore=5 FTNTFGTcraction=262144 FTNTFGTcrlevel=low FTNTFGTosname=Windows FTNTFGTsrcswversion=10 / 2016 FTNTFGTunauthuser=jdoe FTNTFGTunauthusersource=kerberos FTNTFGTmastersrcmac=02:00:00:00:00:00 FTNTFGTsrcmac=02:00:00:00:00:00 FTNTFGTsrcserver=0\n```<br><br><i>(created from <a href=https://sekoia8055.zendesk.com/agent/tickets/5534>Zendesk ticket #5534</a>)<br> gz#5534</i>",
+    "message": "0|Fortinet|Fortigate|v7.2.10|00011|traffic:forward ip-conn|4|deviceExternalId=FGT40FTK23052620 FTNTFGTeventtime=1737553257865429339 FTNTFGTtz=+0100 FTNTFGTlogid=0000000011 cat=traffic:forward FTNTFGTsubtype=forward FTNTFGTlevel=warning FTNTFGTvd=root src=198.51.100.4 shost=example.com spt=53272 deviceInboundInterface=interface_02 FTNTFGTsrcintfrole=lan dst=203.0.113.8 dpt=443 deviceOutboundInterface=interface_01 FTNTFGTdstintfrole=undefined FTNTFGTsrccountry=Reserved FTNTFGTdstcountry=France externalId=1248357 proto=6 act=ip-conn FTNTFGTpolicyid=6 FTNTFGTpolicytype=policy FTNTFGTpoluuid=c2d241ae-2bb9-51ee-e76b-094ea7f446e8 app=HTTPS FTNTFGTappcat=unscanned FTNTFGTcrscore=5 FTNTFGTcraction=262144 FTNTFGTcrlevel=low FTNTFGTosname=Windows FTNTFGTsrcswversion=10 / 2016 FTNTFGTunauthuser=jdoe FTNTFGTunauthusersource=kerberos FTNTFGTmastersrcmac=02:00:00:00:00:00 FTNTFGTsrcmac=02:00:00:00:00:00 FTNTFGTsrcserver=0\n```<br><br><i>(created from <a href=https://sekoia8055.zendesk.com/agent/tickets/5534>Zendesk ticket #5534</a>)<br> gz#5534</i>",
     "event": {
       "action": "ip-conn",
       "category": "traffic",
@@ -26,11 +26,11 @@
       "type": "forward"
     },
     "destination": {
-      "address": "5.6.7.8",
+      "address": "203.0.113.8",
       "geo": {
         "country_name": "France"
       },
-      "ip": "5.6.7.8",
+      "ip": "203.0.113.8",
       "port": 443
     },
     "fortinet": {
@@ -84,8 +84,8 @@
         "example.com"
       ],
       "ip": [
-        "1.2.3.4",
-        "5.6.7.8"
+        "198.51.100.4",
+        "203.0.113.8"
       ],
       "user": [
         "jdoe"
@@ -98,7 +98,7 @@
     "source": {
       "address": "example.com",
       "domain": "example.com",
-      "ip": "1.2.3.4",
+      "ip": "198.51.100.4",
       "mac": "02:00:00:00:00:00",
       "port": 53272,
       "registered_domain": "example.com",

--- a/Fortinet/fortigate/tests/traffic_forward.CEF-6.json
+++ b/Fortinet/fortigate/tests/traffic_forward.CEF-6.json
@@ -44,9 +44,9 @@
       "level": "notice"
     },
     "network": {
-      "application": "TCP_8093",
+      "application": "SSL_TLSv1.3",
       "bytes": 4151,
-      "protocol": "tcp_8093",
+      "protocol": "ssl_tlsv1.3",
       "transport": "tcp"
     },
     "observer": {

--- a/Fortinet/fortigate/tests/traffic_forward.CEF-6.json
+++ b/Fortinet/fortigate/tests/traffic_forward.CEF-6.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "CEF:0|Fortinet|Fortigate|v7.4.9|00013|traffic:forward close|3|deviceExternalId=FGTEXAMPLE FTNTFGTeventtime=1762443492031974938 FTNTFGTtz=+0100 FTNTFGTlogid=0000000013 cat=traffic:forward FTNTFGTsubtype=forward FTNTFGTlevel=notice FTNTFGTvd=root src=1.2.3.4 spt=64746 deviceInboundInterface=port2 FTNTFGTsrcintfrole=dmz dst=192.168.115.11 dpt=8093 deviceOutboundInterface=port10 FTNTFGTdstintfrole=dmz FTNTFGTsrccountry=Reserved FTNTFGTdstcountry=Reserved externalId=1234 proto=6 act=close FTNTFGTpolicyid=859 FTNTFGTpolicytype=policy FTNTFGTpoluuid=00000000-0000-0000-0000-000000000000 FTNTFGTpolicyname=Filtrage ID Eset app=TCP_8093 FTNTFGTtrandisp=noop FTNTFGTappid=47013 FTNTFGTapp=SSL_TLSv1.3 FTNTFGTappcat=Network.Service FTNTFGTapprisk=medium FTNTFGTapplist=g-APP_MONITOR FTNTFGTduration=92 out=1504 in=2647 FTNTFGTsentpkt=9 FTNTFGTrcvdpkt=9 FTNTFGTutmaction=allow FTNTFGTcountapp=2"
+    "message": "CEF:0|Fortinet|Fortigate|v7.4.9|00013|traffic:forward close|3|deviceExternalId=FGTEXAMPLE FTNTFGTeventtime=1762443492031974938 FTNTFGTtz=+0100 FTNTFGTlogid=0000000013 cat=traffic:forward FTNTFGTsubtype=forward FTNTFGTlevel=notice FTNTFGTvd=root src=198.51.100.4 spt=64746 deviceInboundInterface=port2 FTNTFGTsrcintfrole=dmz dst=192.0.2.11 dpt=8093 deviceOutboundInterface=port10 FTNTFGTdstintfrole=dmz FTNTFGTsrccountry=Reserved FTNTFGTdstcountry=Reserved externalId=1234 proto=6 act=close FTNTFGTpolicyid=859 FTNTFGTpolicytype=policy FTNTFGTpoluuid=00000000-0000-0000-0000-000000000000 FTNTFGTpolicyname=Filtrage ID Eset app=TCP_8093 FTNTFGTtrandisp=noop FTNTFGTappid=47013 FTNTFGTapp=SSL_TLSv1.3 FTNTFGTappcat=Network.Service FTNTFGTapprisk=medium FTNTFGTapplist=g-APP_MONITOR FTNTFGTduration=92 out=1504 in=2647 FTNTFGTsentpkt=9 FTNTFGTrcvdpkt=9 FTNTFGTutmaction=allow FTNTFGTcountapp=2"
   },
   "expected": {
-    "message": "CEF:0|Fortinet|Fortigate|v7.4.9|00013|traffic:forward close|3|deviceExternalId=FGTEXAMPLE FTNTFGTeventtime=1762443492031974938 FTNTFGTtz=+0100 FTNTFGTlogid=0000000013 cat=traffic:forward FTNTFGTsubtype=forward FTNTFGTlevel=notice FTNTFGTvd=root src=1.2.3.4 spt=64746 deviceInboundInterface=port2 FTNTFGTsrcintfrole=dmz dst=192.168.115.11 dpt=8093 deviceOutboundInterface=port10 FTNTFGTdstintfrole=dmz FTNTFGTsrccountry=Reserved FTNTFGTdstcountry=Reserved externalId=1234 proto=6 act=close FTNTFGTpolicyid=859 FTNTFGTpolicytype=policy FTNTFGTpoluuid=00000000-0000-0000-0000-000000000000 FTNTFGTpolicyname=Filtrage ID Eset app=TCP_8093 FTNTFGTtrandisp=noop FTNTFGTappid=47013 FTNTFGTapp=SSL_TLSv1.3 FTNTFGTappcat=Network.Service FTNTFGTapprisk=medium FTNTFGTapplist=g-APP_MONITOR FTNTFGTduration=92 out=1504 in=2647 FTNTFGTsentpkt=9 FTNTFGTrcvdpkt=9 FTNTFGTutmaction=allow FTNTFGTcountapp=2",
+    "message": "CEF:0|Fortinet|Fortigate|v7.4.9|00013|traffic:forward close|3|deviceExternalId=FGTEXAMPLE FTNTFGTeventtime=1762443492031974938 FTNTFGTtz=+0100 FTNTFGTlogid=0000000013 cat=traffic:forward FTNTFGTsubtype=forward FTNTFGTlevel=notice FTNTFGTvd=root src=198.51.100.4 spt=64746 deviceInboundInterface=port2 FTNTFGTsrcintfrole=dmz dst=192.0.2.11 dpt=8093 deviceOutboundInterface=port10 FTNTFGTdstintfrole=dmz FTNTFGTsrccountry=Reserved FTNTFGTdstcountry=Reserved externalId=1234 proto=6 act=close FTNTFGTpolicyid=859 FTNTFGTpolicytype=policy FTNTFGTpoluuid=00000000-0000-0000-0000-000000000000 FTNTFGTpolicyname=Filtrage ID Eset app=TCP_8093 FTNTFGTtrandisp=noop FTNTFGTappid=47013 FTNTFGTapp=SSL_TLSv1.3 FTNTFGTappcat=Network.Service FTNTFGTapprisk=medium FTNTFGTapplist=g-APP_MONITOR FTNTFGTduration=92 out=1504 in=2647 FTNTFGTsentpkt=9 FTNTFGTrcvdpkt=9 FTNTFGTutmaction=allow FTNTFGTcountapp=2",
     "event": {
       "action": "close",
       "category": "traffic",
@@ -21,9 +21,9 @@
       "type": "forward"
     },
     "destination": {
-      "address": "192.168.115.11",
+      "address": "192.0.2.11",
       "bytes": 2647,
-      "ip": "192.168.115.11",
+      "ip": "192.0.2.11",
       "packets": 9,
       "port": 8093
     },
@@ -69,8 +69,8 @@
     },
     "related": {
       "ip": [
-        "1.2.3.4",
-        "192.168.115.11"
+        "192.0.2.11",
+        "198.51.100.4"
       ]
     },
     "rule": {
@@ -79,9 +79,9 @@
       "ruleset": "g-APP_MONITOR"
     },
     "source": {
-      "address": "1.2.3.4",
+      "address": "198.51.100.4",
       "bytes": 1504,
-      "ip": "1.2.3.4",
+      "ip": "198.51.100.4",
       "packets": 9,
       "port": 64746
     }

--- a/Fortinet/fortigate/tests/traffic_forward.CEF-7.json
+++ b/Fortinet/fortigate/tests/traffic_forward.CEF-7.json
@@ -53,9 +53,9 @@
       "level": "notice"
     },
     "network": {
-      "application": "http_https_proxy",
+      "application": "TrendMicro.IWSVA",
       "bytes": 958,
-      "protocol": "http_https_proxy",
+      "protocol": "trendmicro.iwsva",
       "transport": "tcp"
     },
     "observer": {

--- a/Fortinet/fortigate/tests/traffic_forward.CEF-7.json
+++ b/Fortinet/fortigate/tests/traffic_forward.CEF-7.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "CEF:0|Fortinet|Fortigate|v7.4.9|00013|traffic:forward client-rst|3|deviceExternalId=FGTEXAMPLE FTNTFGTeventtime=1762521404541985717 FTNTFGTtz=+0100 FTNTFGTlogid=0000000013 cat=traffic:forward FTNTFGTsubtype=forward FTNTFGTlevel=notice FTNTFGTvd=root src=1.2.3.4 spt=56006 deviceInboundInterface=port2 FTNTFGTsrcintfrole=dmz dst=192.168.100.7 dpt=8080 deviceOutboundInterface=port1 FTNTFGTdstintfrole=dmz FTNTFGTsrccountry=Reserved FTNTFGTdstcountry=Reserved externalId=1234 proto=6 act=client-rst FTNTFGTpolicyid=860 FTNTFGTpolicytype=policy FTNTFGTpoluuid=00000000-0000-0000-0000-000000000000 FTNTFGTpolicyname=Filtrage ID Proxy duser=USER1 FTNTFGTauthserver=FSSO_collector_agent-1 FTNTFGTdstuser=USER2 app=http_https_proxy FTNTFGTtrandisp=noop FTNTFGTappid=52305 FTNTFGTapp=TrendMicro.IWSVA FTNTFGTappcat=Cloud.IT FTNTFGTapprisk=low FTNTFGTapplist=g-APP_MONITOR FTNTFGTduration=35 out=440 in=518 FTNTFGTsentpkt=5 FTNTFGTrcvdpkt=5 FTNTFGTutmaction=allow FTNTFGTcountapp=2 FTNTFGTcrscore=10 FTNTFGTcraction=1048576 msg=Connection Failed"
+    "message": "CEF:0|Fortinet|Fortigate|v7.4.9|00013|traffic:forward client-rst|3|deviceExternalId=FGTEXAMPLE FTNTFGTeventtime=1762521404541985717 FTNTFGTtz=+0100 FTNTFGTlogid=0000000013 cat=traffic:forward FTNTFGTsubtype=forward FTNTFGTlevel=notice FTNTFGTvd=root src=198.51.100.4 spt=56006 deviceInboundInterface=port2 FTNTFGTsrcintfrole=dmz dst=192.0.2.7 dpt=8080 deviceOutboundInterface=port1 FTNTFGTdstintfrole=dmz FTNTFGTsrccountry=Reserved FTNTFGTdstcountry=Reserved externalId=1234 proto=6 act=client-rst FTNTFGTpolicyid=860 FTNTFGTpolicytype=policy FTNTFGTpoluuid=00000000-0000-0000-0000-000000000000 FTNTFGTpolicyname=Filtrage ID Proxy duser=USER1 FTNTFGTauthserver=FSSO_collector_agent-1 FTNTFGTdstuser=USER2 app=http_https_proxy FTNTFGTtrandisp=noop FTNTFGTappid=52305 FTNTFGTapp=TrendMicro.IWSVA FTNTFGTappcat=Cloud.IT FTNTFGTapprisk=low FTNTFGTapplist=g-APP_MONITOR FTNTFGTduration=35 out=440 in=518 FTNTFGTsentpkt=5 FTNTFGTrcvdpkt=5 FTNTFGTutmaction=allow FTNTFGTcountapp=2 FTNTFGTcrscore=10 FTNTFGTcraction=1048576 msg=Connection Failed"
   },
   "expected": {
-    "message": "CEF:0|Fortinet|Fortigate|v7.4.9|00013|traffic:forward client-rst|3|deviceExternalId=FGTEXAMPLE FTNTFGTeventtime=1762521404541985717 FTNTFGTtz=+0100 FTNTFGTlogid=0000000013 cat=traffic:forward FTNTFGTsubtype=forward FTNTFGTlevel=notice FTNTFGTvd=root src=1.2.3.4 spt=56006 deviceInboundInterface=port2 FTNTFGTsrcintfrole=dmz dst=192.168.100.7 dpt=8080 deviceOutboundInterface=port1 FTNTFGTdstintfrole=dmz FTNTFGTsrccountry=Reserved FTNTFGTdstcountry=Reserved externalId=1234 proto=6 act=client-rst FTNTFGTpolicyid=860 FTNTFGTpolicytype=policy FTNTFGTpoluuid=00000000-0000-0000-0000-000000000000 FTNTFGTpolicyname=Filtrage ID Proxy duser=USER1 FTNTFGTauthserver=FSSO_collector_agent-1 FTNTFGTdstuser=USER2 app=http_https_proxy FTNTFGTtrandisp=noop FTNTFGTappid=52305 FTNTFGTapp=TrendMicro.IWSVA FTNTFGTappcat=Cloud.IT FTNTFGTapprisk=low FTNTFGTapplist=g-APP_MONITOR FTNTFGTduration=35 out=440 in=518 FTNTFGTsentpkt=5 FTNTFGTrcvdpkt=5 FTNTFGTutmaction=allow FTNTFGTcountapp=2 FTNTFGTcrscore=10 FTNTFGTcraction=1048576 msg=Connection Failed",
+    "message": "CEF:0|Fortinet|Fortigate|v7.4.9|00013|traffic:forward client-rst|3|deviceExternalId=FGTEXAMPLE FTNTFGTeventtime=1762521404541985717 FTNTFGTtz=+0100 FTNTFGTlogid=0000000013 cat=traffic:forward FTNTFGTsubtype=forward FTNTFGTlevel=notice FTNTFGTvd=root src=198.51.100.4 spt=56006 deviceInboundInterface=port2 FTNTFGTsrcintfrole=dmz dst=192.0.2.7 dpt=8080 deviceOutboundInterface=port1 FTNTFGTdstintfrole=dmz FTNTFGTsrccountry=Reserved FTNTFGTdstcountry=Reserved externalId=1234 proto=6 act=client-rst FTNTFGTpolicyid=860 FTNTFGTpolicytype=policy FTNTFGTpoluuid=00000000-0000-0000-0000-000000000000 FTNTFGTpolicyname=Filtrage ID Proxy duser=USER1 FTNTFGTauthserver=FSSO_collector_agent-1 FTNTFGTdstuser=USER2 app=http_https_proxy FTNTFGTtrandisp=noop FTNTFGTappid=52305 FTNTFGTapp=TrendMicro.IWSVA FTNTFGTappcat=Cloud.IT FTNTFGTapprisk=low FTNTFGTapplist=g-APP_MONITOR FTNTFGTduration=35 out=440 in=518 FTNTFGTsentpkt=5 FTNTFGTrcvdpkt=5 FTNTFGTutmaction=allow FTNTFGTcountapp=2 FTNTFGTcrscore=10 FTNTFGTcraction=1048576 msg=Connection Failed",
     "event": {
       "action": "client-rst",
       "category": "traffic",
@@ -23,9 +23,9 @@
       "type": "forward"
     },
     "destination": {
-      "address": "192.168.100.7",
+      "address": "192.0.2.7",
       "bytes": 518,
-      "ip": "192.168.100.7",
+      "ip": "192.0.2.7",
       "packets": 5,
       "port": 8080,
       "user": {
@@ -78,8 +78,8 @@
     },
     "related": {
       "ip": [
-        "1.2.3.4",
-        "192.168.100.7"
+        "192.0.2.7",
+        "198.51.100.4"
       ],
       "user": [
         "USER1",
@@ -92,9 +92,9 @@
       "ruleset": "g-APP_MONITOR"
     },
     "source": {
-      "address": "1.2.3.4",
+      "address": "198.51.100.4",
       "bytes": 440,
-      "ip": "1.2.3.4",
+      "ip": "198.51.100.4",
       "packets": 5,
       "port": 56006,
       "user": {

--- a/Fortinet/fortigate/tests/traffic_forward.CEF.json
+++ b/Fortinet/fortigate/tests/traffic_forward.CEF.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "CEF:0|Fortinet|Fortigate|v5.6.0|00013|traffic:forward close|3|FTNTFGTlogid=0000000013 cat=traffic:forward FTNTFGTsubtype=forward FTNTFGTlevel=notice FTNTFGTvd=vdom1 src=hostname shost=example spt=45719 deviceInboundInterface=port15 dst=hostname dhost=hostname dpt=80 deviceOutboundInterface=port19 FTNTFGTpoluuid=61c4243a-34ba-51e5-c32a-3859389a5162 externalId=56633 proto=6 act=close cs5=10 cs5Label=Policy Id FTNTFGTdstcountry=Reserved FTNTFGTsrccountry=Reserved FTNTFGTtrandisp=snat sourceTranslatedAddress=1.1.1.1 sourceTranslatedPort=45719 app=HTTP FTNTFGTappid=38783 FTNTFGTapp=Wget.Like FTNTFGTappcat=General.Interest FTNTFGTapprisk=low FTNTFGTapplist=default FTNTFGTappact=detected cn1=7 cn1Label=Duration out=398 in=1605 cn2=5 cn2Label=Packets Sent cn3=5 cn3Label=Packets Received FTNTFGTutmaction=block FTNTFGTcountav=1 FTNTFGTcountapp=1 FTNTFGTcrscore=50 FTNTFGTcraction=2"
+    "message": "CEF:0|Fortinet|Fortigate|v5.6.0|00013|traffic:forward close|3|FTNTFGTlogid=0000000013 cat=traffic:forward FTNTFGTsubtype=forward FTNTFGTlevel=notice FTNTFGTvd=vdom1 src=hostname shost=example spt=45719 deviceInboundInterface=port15 dst=hostname dhost=hostname dpt=80 deviceOutboundInterface=port19 FTNTFGTpoluuid=61c4243a-34ba-51e5-c32a-3859389a5162 externalId=56633 proto=6 act=close cs5=10 cs5Label=Policy Id FTNTFGTdstcountry=Reserved FTNTFGTsrccountry=Reserved FTNTFGTtrandisp=snat sourceTranslatedAddress=192.0.2.101 sourceTranslatedPort=45719 app=HTTP FTNTFGTappid=38783 FTNTFGTapp=Wget.Like FTNTFGTappcat=General.Interest FTNTFGTapprisk=low FTNTFGTapplist=default FTNTFGTappact=detected cn1=7 cn1Label=Duration out=398 in=1605 cn2=5 cn2Label=Packets Sent cn3=5 cn3Label=Packets Received FTNTFGTutmaction=block FTNTFGTcountav=1 FTNTFGTcountapp=1 FTNTFGTcrscore=50 FTNTFGTcraction=2"
   },
   "expected": {
-    "message": "CEF:0|Fortinet|Fortigate|v5.6.0|00013|traffic:forward close|3|FTNTFGTlogid=0000000013 cat=traffic:forward FTNTFGTsubtype=forward FTNTFGTlevel=notice FTNTFGTvd=vdom1 src=hostname shost=example spt=45719 deviceInboundInterface=port15 dst=hostname dhost=hostname dpt=80 deviceOutboundInterface=port19 FTNTFGTpoluuid=61c4243a-34ba-51e5-c32a-3859389a5162 externalId=56633 proto=6 act=close cs5=10 cs5Label=Policy Id FTNTFGTdstcountry=Reserved FTNTFGTsrccountry=Reserved FTNTFGTtrandisp=snat sourceTranslatedAddress=1.1.1.1 sourceTranslatedPort=45719 app=HTTP FTNTFGTappid=38783 FTNTFGTapp=Wget.Like FTNTFGTappcat=General.Interest FTNTFGTapprisk=low FTNTFGTapplist=default FTNTFGTappact=detected cn1=7 cn1Label=Duration out=398 in=1605 cn2=5 cn2Label=Packets Sent cn3=5 cn3Label=Packets Received FTNTFGTutmaction=block FTNTFGTcountav=1 FTNTFGTcountapp=1 FTNTFGTcrscore=50 FTNTFGTcraction=2",
+    "message": "CEF:0|Fortinet|Fortigate|v5.6.0|00013|traffic:forward close|3|FTNTFGTlogid=0000000013 cat=traffic:forward FTNTFGTsubtype=forward FTNTFGTlevel=notice FTNTFGTvd=vdom1 src=hostname shost=example spt=45719 deviceInboundInterface=port15 dst=hostname dhost=hostname dpt=80 deviceOutboundInterface=port19 FTNTFGTpoluuid=61c4243a-34ba-51e5-c32a-3859389a5162 externalId=56633 proto=6 act=close cs5=10 cs5Label=Policy Id FTNTFGTdstcountry=Reserved FTNTFGTsrccountry=Reserved FTNTFGTtrandisp=snat sourceTranslatedAddress=192.0.2.101 sourceTranslatedPort=45719 app=HTTP FTNTFGTappid=38783 FTNTFGTapp=Wget.Like FTNTFGTappcat=General.Interest FTNTFGTapprisk=low FTNTFGTapplist=default FTNTFGTappact=detected cn1=7 cn1Label=Duration out=398 in=1605 cn2=5 cn2Label=Packets Sent cn3=5 cn3Label=Packets Received FTNTFGTutmaction=block FTNTFGTcountav=1 FTNTFGTcountapp=1 FTNTFGTcrscore=50 FTNTFGTcraction=2",
     "event": {
       "action": "close",
       "category": "traffic",
@@ -68,7 +68,7 @@
         "hostname"
       ],
       "ip": [
-        "1.1.1.1"
+        "192.0.2.101"
       ]
     },
     "rule": {
@@ -81,7 +81,7 @@
       "bytes": 398,
       "domain": "example",
       "nat": {
-        "ip": "1.1.1.1",
+        "ip": "192.0.2.101",
         "port": 45719
       },
       "packets": 5,

--- a/Fortinet/fortigate/tests/traffic_forward.CEF.json
+++ b/Fortinet/fortigate/tests/traffic_forward.CEF.json
@@ -42,9 +42,9 @@
       "level": "notice"
     },
     "network": {
-      "application": "HTTP",
+      "application": "Wget.Like",
       "bytes": 2003,
-      "protocol": "http",
+      "protocol": "wget.like",
       "transport": "tcp"
     },
     "observer": {

--- a/Fortinet/fortigate/tests/traffic_forward.CSV.json
+++ b/Fortinet/fortigate/tests/traffic_forward.CSV.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "date=2018-07-26,time=16:51:36,logid=\"0000000013\",type=\"traffic\",subtype=\"forward\",level=\"notice\",vd=\"root\",eventtime=1532616695,srcip=1.1.1.1,srcport=10016,srcintf=\"test\",srcintfrole=\"undefined\",dstip=192.0.2.1,dstport=20,dstintf=\"dmz1\",dstintfrole=\"dmz\",sessionid=10006,proto=6,action=\"accept\",policyid=1,policytype=\"policy\",service=\"tcp/20\",dstcountry=\"France\",srccountry=\"United States\",trandisp=\"noop\",appid=35421,app=\"application\",appcat=\"Storage.Backup\",apprisk=\"medium\",applist=\"default\",duration=10,sentbyte=2000,rcvdbyte=1000,sentpkt=0,rcvdpkt=0,utmaction=\"allow\",countapp=1,devtype=\"iPad\",osname=\"Apple\",osversion=\"ver\",mastersrcmac=\"02:00:00:00:00:00\",srcmac=\"02:00:00:00:00:00\",srcserver=0,dstdevtype=\"Android Phone\",dstosname=\"Android\",dstosversion=\"ver\",masterdstmac=\"02:00:00:00:00:00\",dstmac=\"02:00:00:00:00:00\",dstserver=0,utmref=65491-194"
+    "message": "date=2018-07-26,time=16:51:36,logid=\"0000000013\",type=\"traffic\",subtype=\"forward\",level=\"notice\",vd=\"root\",eventtime=1532616695,srcip=192.0.2.101,srcport=10016,srcintf=\"test\",srcintfrole=\"undefined\",dstip=192.0.2.1,dstport=20,dstintf=\"dmz1\",dstintfrole=\"dmz\",sessionid=10006,proto=6,action=\"accept\",policyid=1,policytype=\"policy\",service=\"tcp/20\",dstcountry=\"France\",srccountry=\"United States\",trandisp=\"noop\",appid=35421,app=\"application\",appcat=\"Storage.Backup\",apprisk=\"medium\",applist=\"default\",duration=10,sentbyte=2000,rcvdbyte=1000,sentpkt=0,rcvdpkt=0,utmaction=\"allow\",countapp=1,devtype=\"iPad\",osname=\"Apple\",osversion=\"ver\",mastersrcmac=\"02:00:00:00:00:00\",srcmac=\"02:00:00:00:00:00\",srcserver=0,dstdevtype=\"Android Phone\",dstosname=\"Android\",dstosversion=\"ver\",masterdstmac=\"02:00:00:00:00:00\",dstmac=\"02:00:00:00:00:00\",dstserver=0,utmref=65491-194"
   },
   "expected": {
-    "message": "date=2018-07-26,time=16:51:36,logid=\"0000000013\",type=\"traffic\",subtype=\"forward\",level=\"notice\",vd=\"root\",eventtime=1532616695,srcip=1.1.1.1,srcport=10016,srcintf=\"test\",srcintfrole=\"undefined\",dstip=192.0.2.1,dstport=20,dstintf=\"dmz1\",dstintfrole=\"dmz\",sessionid=10006,proto=6,action=\"accept\",policyid=1,policytype=\"policy\",service=\"tcp/20\",dstcountry=\"France\",srccountry=\"United States\",trandisp=\"noop\",appid=35421,app=\"application\",appcat=\"Storage.Backup\",apprisk=\"medium\",applist=\"default\",duration=10,sentbyte=2000,rcvdbyte=1000,sentpkt=0,rcvdpkt=0,utmaction=\"allow\",countapp=1,devtype=\"iPad\",osname=\"Apple\",osversion=\"ver\",mastersrcmac=\"02:00:00:00:00:00\",srcmac=\"02:00:00:00:00:00\",srcserver=0,dstdevtype=\"Android Phone\",dstosname=\"Android\",dstosversion=\"ver\",masterdstmac=\"02:00:00:00:00:00\",dstmac=\"02:00:00:00:00:00\",dstserver=0,utmref=65491-194",
+    "message": "date=2018-07-26,time=16:51:36,logid=\"0000000013\",type=\"traffic\",subtype=\"forward\",level=\"notice\",vd=\"root\",eventtime=1532616695,srcip=192.0.2.101,srcport=10016,srcintf=\"test\",srcintfrole=\"undefined\",dstip=192.0.2.1,dstport=20,dstintf=\"dmz1\",dstintfrole=\"dmz\",sessionid=10006,proto=6,action=\"accept\",policyid=1,policytype=\"policy\",service=\"tcp/20\",dstcountry=\"France\",srccountry=\"United States\",trandisp=\"noop\",appid=35421,app=\"application\",appcat=\"Storage.Backup\",apprisk=\"medium\",applist=\"default\",duration=10,sentbyte=2000,rcvdbyte=1000,sentpkt=0,rcvdpkt=0,utmaction=\"allow\",countapp=1,devtype=\"iPad\",osname=\"Apple\",osversion=\"ver\",mastersrcmac=\"02:00:00:00:00:00\",srcmac=\"02:00:00:00:00:00\",srcserver=0,dstdevtype=\"Android Phone\",dstosname=\"Android\",dstosversion=\"ver\",masterdstmac=\"02:00:00:00:00:00\",dstmac=\"02:00:00:00:00:00\",dstserver=0,utmref=65491-194",
     "event": {
       "action": "accept",
       "category": "traffic",
@@ -74,8 +74,8 @@
     },
     "related": {
       "ip": [
-        "1.1.1.1",
-        "192.0.2.1"
+        "192.0.2.1",
+        "192.0.2.101"
       ]
     },
     "rule": {
@@ -84,12 +84,12 @@
       "ruleset": "default"
     },
     "source": {
-      "address": "1.1.1.1",
+      "address": "192.0.2.101",
       "bytes": 2000,
       "geo": {
         "country_name": "United States"
       },
-      "ip": "1.1.1.1",
+      "ip": "192.0.2.101",
       "mac": "02:00:00:00:00:00",
       "packets": 0,
       "port": 10016

--- a/Fortinet/fortigate/tests/traffic_forward.STANDARD.json
+++ b/Fortinet/fortigate/tests/traffic_forward.STANDARD.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "date=2018-07-26 time=16:51:36 logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"root\" eventtime=1532616695 srcip=1.1.1.1 srcport=10016 srcintf=\"test\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstport=20 dstintf=\"test1\" dstintfrole=\"dmz\" sessionid=10006 proto=6 action=\"accept\" policyid=1 policytype=\"policy\" service=\"tcp/20\" dstcountry=\"France\" srccountry=\"United States\" trandisp=\"noop\" appid=35421 app=\"Dropbox_File.Download\" appcat=\"Storage.Backup\" apprisk=\"medium\" applist=\"default\" duration=10 sentbyte=2000 rcvdbyte=1000 sentpkt=0 rcvdpkt=0 utmaction=\"allow\" countapp=1 devtype=\"iPad\" osname=\"Apple\" osversion=\"ver\" mastersrcmac=\"02:00:00:00:00:00\" srcmac=\"02:00:00:00:00:00\" srcserver=0 dstdevtype=\"Android Phone\" dstosname=\"Android\" dstosversion=\"ver\" masterdstmac=\"02:00:00:00:00:00\" dstmac=\"02:00:00:00:00:00\" dstserver=0 utmref=65491-194"
+    "message": "date=2018-07-26 time=16:51:36 logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"root\" eventtime=1532616695 srcip=192.0.2.101 srcport=10016 srcintf=\"test\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstport=20 dstintf=\"test1\" dstintfrole=\"dmz\" sessionid=10006 proto=6 action=\"accept\" policyid=1 policytype=\"policy\" service=\"tcp/20\" dstcountry=\"France\" srccountry=\"United States\" trandisp=\"noop\" appid=35421 app=\"Dropbox_File.Download\" appcat=\"Storage.Backup\" apprisk=\"medium\" applist=\"default\" duration=10 sentbyte=2000 rcvdbyte=1000 sentpkt=0 rcvdpkt=0 utmaction=\"allow\" countapp=1 devtype=\"iPad\" osname=\"Apple\" osversion=\"ver\" mastersrcmac=\"02:00:00:00:00:00\" srcmac=\"02:00:00:00:00:00\" srcserver=0 dstdevtype=\"Android Phone\" dstosname=\"Android\" dstosversion=\"ver\" masterdstmac=\"02:00:00:00:00:00\" dstmac=\"02:00:00:00:00:00\" dstserver=0 utmref=65491-194"
   },
   "expected": {
-    "message": "date=2018-07-26 time=16:51:36 logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"root\" eventtime=1532616695 srcip=1.1.1.1 srcport=10016 srcintf=\"test\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstport=20 dstintf=\"test1\" dstintfrole=\"dmz\" sessionid=10006 proto=6 action=\"accept\" policyid=1 policytype=\"policy\" service=\"tcp/20\" dstcountry=\"France\" srccountry=\"United States\" trandisp=\"noop\" appid=35421 app=\"Dropbox_File.Download\" appcat=\"Storage.Backup\" apprisk=\"medium\" applist=\"default\" duration=10 sentbyte=2000 rcvdbyte=1000 sentpkt=0 rcvdpkt=0 utmaction=\"allow\" countapp=1 devtype=\"iPad\" osname=\"Apple\" osversion=\"ver\" mastersrcmac=\"02:00:00:00:00:00\" srcmac=\"02:00:00:00:00:00\" srcserver=0 dstdevtype=\"Android Phone\" dstosname=\"Android\" dstosversion=\"ver\" masterdstmac=\"02:00:00:00:00:00\" dstmac=\"02:00:00:00:00:00\" dstserver=0 utmref=65491-194",
+    "message": "date=2018-07-26 time=16:51:36 logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"root\" eventtime=1532616695 srcip=192.0.2.101 srcport=10016 srcintf=\"test\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstport=20 dstintf=\"test1\" dstintfrole=\"dmz\" sessionid=10006 proto=6 action=\"accept\" policyid=1 policytype=\"policy\" service=\"tcp/20\" dstcountry=\"France\" srccountry=\"United States\" trandisp=\"noop\" appid=35421 app=\"Dropbox_File.Download\" appcat=\"Storage.Backup\" apprisk=\"medium\" applist=\"default\" duration=10 sentbyte=2000 rcvdbyte=1000 sentpkt=0 rcvdpkt=0 utmaction=\"allow\" countapp=1 devtype=\"iPad\" osname=\"Apple\" osversion=\"ver\" mastersrcmac=\"02:00:00:00:00:00\" srcmac=\"02:00:00:00:00:00\" srcserver=0 dstdevtype=\"Android Phone\" dstosname=\"Android\" dstosversion=\"ver\" masterdstmac=\"02:00:00:00:00:00\" dstmac=\"02:00:00:00:00:00\" dstserver=0 utmref=65491-194",
     "event": {
       "action": "accept",
       "category": "traffic",
@@ -74,8 +74,8 @@
     },
     "related": {
       "ip": [
-        "1.1.1.1",
-        "192.0.2.1"
+        "192.0.2.1",
+        "192.0.2.101"
       ]
     },
     "rule": {
@@ -84,12 +84,12 @@
       "ruleset": "default"
     },
     "source": {
-      "address": "1.1.1.1",
+      "address": "192.0.2.101",
       "bytes": 2000,
       "geo": {
         "country_name": "United States"
       },
-      "ip": "1.1.1.1",
+      "ip": "192.0.2.101",
       "mac": "02:00:00:00:00:00",
       "packets": 0,
       "port": 10016

--- a/Fortinet/fortigate/tests/traffic_forward.STANDARD_2.json
+++ b/Fortinet/fortigate/tests/traffic_forward.STANDARD_2.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "date=2021-06-21 time=09:38:29 devname=\"abc\" devid=\"1\" logid=\"0000000010\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"PRX1-AA\" eventtime=1624261109 srcip=1.1.1.1 srcport=50592 srcintf=\"port2\" srcintfrole=\"dmz\" dstip=192.0.2.1 dstport=443 dstintf=\"test\" dstintfrole=\"wan\" sessionid=1224900441 poluuid=\"1eb429d4-ff52-51ea-d119-d1db60e409a6\" dstcountry=\"United Kingdom\" srccountry=\"Reserved\" service=\"HTTPS\" wanoptapptype=\"web-proxy\" proto=6 action=\"accept\" duration=37 policyid=1 policytype=\"proxy-policy\" wanin=5851 rcvdbyte=5851 wanout=2523 lanin=2769 sentbyte=2769 lanout=5923 appcat=\"unscanned\" utmaction=\"allow\" countweb=1"
+    "message": "date=2021-06-21 time=09:38:29 devname=\"abc\" devid=\"1\" logid=\"0000000010\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"PRX1-AA\" eventtime=1624261109 srcip=192.0.2.101 srcport=50592 srcintf=\"port2\" srcintfrole=\"dmz\" dstip=192.0.2.1 dstport=443 dstintf=\"test\" dstintfrole=\"wan\" sessionid=1224900441 poluuid=\"1eb429d4-ff52-51ea-d119-d1db60e409a6\" dstcountry=\"United Kingdom\" srccountry=\"Reserved\" service=\"HTTPS\" wanoptapptype=\"web-proxy\" proto=6 action=\"accept\" duration=37 policyid=1 policytype=\"proxy-policy\" wanin=5851 rcvdbyte=5851 wanout=2523 lanin=2769 sentbyte=2769 lanout=5923 appcat=\"unscanned\" utmaction=\"allow\" countweb=1"
   },
   "expected": {
-    "message": "date=2021-06-21 time=09:38:29 devname=\"abc\" devid=\"1\" logid=\"0000000010\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"PRX1-AA\" eventtime=1624261109 srcip=1.1.1.1 srcport=50592 srcintf=\"port2\" srcintfrole=\"dmz\" dstip=192.0.2.1 dstport=443 dstintf=\"test\" dstintfrole=\"wan\" sessionid=1224900441 poluuid=\"1eb429d4-ff52-51ea-d119-d1db60e409a6\" dstcountry=\"United Kingdom\" srccountry=\"Reserved\" service=\"HTTPS\" wanoptapptype=\"web-proxy\" proto=6 action=\"accept\" duration=37 policyid=1 policytype=\"proxy-policy\" wanin=5851 rcvdbyte=5851 wanout=2523 lanin=2769 sentbyte=2769 lanout=5923 appcat=\"unscanned\" utmaction=\"allow\" countweb=1",
+    "message": "date=2021-06-21 time=09:38:29 devname=\"abc\" devid=\"1\" logid=\"0000000010\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"PRX1-AA\" eventtime=1624261109 srcip=192.0.2.101 srcport=50592 srcintf=\"port2\" srcintfrole=\"dmz\" dstip=192.0.2.1 dstport=443 dstintf=\"test\" dstintfrole=\"wan\" sessionid=1224900441 poluuid=\"1eb429d4-ff52-51ea-d119-d1db60e409a6\" dstcountry=\"United Kingdom\" srccountry=\"Reserved\" service=\"HTTPS\" wanoptapptype=\"web-proxy\" proto=6 action=\"accept\" duration=37 policyid=1 policytype=\"proxy-policy\" wanin=5851 rcvdbyte=5851 wanout=2523 lanin=2769 sentbyte=2769 lanout=5923 appcat=\"unscanned\" utmaction=\"allow\" countweb=1",
     "event": {
       "action": "accept",
       "category": "traffic",
@@ -71,8 +71,8 @@
         "abc"
       ],
       "ip": [
-        "1.1.1.1",
-        "192.0.2.1"
+        "192.0.2.1",
+        "192.0.2.101"
       ]
     },
     "rule": {
@@ -80,9 +80,9 @@
       "ruleset": "proxy-policy"
     },
     "source": {
-      "address": "1.1.1.1",
+      "address": "192.0.2.101",
       "bytes": 2769,
-      "ip": "1.1.1.1",
+      "ip": "192.0.2.101",
       "port": 50592
     }
   }

--- a/Fortinet/fortigate/tests/traffic_forward_FTNTFGTtz.CEF.json
+++ b/Fortinet/fortigate/tests/traffic_forward_FTNTFGTtz.CEF.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.4.9|00011|traffic:forward dns|4|deviceExternalId=FG5H0ETB19909686 FTNTFGTeventtime=1662381825920035319 FTNTFGTtz=+0200 FTNTFGTlogid=0000000011 cat=traffic:forward FTNTFGTsubtype=forward FTNTFGTlevel=warning FTNTFGTvd=root src=172.16.222.150 spt=49956 deviceInboundInterface=port1 FTNTFGTsrcintfrole=wan dst=172.18.67.10 dpt=53 deviceOutboundInterface=RWC FRANCE 2023 FTNTFGTdstintfrole=lan FTNTFGTsrccountry=Reserved FTNTFGTdstcountry=Reserved externalId=1797928567 proto=17 act=dns FTNTFGTpolicyid=30 FTNTFGTpolicytype=policy FTNTFGTpoluuid=6c8b6672-0b92-51ea-95a0-556c3c0fdb8f FTNTFGTpolicyname=CLT-RWC2023-001 FTNTFGTcentralnatid=6 app=DNS FTNTFGTappcat=unscanned FTNTFGTcrscore=5 FTNTFGTcraction=262144 FTNTFGTcrlevel=low FTNTFGTdsthwvendor=VMware FTNTFGTdstdevtype=Server FTNTFGTdstfamily=Virtual Machine FTNTFGTdstosname=Windows FTNTFGTdsthwversion=Workstation Pro FTNTFGTdstswversion=7 FTNTFGTmasterdstmac=02:00:00:00:00:00 FTNTFGTdstmac=02:00:00:00:00:00 FTNTFGTdstserver=0"
+    "message": "CEF:0|Fortinet|Fortigate|v6.4.9|00011|traffic:forward dns|4|deviceExternalId=FG5H0ETB19909686 FTNTFGTeventtime=1662381825920035319 FTNTFGTtz=+0200 FTNTFGTlogid=0000000011 cat=traffic:forward FTNTFGTsubtype=forward FTNTFGTlevel=warning FTNTFGTvd=root src=203.0.113.150 spt=49956 deviceInboundInterface=port1 FTNTFGTsrcintfrole=wan dst=203.0.113.10 dpt=53 deviceOutboundInterface=RWC FRANCE 2023 FTNTFGTdstintfrole=lan FTNTFGTsrccountry=Reserved FTNTFGTdstcountry=Reserved externalId=1797928567 proto=17 act=dns FTNTFGTpolicyid=30 FTNTFGTpolicytype=policy FTNTFGTpoluuid=6c8b6672-0b92-51ea-95a0-556c3c0fdb8f FTNTFGTpolicyname=CLT-RWC2023-001 FTNTFGTcentralnatid=6 app=DNS FTNTFGTappcat=unscanned FTNTFGTcrscore=5 FTNTFGTcraction=262144 FTNTFGTcrlevel=low FTNTFGTdsthwvendor=VMware FTNTFGTdstdevtype=Server FTNTFGTdstfamily=Virtual Machine FTNTFGTdstosname=Windows FTNTFGTdsthwversion=Workstation Pro FTNTFGTdstswversion=7 FTNTFGTmasterdstmac=02:00:00:00:00:00 FTNTFGTdstmac=02:00:00:00:00:00 FTNTFGTdstserver=0"
   },
   "expected": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.4.9|00011|traffic:forward dns|4|deviceExternalId=FG5H0ETB19909686 FTNTFGTeventtime=1662381825920035319 FTNTFGTtz=+0200 FTNTFGTlogid=0000000011 cat=traffic:forward FTNTFGTsubtype=forward FTNTFGTlevel=warning FTNTFGTvd=root src=172.16.222.150 spt=49956 deviceInboundInterface=port1 FTNTFGTsrcintfrole=wan dst=172.18.67.10 dpt=53 deviceOutboundInterface=RWC FRANCE 2023 FTNTFGTdstintfrole=lan FTNTFGTsrccountry=Reserved FTNTFGTdstcountry=Reserved externalId=1797928567 proto=17 act=dns FTNTFGTpolicyid=30 FTNTFGTpolicytype=policy FTNTFGTpoluuid=6c8b6672-0b92-51ea-95a0-556c3c0fdb8f FTNTFGTpolicyname=CLT-RWC2023-001 FTNTFGTcentralnatid=6 app=DNS FTNTFGTappcat=unscanned FTNTFGTcrscore=5 FTNTFGTcraction=262144 FTNTFGTcrlevel=low FTNTFGTdsthwvendor=VMware FTNTFGTdstdevtype=Server FTNTFGTdstfamily=Virtual Machine FTNTFGTdstosname=Windows FTNTFGTdsthwversion=Workstation Pro FTNTFGTdstswversion=7 FTNTFGTmasterdstmac=02:00:00:00:00:00 FTNTFGTdstmac=02:00:00:00:00:00 FTNTFGTdstserver=0",
+    "message": "CEF:0|Fortinet|Fortigate|v6.4.9|00011|traffic:forward dns|4|deviceExternalId=FG5H0ETB19909686 FTNTFGTeventtime=1662381825920035319 FTNTFGTtz=+0200 FTNTFGTlogid=0000000011 cat=traffic:forward FTNTFGTsubtype=forward FTNTFGTlevel=warning FTNTFGTvd=root src=203.0.113.150 spt=49956 deviceInboundInterface=port1 FTNTFGTsrcintfrole=wan dst=203.0.113.10 dpt=53 deviceOutboundInterface=RWC FRANCE 2023 FTNTFGTdstintfrole=lan FTNTFGTsrccountry=Reserved FTNTFGTdstcountry=Reserved externalId=1797928567 proto=17 act=dns FTNTFGTpolicyid=30 FTNTFGTpolicytype=policy FTNTFGTpoluuid=6c8b6672-0b92-51ea-95a0-556c3c0fdb8f FTNTFGTpolicyname=CLT-RWC2023-001 FTNTFGTcentralnatid=6 app=DNS FTNTFGTappcat=unscanned FTNTFGTcrscore=5 FTNTFGTcraction=262144 FTNTFGTcrlevel=low FTNTFGTdsthwvendor=VMware FTNTFGTdstdevtype=Server FTNTFGTdstfamily=Virtual Machine FTNTFGTdstosname=Windows FTNTFGTdsthwversion=Workstation Pro FTNTFGTdstswversion=7 FTNTFGTmasterdstmac=02:00:00:00:00:00 FTNTFGTdstmac=02:00:00:00:00:00 FTNTFGTdstserver=0",
     "event": {
       "action": "dns",
       "category": "traffic",
@@ -20,8 +20,8 @@
       "type": "forward"
     },
     "destination": {
-      "address": "172.18.67.10",
-      "ip": "172.18.67.10",
+      "address": "203.0.113.10",
+      "ip": "203.0.113.10",
       "mac": "02:00:00:00:00:00",
       "port": 53
     },
@@ -67,8 +67,8 @@
     },
     "related": {
       "ip": [
-        "172.16.222.150",
-        "172.18.67.10"
+        "203.0.113.10",
+        "203.0.113.150"
       ]
     },
     "rule": {
@@ -76,8 +76,8 @@
       "ruleset": "policy"
     },
     "source": {
-      "address": "172.16.222.150",
-      "ip": "172.16.222.150",
+      "address": "203.0.113.150",
+      "ip": "203.0.113.150",
       "port": 49956
     }
   }

--- a/Fortinet/fortigate/tests/traffic_nat.STANDARD.json
+++ b/Fortinet/fortigate/tests/traffic_nat.STANDARD.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "date=2018-07-26 time=14:56:21 devname=\"abc\" devid=\"1\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"root\" eventtime=1609941381 srcip=1.1.1.1 srcport=52125 srcintf=\"port9\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstport=3727 dstintf=\"port10\" dstintfrole=\"undefined\" poluuid=\"d77c53b2-a3c6-51e9-49b2-61c9e68c1f7e\" sessionid=578033623 proto=6 action=\"server-rst\" policyid=207 policytype=\"policy\" service=\"tcp/3727\" dstcountry=\"France\" srccountry=\"Netherlands\" trandisp=\"dnat\" tranip=192.0.2.1 tranport=3727 duration=5 sentbyte=80 rcvdbyte=40 sentpkt=2 rcvdpkt=1 appcat=\"unscanned\" dstdevtype=\"Router/NAT Device\" dstdevcategory=\"Windows Device\" masterdstmac=\"02:00:00:00:00:00\" dstmac=\"02:00:00:00:00:00\" dstserver=1"
+    "message": "date=2018-07-26 time=14:56:21 devname=\"abc\" devid=\"1\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"root\" eventtime=1609941381 srcip=192.0.2.101 srcport=52125 srcintf=\"port9\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstport=3727 dstintf=\"port10\" dstintfrole=\"undefined\" poluuid=\"d77c53b2-a3c6-51e9-49b2-61c9e68c1f7e\" sessionid=578033623 proto=6 action=\"server-rst\" policyid=207 policytype=\"policy\" service=\"tcp/3727\" dstcountry=\"France\" srccountry=\"Netherlands\" trandisp=\"dnat\" tranip=192.0.2.1 tranport=3727 duration=5 sentbyte=80 rcvdbyte=40 sentpkt=2 rcvdpkt=1 appcat=\"unscanned\" dstdevtype=\"Router/NAT Device\" dstdevcategory=\"Windows Device\" masterdstmac=\"02:00:00:00:00:00\" dstmac=\"02:00:00:00:00:00\" dstserver=1"
   },
   "expected": {
-    "message": "date=2018-07-26 time=14:56:21 devname=\"abc\" devid=\"1\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"root\" eventtime=1609941381 srcip=1.1.1.1 srcport=52125 srcintf=\"port9\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstport=3727 dstintf=\"port10\" dstintfrole=\"undefined\" poluuid=\"d77c53b2-a3c6-51e9-49b2-61c9e68c1f7e\" sessionid=578033623 proto=6 action=\"server-rst\" policyid=207 policytype=\"policy\" service=\"tcp/3727\" dstcountry=\"France\" srccountry=\"Netherlands\" trandisp=\"dnat\" tranip=192.0.2.1 tranport=3727 duration=5 sentbyte=80 rcvdbyte=40 sentpkt=2 rcvdpkt=1 appcat=\"unscanned\" dstdevtype=\"Router/NAT Device\" dstdevcategory=\"Windows Device\" masterdstmac=\"02:00:00:00:00:00\" dstmac=\"02:00:00:00:00:00\" dstserver=1",
+    "message": "date=2018-07-26 time=14:56:21 devname=\"abc\" devid=\"1\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"root\" eventtime=1609941381 srcip=192.0.2.101 srcport=52125 srcintf=\"port9\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstport=3727 dstintf=\"port10\" dstintfrole=\"undefined\" poluuid=\"d77c53b2-a3c6-51e9-49b2-61c9e68c1f7e\" sessionid=578033623 proto=6 action=\"server-rst\" policyid=207 policytype=\"policy\" service=\"tcp/3727\" dstcountry=\"France\" srccountry=\"Netherlands\" trandisp=\"dnat\" tranip=192.0.2.1 tranport=3727 duration=5 sentbyte=80 rcvdbyte=40 sentpkt=2 rcvdpkt=1 appcat=\"unscanned\" dstdevtype=\"Router/NAT Device\" dstdevcategory=\"Windows Device\" masterdstmac=\"02:00:00:00:00:00\" dstmac=\"02:00:00:00:00:00\" dstserver=1",
     "event": {
       "action": "server-rst",
       "category": "traffic",
@@ -74,8 +74,8 @@
         "abc"
       ],
       "ip": [
-        "1.1.1.1",
-        "192.0.2.1"
+        "192.0.2.1",
+        "192.0.2.101"
       ]
     },
     "rule": {
@@ -83,12 +83,12 @@
       "ruleset": "policy"
     },
     "source": {
-      "address": "1.1.1.1",
+      "address": "192.0.2.101",
       "bytes": 80,
       "geo": {
         "country_name": "Netherlands"
       },
-      "ip": "1.1.1.1",
+      "ip": "192.0.2.101",
       "packets": 2,
       "port": 52125
     }

--- a/Fortinet/fortigate/tests/traffic_nat_1.STANDARD.json
+++ b/Fortinet/fortigate/tests/traffic_nat_1.STANDARD.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "timestamp=1709762763 devname=\"FW-001\" devid=\"FG100D6G11111111\" vd=\"root\" date=2024-03-06 time=22:06:03 logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" eventtime=1709762764028577926 tz=\"+0000\" srcip=1.2.3.4 srcname=\"example.com\" srcport=62979 srcintf=\"Port3.999\" srcintfrole=\"lan\" dstip=5.6.7.8 dstport=53 dstintf=\"wan1\" dstintfrole=\"undefined\" sessionid=538959618 proto=17 action=\"accept\" policyid=41 policytype=\"policy\" poluuid=\"703570eee-edfc-4565-8599-c6a75fd3e1e8\" service=\"DNS\" dstcountry=\"France\" srccountry=\"Reserved\" trandisp=\"snat\" transip=192.0.2.1 transport=62979 appid=16195 app=\"DNS\" appcat=\"Network.Service\" apprisk=\"elevated\" applist=\"EMEA_Monitor\" duration=189 sentbyte=285 rcvdbyte=0 sentpkt=5 rcvdpkt=0 osname=\"Windows\" srcswversion=\"10\" mastersrcmac=\"02:00:00:00:00:00\" srcmac=\"02:00:00:00:00:00\" srcserver=0"
+    "message": "timestamp=1709762763 devname=\"FW-001\" devid=\"FG100D6G11111111\" vd=\"root\" date=2024-03-06 time=22:06:03 logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" eventtime=1709762764028577926 tz=\"+0000\" srcip=198.51.100.4 srcname=\"example.com\" srcport=62979 srcintf=\"Port3.999\" srcintfrole=\"lan\" dstip=203.0.113.8 dstport=53 dstintf=\"wan1\" dstintfrole=\"undefined\" sessionid=538959618 proto=17 action=\"accept\" policyid=41 policytype=\"policy\" poluuid=\"703570eee-edfc-4565-8599-c6a75fd3e1e8\" service=\"DNS\" dstcountry=\"France\" srccountry=\"Reserved\" trandisp=\"snat\" transip=192.0.2.1 transport=62979 appid=16195 app=\"DNS\" appcat=\"Network.Service\" apprisk=\"elevated\" applist=\"EMEA_Monitor\" duration=189 sentbyte=285 rcvdbyte=0 sentpkt=5 rcvdpkt=0 osname=\"Windows\" srcswversion=\"10\" mastersrcmac=\"02:00:00:00:00:00\" srcmac=\"02:00:00:00:00:00\" srcserver=0"
   },
   "expected": {
-    "message": "timestamp=1709762763 devname=\"FW-001\" devid=\"FG100D6G11111111\" vd=\"root\" date=2024-03-06 time=22:06:03 logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" eventtime=1709762764028577926 tz=\"+0000\" srcip=1.2.3.4 srcname=\"example.com\" srcport=62979 srcintf=\"Port3.999\" srcintfrole=\"lan\" dstip=5.6.7.8 dstport=53 dstintf=\"wan1\" dstintfrole=\"undefined\" sessionid=538959618 proto=17 action=\"accept\" policyid=41 policytype=\"policy\" poluuid=\"703570eee-edfc-4565-8599-c6a75fd3e1e8\" service=\"DNS\" dstcountry=\"France\" srccountry=\"Reserved\" trandisp=\"snat\" transip=192.0.2.1 transport=62979 appid=16195 app=\"DNS\" appcat=\"Network.Service\" apprisk=\"elevated\" applist=\"EMEA_Monitor\" duration=189 sentbyte=285 rcvdbyte=0 sentpkt=5 rcvdpkt=0 osname=\"Windows\" srcswversion=\"10\" mastersrcmac=\"02:00:00:00:00:00\" srcmac=\"02:00:00:00:00:00\" srcserver=0",
+    "message": "timestamp=1709762763 devname=\"FW-001\" devid=\"FG100D6G11111111\" vd=\"root\" date=2024-03-06 time=22:06:03 logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" eventtime=1709762764028577926 tz=\"+0000\" srcip=198.51.100.4 srcname=\"example.com\" srcport=62979 srcintf=\"Port3.999\" srcintfrole=\"lan\" dstip=203.0.113.8 dstport=53 dstintf=\"wan1\" dstintfrole=\"undefined\" sessionid=538959618 proto=17 action=\"accept\" policyid=41 policytype=\"policy\" poluuid=\"703570eee-edfc-4565-8599-c6a75fd3e1e8\" service=\"DNS\" dstcountry=\"France\" srccountry=\"Reserved\" trandisp=\"snat\" transip=192.0.2.1 transport=62979 appid=16195 app=\"DNS\" appcat=\"Network.Service\" apprisk=\"elevated\" applist=\"EMEA_Monitor\" duration=189 sentbyte=285 rcvdbyte=0 sentpkt=5 rcvdpkt=0 osname=\"Windows\" srcswversion=\"10\" mastersrcmac=\"02:00:00:00:00:00\" srcmac=\"02:00:00:00:00:00\" srcserver=0",
     "event": {
       "action": "accept",
       "category": "traffic",
@@ -21,12 +21,12 @@
       "type": "forward"
     },
     "destination": {
-      "address": "5.6.7.8",
+      "address": "203.0.113.8",
       "bytes": 0,
       "geo": {
         "country_name": "France"
       },
-      "ip": "5.6.7.8",
+      "ip": "203.0.113.8",
       "packets": 0,
       "port": 53
     },
@@ -81,9 +81,9 @@
         "FW-001"
       ],
       "ip": [
-        "1.2.3.4",
         "192.0.2.1",
-        "5.6.7.8"
+        "198.51.100.4",
+        "203.0.113.8"
       ]
     },
     "rule": {
@@ -92,9 +92,9 @@
       "ruleset": "EMEA_Monitor"
     },
     "source": {
-      "address": "1.2.3.4",
+      "address": "198.51.100.4",
       "bytes": 285,
-      "ip": "1.2.3.4",
+      "ip": "198.51.100.4",
       "mac": "02:00:00:00:00:00",
       "nat": {
         "ip": "192.0.2.1"

--- a/Fortinet/fortigate/tests/traffic_nat_2.STANDARD.json
+++ b/Fortinet/fortigate/tests/traffic_nat_2.STANDARD.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "timestamp=1732640381 devname=\"12_LE_XXXXX-60F\" devid=\"xxxxxxxxxxxxxxxxxxx\" vd=\"root\" date=2024-11-26 time=16:59:41 eventtime=1732633180924621531 tz=\"+0200\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" srcip=1.2.3.4 srcname=\"example.com\" srcport=56745 srcintf=\"internal\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstport=80 dstintf=\"wan1\" dstintfrole=\"undefined\" srccountry=\"Reserved\" dstcountry=\"Egypt\" sessionid=157131884 proto=6 action=\"close\" policyid=12 policytype=\"policy\" poluuid=\"c1353c04-b6ee-51ea-9664-c8541f024774\" policyname=\"LAN to Internet\" service=\"HTTP\" trandisp=\"snat\" transip=192.0.2.1 transport=56745 appid=15893 app=\"HTTP.BROWSER\" appcat=\"Web.Client\" apprisk=\"medium\" applist=\"block-high-risk\" duration=1 sentbyte=483 rcvdbyte=399 sentpkt=7 rcvdpkt=5 wanin=187 wanout=111 lanin=111 lanout=187 utmaction=\"allow\" countweb=1 osname=\"Windows\" srcswversion=\"10\" mastersrcmac=\"02:00:00:00:00:00\" srcmac=\"02:00:00:00:00:00\" srcserver=0"
+    "message": "timestamp=1732640381 devname=\"12_LE_XXXXX-60F\" devid=\"xxxxxxxxxxxxxxxxxxx\" vd=\"root\" date=2024-11-26 time=16:59:41 eventtime=1732633180924621531 tz=\"+0200\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" srcip=198.51.100.4 srcname=\"example.com\" srcport=56745 srcintf=\"internal\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstport=80 dstintf=\"wan1\" dstintfrole=\"undefined\" srccountry=\"Reserved\" dstcountry=\"Egypt\" sessionid=157131884 proto=6 action=\"close\" policyid=12 policytype=\"policy\" poluuid=\"c1353c04-b6ee-51ea-9664-c8541f024774\" policyname=\"LAN to Internet\" service=\"HTTP\" trandisp=\"snat\" transip=192.0.2.1 transport=56745 appid=15893 app=\"HTTP.BROWSER\" appcat=\"Web.Client\" apprisk=\"medium\" applist=\"block-high-risk\" duration=1 sentbyte=483 rcvdbyte=399 sentpkt=7 rcvdpkt=5 wanin=187 wanout=111 lanin=111 lanout=187 utmaction=\"allow\" countweb=1 osname=\"Windows\" srcswversion=\"10\" mastersrcmac=\"02:00:00:00:00:00\" srcmac=\"02:00:00:00:00:00\" srcserver=0"
   },
   "expected": {
-    "message": "timestamp=1732640381 devname=\"12_LE_XXXXX-60F\" devid=\"xxxxxxxxxxxxxxxxxxx\" vd=\"root\" date=2024-11-26 time=16:59:41 eventtime=1732633180924621531 tz=\"+0200\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" srcip=1.2.3.4 srcname=\"example.com\" srcport=56745 srcintf=\"internal\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstport=80 dstintf=\"wan1\" dstintfrole=\"undefined\" srccountry=\"Reserved\" dstcountry=\"Egypt\" sessionid=157131884 proto=6 action=\"close\" policyid=12 policytype=\"policy\" poluuid=\"c1353c04-b6ee-51ea-9664-c8541f024774\" policyname=\"LAN to Internet\" service=\"HTTP\" trandisp=\"snat\" transip=192.0.2.1 transport=56745 appid=15893 app=\"HTTP.BROWSER\" appcat=\"Web.Client\" apprisk=\"medium\" applist=\"block-high-risk\" duration=1 sentbyte=483 rcvdbyte=399 sentpkt=7 rcvdpkt=5 wanin=187 wanout=111 lanin=111 lanout=187 utmaction=\"allow\" countweb=1 osname=\"Windows\" srcswversion=\"10\" mastersrcmac=\"02:00:00:00:00:00\" srcmac=\"02:00:00:00:00:00\" srcserver=0",
+    "message": "timestamp=1732640381 devname=\"12_LE_XXXXX-60F\" devid=\"xxxxxxxxxxxxxxxxxxx\" vd=\"root\" date=2024-11-26 time=16:59:41 eventtime=1732633180924621531 tz=\"+0200\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" srcip=198.51.100.4 srcname=\"example.com\" srcport=56745 srcintf=\"internal\" srcintfrole=\"undefined\" dstip=192.0.2.1 dstport=80 dstintf=\"wan1\" dstintfrole=\"undefined\" srccountry=\"Reserved\" dstcountry=\"Egypt\" sessionid=157131884 proto=6 action=\"close\" policyid=12 policytype=\"policy\" poluuid=\"c1353c04-b6ee-51ea-9664-c8541f024774\" policyname=\"LAN to Internet\" service=\"HTTP\" trandisp=\"snat\" transip=192.0.2.1 transport=56745 appid=15893 app=\"HTTP.BROWSER\" appcat=\"Web.Client\" apprisk=\"medium\" applist=\"block-high-risk\" duration=1 sentbyte=483 rcvdbyte=399 sentpkt=7 rcvdpkt=5 wanin=187 wanout=111 lanin=111 lanout=187 utmaction=\"allow\" countweb=1 osname=\"Windows\" srcswversion=\"10\" mastersrcmac=\"02:00:00:00:00:00\" srcmac=\"02:00:00:00:00:00\" srcserver=0",
     "event": {
       "action": "close",
       "category": "traffic",
@@ -82,8 +82,8 @@
         "12_LE_XXXXX-60F"
       ],
       "ip": [
-        "1.2.3.4",
-        "192.0.2.1"
+        "192.0.2.1",
+        "198.51.100.4"
       ]
     },
     "rule": {
@@ -92,9 +92,9 @@
       "ruleset": "block-high-risk"
     },
     "source": {
-      "address": "1.2.3.4",
+      "address": "198.51.100.4",
       "bytes": 483,
-      "ip": "1.2.3.4",
+      "ip": "198.51.100.4",
       "mac": "02:00:00:00:00:00",
       "nat": {
         "ip": "192.0.2.1"

--- a/Fortinet/fortigate/tests/traffic_with_pass_and_cert.json
+++ b/Fortinet/fortigate/tests/traffic_with_pass_and_cert.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "logver=704072731 timestamp=1744010938 devname=\"my-device\" devid=\"1111111111111111\" vd=\"root\" date=2025-04-07 time=07:28:58 eventtime=1744010938310787908 logid=\"0000000020\" type=\"traffic\" subtype=\"forward\" level=\"notice\" srcip=1.2.3.4 srcport=55880 srcintf=\"ssl.root\" srcintfrole=\"undefined\" dstip=5.6.7.8 dstport=22 dstintf=\"VLAN-4002\" dstintfrole=\"lan\" srcuuid=\"d24dfae2-ee8d-4319-ac8a-f49fb888f8c3\" dstuuid=\"1949578e-2022-47e4-a779-069cfca42d20\" srccountry=\"Reserved\" dstcountry=\"Reserved\" sessionid=123 proto=6 action=\"accept\" policyid=9 policytype=\"policy\" poluuid=\"194b8d20-da82-4838-ae8c-712bcdb8eba7\" policyname=\"sslvpn_2_prd-vault-net\" user=\"john.doe,cn=john.doe\" group=\"my-group\" service=\"SSH\" trandisp=\"snat\" transip=192.0.2.1 transport=55880 appcat=\"unscanned\" duration=9380 sentbyte=215866 rcvdbyte=515657 sentpkt=2954 rcvdpkt=2055 sentdelta=156 rcvddelta=80 durationdelta=120 sentpktdelta=2 rcvdpktdelta=1 dsthwvendor=\"Fortinet\" dstdevtype=\"Router\" masterdstmac=\"02:00:00:00:00:00\" dstmac=\"02:00:00:00:00:00\" dstserver=0 tz=\"+0000\""
+    "message": "logver=704072731 timestamp=1744010938 devname=\"my-device\" devid=\"1111111111111111\" vd=\"root\" date=2025-04-07 time=07:28:58 eventtime=1744010938310787908 logid=\"0000000020\" type=\"traffic\" subtype=\"forward\" level=\"notice\" srcip=198.51.100.4 srcport=55880 srcintf=\"ssl.root\" srcintfrole=\"undefined\" dstip=203.0.113.8 dstport=22 dstintf=\"VLAN-4002\" dstintfrole=\"lan\" srcuuid=\"d24dfae2-ee8d-4319-ac8a-f49fb888f8c3\" dstuuid=\"1949578e-2022-47e4-a779-069cfca42d20\" srccountry=\"Reserved\" dstcountry=\"Reserved\" sessionid=123 proto=6 action=\"accept\" policyid=9 policytype=\"policy\" poluuid=\"194b8d20-da82-4838-ae8c-712bcdb8eba7\" policyname=\"sslvpn_2_prd-vault-net\" user=\"john.doe,cn=john.doe\" group=\"my-group\" service=\"SSH\" trandisp=\"snat\" transip=192.0.2.1 transport=55880 appcat=\"unscanned\" duration=9380 sentbyte=215866 rcvdbyte=515657 sentpkt=2954 rcvdpkt=2055 sentdelta=156 rcvddelta=80 durationdelta=120 sentpktdelta=2 rcvdpktdelta=1 dsthwvendor=\"Fortinet\" dstdevtype=\"Router\" masterdstmac=\"02:00:00:00:00:00\" dstmac=\"02:00:00:00:00:00\" dstserver=0 tz=\"+0000\""
   },
   "expected": {
-    "message": "logver=704072731 timestamp=1744010938 devname=\"my-device\" devid=\"1111111111111111\" vd=\"root\" date=2025-04-07 time=07:28:58 eventtime=1744010938310787908 logid=\"0000000020\" type=\"traffic\" subtype=\"forward\" level=\"notice\" srcip=1.2.3.4 srcport=55880 srcintf=\"ssl.root\" srcintfrole=\"undefined\" dstip=5.6.7.8 dstport=22 dstintf=\"VLAN-4002\" dstintfrole=\"lan\" srcuuid=\"d24dfae2-ee8d-4319-ac8a-f49fb888f8c3\" dstuuid=\"1949578e-2022-47e4-a779-069cfca42d20\" srccountry=\"Reserved\" dstcountry=\"Reserved\" sessionid=123 proto=6 action=\"accept\" policyid=9 policytype=\"policy\" poluuid=\"194b8d20-da82-4838-ae8c-712bcdb8eba7\" policyname=\"sslvpn_2_prd-vault-net\" user=\"john.doe,cn=john.doe\" group=\"my-group\" service=\"SSH\" trandisp=\"snat\" transip=192.0.2.1 transport=55880 appcat=\"unscanned\" duration=9380 sentbyte=215866 rcvdbyte=515657 sentpkt=2954 rcvdpkt=2055 sentdelta=156 rcvddelta=80 durationdelta=120 sentpktdelta=2 rcvdpktdelta=1 dsthwvendor=\"Fortinet\" dstdevtype=\"Router\" masterdstmac=\"02:00:00:00:00:00\" dstmac=\"02:00:00:00:00:00\" dstserver=0 tz=\"+0000\"",
+    "message": "logver=704072731 timestamp=1744010938 devname=\"my-device\" devid=\"1111111111111111\" vd=\"root\" date=2025-04-07 time=07:28:58 eventtime=1744010938310787908 logid=\"0000000020\" type=\"traffic\" subtype=\"forward\" level=\"notice\" srcip=198.51.100.4 srcport=55880 srcintf=\"ssl.root\" srcintfrole=\"undefined\" dstip=203.0.113.8 dstport=22 dstintf=\"VLAN-4002\" dstintfrole=\"lan\" srcuuid=\"d24dfae2-ee8d-4319-ac8a-f49fb888f8c3\" dstuuid=\"1949578e-2022-47e4-a779-069cfca42d20\" srccountry=\"Reserved\" dstcountry=\"Reserved\" sessionid=123 proto=6 action=\"accept\" policyid=9 policytype=\"policy\" poluuid=\"194b8d20-da82-4838-ae8c-712bcdb8eba7\" policyname=\"sslvpn_2_prd-vault-net\" user=\"john.doe,cn=john.doe\" group=\"my-group\" service=\"SSH\" trandisp=\"snat\" transip=192.0.2.1 transport=55880 appcat=\"unscanned\" duration=9380 sentbyte=215866 rcvdbyte=515657 sentpkt=2954 rcvdpkt=2055 sentdelta=156 rcvddelta=80 durationdelta=120 sentpktdelta=2 rcvdpktdelta=1 dsthwvendor=\"Fortinet\" dstdevtype=\"Router\" masterdstmac=\"02:00:00:00:00:00\" dstmac=\"02:00:00:00:00:00\" dstserver=0 tz=\"+0000\"",
     "event": {
       "action": "accept",
       "category": "traffic",
@@ -21,9 +21,9 @@
       "type": "forward"
     },
     "destination": {
-      "address": "5.6.7.8",
+      "address": "203.0.113.8",
       "bytes": 80,
-      "ip": "5.6.7.8",
+      "ip": "203.0.113.8",
       "mac": "02:00:00:00:00:00",
       "packets": 1,
       "port": 22
@@ -81,9 +81,9 @@
         "my-device"
       ],
       "ip": [
-        "1.2.3.4",
         "192.0.2.1",
-        "5.6.7.8"
+        "198.51.100.4",
+        "203.0.113.8"
       ],
       "user": [
         "john.doe"
@@ -94,9 +94,9 @@
       "ruleset": "policy"
     },
     "source": {
-      "address": "1.2.3.4",
+      "address": "198.51.100.4",
       "bytes": 156,
-      "ip": "1.2.3.4",
+      "ip": "198.51.100.4",
       "nat": {
         "ip": "192.0.2.1"
       },

--- a/Fortinet/fortigate/tests/traffic_with_referrer.json
+++ b/Fortinet/fortigate/tests/traffic_with_referrer.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "time=10:11:05 devname=MYDEVICE device_id=1111111111111111 log_id=000000001 type=traffic subtype=slb_http pri=information vd=waf msg_id=123456 duration=2742 ibytes=4513 obytes=4518 proto=6 service=\"https\" src=\"1.2.3.4\" src_port=52412 dst=\"5.6.7.8\" dst_port=443 trans_src=\"9.10.11.12\" trans_src_port=56484 trans_dst=\"13.14.15.16\" trans_dst_port=80 policy=\"VS_FRED_PROD_WEB\" action=\"user1\" http_method=\"get\" http_host=\"example.com\" http_agent=\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36\" http_url=\"/api/v2/Users\" http_qry=\"ciId=82613&onlyActive=true&/api/v2/Users\" http_referer=\"https://example.com/index\" http_cookie=\"COOKIES\" http_retcode=\"200\" user=\"user1\" usrgrp=\"user1\" auth_status=\"user1\" srccountry=\"Reunion\" dstcountry=\"Reserved\" real_server=\"PROD_WEB01_13.14.15.16\""
+    "message": "time=10:11:05 devname=MYDEVICE device_id=1111111111111111 log_id=000000001 type=traffic subtype=slb_http pri=information vd=waf msg_id=123456 duration=2742 ibytes=4513 obytes=4518 proto=6 service=\"https\" src=\"198.51.100.4\" src_port=52412 dst=\"203.0.113.8\" dst_port=443 trans_src=\"203.0.113.12\" trans_src_port=56484 trans_dst=\"203.0.113.16\" trans_dst_port=80 policy=\"VS_FRED_PROD_WEB\" action=\"user1\" http_method=\"get\" http_host=\"example.com\" http_agent=\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/192.0.2.138 Safari/537.36\" http_url=\"/api/v2/Users\" http_qry=\"ciId=82613&onlyActive=true&/api/v2/Users\" http_referer=\"https://example.com/index\" http_cookie=\"COOKIES\" http_retcode=\"200\" user=\"user1\" usrgrp=\"user1\" auth_status=\"user1\" srccountry=\"Reunion\" dstcountry=\"Reserved\" real_server=\"PROD_WEB01_13.14.15.16\""
   },
   "expected": {
-    "message": "time=10:11:05 devname=MYDEVICE device_id=1111111111111111 log_id=000000001 type=traffic subtype=slb_http pri=information vd=waf msg_id=123456 duration=2742 ibytes=4513 obytes=4518 proto=6 service=\"https\" src=\"1.2.3.4\" src_port=52412 dst=\"5.6.7.8\" dst_port=443 trans_src=\"9.10.11.12\" trans_src_port=56484 trans_dst=\"13.14.15.16\" trans_dst_port=80 policy=\"VS_FRED_PROD_WEB\" action=\"user1\" http_method=\"get\" http_host=\"example.com\" http_agent=\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36\" http_url=\"/api/v2/Users\" http_qry=\"ciId=82613&onlyActive=true&/api/v2/Users\" http_referer=\"https://example.com/index\" http_cookie=\"COOKIES\" http_retcode=\"200\" user=\"user1\" usrgrp=\"user1\" auth_status=\"user1\" srccountry=\"Reunion\" dstcountry=\"Reserved\" real_server=\"PROD_WEB01_13.14.15.16\"",
+    "message": "time=10:11:05 devname=MYDEVICE device_id=1111111111111111 log_id=000000001 type=traffic subtype=slb_http pri=information vd=waf msg_id=123456 duration=2742 ibytes=4513 obytes=4518 proto=6 service=\"https\" src=\"198.51.100.4\" src_port=52412 dst=\"203.0.113.8\" dst_port=443 trans_src=\"203.0.113.12\" trans_src_port=56484 trans_dst=\"203.0.113.16\" trans_dst_port=80 policy=\"VS_FRED_PROD_WEB\" action=\"user1\" http_method=\"get\" http_host=\"example.com\" http_agent=\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/192.0.2.138 Safari/537.36\" http_url=\"/api/v2/Users\" http_qry=\"ciId=82613&onlyActive=true&/api/v2/Users\" http_referer=\"https://example.com/index\" http_cookie=\"COOKIES\" http_retcode=\"200\" user=\"user1\" usrgrp=\"user1\" auth_status=\"user1\" srccountry=\"Reunion\" dstcountry=\"Reserved\" real_server=\"PROD_WEB01_13.14.15.16\"",
     "event": {
       "action": "user1",
       "category": "traffic",
@@ -17,8 +17,8 @@
       "type": "slb_http"
     },
     "destination": {
-      "address": "5.6.7.8",
-      "ip": "5.6.7.8"
+      "address": "203.0.113.8",
+      "ip": "203.0.113.8"
     },
     "fortinet": {
       "fortigate": {
@@ -48,19 +48,19 @@
         "MYDEVICE"
       ],
       "ip": [
-        "1.2.3.4",
-        "5.6.7.8"
+        "198.51.100.4",
+        "203.0.113.8"
       ],
       "user": [
         "user1"
       ]
     },
     "source": {
-      "address": "1.2.3.4",
+      "address": "198.51.100.4",
       "geo": {
         "country_name": "Reunion"
       },
-      "ip": "1.2.3.4",
+      "ip": "198.51.100.4",
       "user": {
         "name": "user1"
       }

--- a/Fortinet/fortigate/tests/tunnel.json
+++ b/Fortinet/fortigate/tests/tunnel.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "logver=60 timestamp=1566916060 tz=\"UTC+2\" devname=\"abc\" devid=\"1\" vd=\"IPSEC\" date=2019-08-27 time=16:27:40 logid=\"0101039949\" type=\"event\" subtype=\"vpn\" level=\"information\" eventtime=1566916060 logdesc=\"SSL VPN statistics\" action=\"tunnel-stats\" tunneltype=\"ssl-tunnel\" tunnelid=1995 remip=1.1.1.1 tunnelip=192.0.2.1 user=\"test\" group=\"GRP_Generic_JAIL_VPN\" dst_host=\"N/A\" nextstat=600 duration=8437 sentbyte=71524041 rcvdbyte=6151809 msg=\"SSL tunnel statistics\"\n"
+    "message": "logver=60 timestamp=1566916060 tz=\"UTC+2\" devname=\"abc\" devid=\"1\" vd=\"IPSEC\" date=2019-08-27 time=16:27:40 logid=\"0101039949\" type=\"event\" subtype=\"vpn\" level=\"information\" eventtime=1566916060 logdesc=\"SSL VPN statistics\" action=\"tunnel-stats\" tunneltype=\"ssl-tunnel\" tunnelid=1995 remip=192.0.2.101 tunnelip=192.0.2.1 user=\"test\" group=\"GRP_Generic_JAIL_VPN\" dst_host=\"N/A\" nextstat=600 duration=8437 sentbyte=71524041 rcvdbyte=6151809 msg=\"SSL tunnel statistics\"\n"
   },
   "expected": {
-    "message": "logver=60 timestamp=1566916060 tz=\"UTC+2\" devname=\"abc\" devid=\"1\" vd=\"IPSEC\" date=2019-08-27 time=16:27:40 logid=\"0101039949\" type=\"event\" subtype=\"vpn\" level=\"information\" eventtime=1566916060 logdesc=\"SSL VPN statistics\" action=\"tunnel-stats\" tunneltype=\"ssl-tunnel\" tunnelid=1995 remip=1.1.1.1 tunnelip=192.0.2.1 user=\"test\" group=\"GRP_Generic_JAIL_VPN\" dst_host=\"N/A\" nextstat=600 duration=8437 sentbyte=71524041 rcvdbyte=6151809 msg=\"SSL tunnel statistics\"\n",
+    "message": "logver=60 timestamp=1566916060 tz=\"UTC+2\" devname=\"abc\" devid=\"1\" vd=\"IPSEC\" date=2019-08-27 time=16:27:40 logid=\"0101039949\" type=\"event\" subtype=\"vpn\" level=\"information\" eventtime=1566916060 logdesc=\"SSL VPN statistics\" action=\"tunnel-stats\" tunneltype=\"ssl-tunnel\" tunnelid=1995 remip=192.0.2.101 tunnelip=192.0.2.1 user=\"test\" group=\"GRP_Generic_JAIL_VPN\" dst_host=\"N/A\" nextstat=600 duration=8437 sentbyte=71524041 rcvdbyte=6151809 msg=\"SSL tunnel statistics\"\n",
     "event": {
       "action": "tunnel-stats",
       "category": "event",
@@ -59,17 +59,17 @@
         "abc"
       ],
       "ip": [
-        "1.1.1.1",
-        "192.0.2.1"
+        "192.0.2.1",
+        "192.0.2.101"
       ],
       "user": [
         "test"
       ]
     },
     "source": {
-      "address": "1.1.1.1",
+      "address": "192.0.2.101",
       "bytes": 71524041,
-      "ip": "1.1.1.1",
+      "ip": "192.0.2.101",
       "nat": {
         "ip": "192.0.2.1"
       },

--- a/Fortinet/fortigate/tests/tunnel_statistics.CSV.json
+++ b/Fortinet/fortigate/tests/tunnel_statistics.CSV.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": " time=12:02:57 devname=\"abc\" devid=\"1\" logid=\"0101037141\" type=\"event\" subtype=\"vpn\" level=\"notice\" vd=\"root\" eventtime=1614855777 logdesc=\"IPsec tunnel statistics\" msg=\"IPsec tunnel statistics\" action=\"tunnel-stats\" remip=1.1.1.1 locip=192.0.2.1 remport=500 locport=500 outintf=\"N/A\" cookies=\"9b064274e0648c03/662c2b1264a2295e\" user=\"N/A\" group=\"N/A\" xauthuser=\"N/A\" xauthgroup=\"N/A\" assignip=N/A vpntunnel=\"VPN-HELPLINE\" tunnelip=N/A tunnelid=0 tunneltype=\"ipsec\" duration=102908570 sentbyte=7649 rcvdbyte=0 nextstat=600"
+    "message": " time=12:02:57 devname=\"abc\" devid=\"1\" logid=\"0101037141\" type=\"event\" subtype=\"vpn\" level=\"notice\" vd=\"root\" eventtime=1614855777 logdesc=\"IPsec tunnel statistics\" msg=\"IPsec tunnel statistics\" action=\"tunnel-stats\" remip=192.0.2.101 locip=192.0.2.1 remport=500 locport=500 outintf=\"N/A\" cookies=\"9b064274e0648c03/662c2b1264a2295e\" user=\"N/A\" group=\"N/A\" xauthuser=\"N/A\" xauthgroup=\"N/A\" assignip=N/A vpntunnel=\"VPN-HELPLINE\" tunnelip=N/A tunnelid=0 tunneltype=\"ipsec\" duration=102908570 sentbyte=7649 rcvdbyte=0 nextstat=600"
   },
   "expected": {
-    "message": " time=12:02:57 devname=\"abc\" devid=\"1\" logid=\"0101037141\" type=\"event\" subtype=\"vpn\" level=\"notice\" vd=\"root\" eventtime=1614855777 logdesc=\"IPsec tunnel statistics\" msg=\"IPsec tunnel statistics\" action=\"tunnel-stats\" remip=1.1.1.1 locip=192.0.2.1 remport=500 locport=500 outintf=\"N/A\" cookies=\"9b064274e0648c03/662c2b1264a2295e\" user=\"N/A\" group=\"N/A\" xauthuser=\"N/A\" xauthgroup=\"N/A\" assignip=N/A vpntunnel=\"VPN-HELPLINE\" tunnelip=N/A tunnelid=0 tunneltype=\"ipsec\" duration=102908570 sentbyte=7649 rcvdbyte=0 nextstat=600",
+    "message": " time=12:02:57 devname=\"abc\" devid=\"1\" logid=\"0101037141\" type=\"event\" subtype=\"vpn\" level=\"notice\" vd=\"root\" eventtime=1614855777 logdesc=\"IPsec tunnel statistics\" msg=\"IPsec tunnel statistics\" action=\"tunnel-stats\" remip=192.0.2.101 locip=192.0.2.1 remport=500 locport=500 outintf=\"N/A\" cookies=\"9b064274e0648c03/662c2b1264a2295e\" user=\"N/A\" group=\"N/A\" xauthuser=\"N/A\" xauthgroup=\"N/A\" assignip=N/A vpntunnel=\"VPN-HELPLINE\" tunnelip=N/A tunnelid=0 tunneltype=\"ipsec\" duration=102908570 sentbyte=7649 rcvdbyte=0 nextstat=600",
     "event": {
       "action": "tunnel-stats",
       "category": "event",
@@ -57,14 +57,14 @@
         "abc"
       ],
       "ip": [
-        "1.1.1.1",
-        "192.0.2.1"
+        "192.0.2.1",
+        "192.0.2.101"
       ]
     },
     "source": {
-      "address": "1.1.1.1",
+      "address": "192.0.2.101",
       "bytes": 7649,
-      "ip": "1.1.1.1",
+      "ip": "192.0.2.101",
       "port": 500
     }
   }

--- a/Fortinet/fortigate/tests/vpn_login_failed.STANDARD.json
+++ b/Fortinet/fortigate/tests/vpn_login_failed.STANDARD.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "time=17:43:43 devname=\"FW-FOOBAR\" devid=\"FG123\" eventtime=1665675824075327440 tz=\"+0200\" logid=\"0101039426\" type=\"event\" subtype=\"vpn\" level=\"alert\" vd=\"root\" logdesc=\"SSL VPN login fail\" action=\"ssl-login-fail\" tunneltype=\"ssl-web\" tunnelid=0 remip=1.1.1.1 user=\"user1\" group=\"N/A\" dst_host=\"N/A\" reason=\"sslvpn_login_cert_checked_error\" msg=\"SSL user failed to logged in\""
+    "message": "time=17:43:43 devname=\"FW-FOOBAR\" devid=\"FG123\" eventtime=1665675824075327440 tz=\"+0200\" logid=\"0101039426\" type=\"event\" subtype=\"vpn\" level=\"alert\" vd=\"root\" logdesc=\"SSL VPN login fail\" action=\"ssl-login-fail\" tunneltype=\"ssl-web\" tunnelid=0 remip=192.0.2.101 user=\"user1\" group=\"N/A\" dst_host=\"N/A\" reason=\"sslvpn_login_cert_checked_error\" msg=\"SSL user failed to logged in\""
   },
   "expected": {
-    "message": "time=17:43:43 devname=\"FW-FOOBAR\" devid=\"FG123\" eventtime=1665675824075327440 tz=\"+0200\" logid=\"0101039426\" type=\"event\" subtype=\"vpn\" level=\"alert\" vd=\"root\" logdesc=\"SSL VPN login fail\" action=\"ssl-login-fail\" tunneltype=\"ssl-web\" tunnelid=0 remip=1.1.1.1 user=\"user1\" group=\"N/A\" dst_host=\"N/A\" reason=\"sslvpn_login_cert_checked_error\" msg=\"SSL user failed to logged in\"",
+    "message": "time=17:43:43 devname=\"FW-FOOBAR\" devid=\"FG123\" eventtime=1665675824075327440 tz=\"+0200\" logid=\"0101039426\" type=\"event\" subtype=\"vpn\" level=\"alert\" vd=\"root\" logdesc=\"SSL VPN login fail\" action=\"ssl-login-fail\" tunneltype=\"ssl-web\" tunnelid=0 remip=192.0.2.101 user=\"user1\" group=\"N/A\" dst_host=\"N/A\" reason=\"sslvpn_login_cert_checked_error\" msg=\"SSL user failed to logged in\"",
     "event": {
       "action": "ssl-login-fail",
       "category": "event",
@@ -46,15 +46,15 @@
         "FW-FOOBAR"
       ],
       "ip": [
-        "1.1.1.1"
+        "192.0.2.101"
       ],
       "user": [
         "user1"
       ]
     },
     "source": {
-      "address": "1.1.1.1",
-      "ip": "1.1.1.1",
+      "address": "192.0.2.101",
+      "ip": "192.0.2.101",
       "user": {
         "name": "user1"
       }

--- a/Fortinet/fortigate/tests/web_filter.json
+++ b/Fortinet/fortigate/tests/web_filter.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "message": "eventtime=1741260033782633377 tz=\"+0100\" logid=\"0319013317\" type=\"utm\" subtype=\"webfilter\" eventtype=\"urlmonitor\" level=\"notice\" vd=\"root\" policyid=32 poluuid=\"test-pol-uuid\" policytype=\"proxy-policy\" sessionid=1139869359 user=\"user1\" group=\"ADMIN\" authserver=\"TEST_AUTH_SERVER\" srcip=1.2.3.4 srcport=18355 srccountry=\"Japan\" srcintf=\"port2\" srcintfrole=\"lan\" dstip=3.4.5.6 dstport=443 dstcountry=\"United States\" dstintf=\"Orange_Pro\" dstintfrole=\"wan\" proto=6 service=\"HTTPS\" hostname=\"example.com\" profile=\"TEST_AUTH_SERVER Web Defaut\" action=\"passthrough\" reqtype=\"direct\" url=\"https://example.com/\" sentbyte=421 rcvdbyte=0 direction=\"outgoing\" msg=\"URL has been visited\" method=\"ip\" cat=255",
+    "message": "eventtime=1741260033782633377 tz=\"+0100\" logid=\"0319013317\" type=\"utm\" subtype=\"webfilter\" eventtype=\"urlmonitor\" level=\"notice\" vd=\"root\" policyid=32 poluuid=\"test-pol-uuid\" policytype=\"proxy-policy\" sessionid=1139869359 user=\"user1\" group=\"ADMIN\" authserver=\"TEST_AUTH_SERVER\" srcip=198.51.100.4 srcport=18355 srccountry=\"Japan\" srcintf=\"port2\" srcintfrole=\"lan\" dstip=203.0.113.6 dstport=443 dstcountry=\"United States\" dstintf=\"Orange_Pro\" dstintfrole=\"wan\" proto=6 service=\"HTTPS\" hostname=\"example.com\" profile=\"TEST_AUTH_SERVER Web Defaut\" action=\"passthrough\" reqtype=\"direct\" url=\"https://example.com/\" sentbyte=421 rcvdbyte=0 direction=\"outgoing\" msg=\"URL has been visited\" method=\"ip\" cat=255",
     "sekoiaio": {
       "intake": {
         "dialect": "Fortinet FortiGate",
@@ -9,7 +9,7 @@
     }
   },
   "expected": {
-    "message": "eventtime=1741260033782633377 tz=\"+0100\" logid=\"0319013317\" type=\"utm\" subtype=\"webfilter\" eventtype=\"urlmonitor\" level=\"notice\" vd=\"root\" policyid=32 poluuid=\"test-pol-uuid\" policytype=\"proxy-policy\" sessionid=1139869359 user=\"user1\" group=\"ADMIN\" authserver=\"TEST_AUTH_SERVER\" srcip=1.2.3.4 srcport=18355 srccountry=\"Japan\" srcintf=\"port2\" srcintfrole=\"lan\" dstip=3.4.5.6 dstport=443 dstcountry=\"United States\" dstintf=\"Orange_Pro\" dstintfrole=\"wan\" proto=6 service=\"HTTPS\" hostname=\"example.com\" profile=\"TEST_AUTH_SERVER Web Defaut\" action=\"passthrough\" reqtype=\"direct\" url=\"https://example.com/\" sentbyte=421 rcvdbyte=0 direction=\"outgoing\" msg=\"URL has been visited\" method=\"ip\" cat=255",
+    "message": "eventtime=1741260033782633377 tz=\"+0100\" logid=\"0319013317\" type=\"utm\" subtype=\"webfilter\" eventtype=\"urlmonitor\" level=\"notice\" vd=\"root\" policyid=32 poluuid=\"test-pol-uuid\" policytype=\"proxy-policy\" sessionid=1139869359 user=\"user1\" group=\"ADMIN\" authserver=\"TEST_AUTH_SERVER\" srcip=198.51.100.4 srcport=18355 srccountry=\"Japan\" srcintf=\"port2\" srcintfrole=\"lan\" dstip=203.0.113.6 dstport=443 dstcountry=\"United States\" dstintf=\"Orange_Pro\" dstintfrole=\"wan\" proto=6 service=\"HTTPS\" hostname=\"example.com\" profile=\"TEST_AUTH_SERVER Web Defaut\" action=\"passthrough\" reqtype=\"direct\" url=\"https://example.com/\" sentbyte=421 rcvdbyte=0 direction=\"outgoing\" msg=\"URL has been visited\" method=\"ip\" cat=255",
     "event": {
       "action": "passthrough",
       "category": "utm",
@@ -28,13 +28,13 @@
       "type": "webfilter"
     },
     "destination": {
-      "address": "3.4.5.6",
+      "address": "203.0.113.6",
       "bytes": 0,
       "domain": "example.com",
       "geo": {
         "country_name": "United States"
       },
-      "ip": "3.4.5.6",
+      "ip": "203.0.113.6",
       "port": 443
     },
     "fortinet": {
@@ -82,8 +82,8 @@
         "example.com"
       ],
       "ip": [
-        "1.2.3.4",
-        "3.4.5.6"
+        "198.51.100.4",
+        "203.0.113.6"
       ],
       "user": [
         "user1"
@@ -93,12 +93,12 @@
       "ruleset": "proxy-policy"
     },
     "source": {
-      "address": "1.2.3.4",
+      "address": "198.51.100.4",
       "bytes": 421,
       "geo": {
         "country_name": "Japan"
       },
-      "ip": "1.2.3.4",
+      "ip": "198.51.100.4",
       "port": 18355,
       "user": {
         "name": "user1"

--- a/Fortinet/fortigate/tests/web_filter_1.json
+++ b/Fortinet/fortigate/tests/web_filter_1.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "message": "time=12:20:33 devname=\"testDev\" devid=\"FGVM2VTM21000062\" eventtime=1741260033527521837 tz=\"+0100\" logid=\"0317013312\" type=\"utm\" subtype=\"webfilter\" eventtype=\"ftgd_allow\" level=\"notice\" vd=\"root\" policyid=106 poluuid=\"test-pol-uuid\" policytype=\"policy\" sessionid=958259665 srcip=1.2.3.4 srcport=55377 srccountry=\"Reserved\" srcintf=\"T_testDev\" srcintfrole=\"undefined\" srcuuid=\"test-src-uuid\" dstip=3.4.5.6 dstport=80 dstcountry=\"France\" dstintf=\"port4\" dstintfrole=\"undefined\" dstuuid=\"test-dst-uuid\" proto=6 service=\"HTTP\" hostname=\"example.com\" profile=\"Filtrage_web_Avanc\u00e9\" action=\"passthrough\" reqtype=\"direct\" url=\"http://example.com/MFEwTzBNMEswSTAJBgUrDgMCGgUABBQ50otx%2Fh0Ztl%2Bz8SiPI7wEWVxDlQQUTiJUIBiV5uNu5g%2F6%123123123%3D\" sentbyte=400 rcvdbyte=0 direction=\"outgoing\" msg=\"URL belongs to an allowed category in policy\" method=\"domain\" cat=50 catdesc=\"Information and Computer Security\"",
+    "message": "time=12:20:33 devname=\"testDev\" devid=\"FGVM2VTM21000062\" eventtime=1741260033527521837 tz=\"+0100\" logid=\"0317013312\" type=\"utm\" subtype=\"webfilter\" eventtype=\"ftgd_allow\" level=\"notice\" vd=\"root\" policyid=106 poluuid=\"test-pol-uuid\" policytype=\"policy\" sessionid=958259665 srcip=198.51.100.4 srcport=55377 srccountry=\"Reserved\" srcintf=\"T_testDev\" srcintfrole=\"undefined\" srcuuid=\"test-src-uuid\" dstip=203.0.113.6 dstport=80 dstcountry=\"France\" dstintf=\"port4\" dstintfrole=\"undefined\" dstuuid=\"test-dst-uuid\" proto=6 service=\"HTTP\" hostname=\"example.com\" profile=\"Filtrage_web_Avanc\u00e9\" action=\"passthrough\" reqtype=\"direct\" url=\"http://example.com/MFEwTzBNMEswSTAJBgUrDgMCGgUABBQ50otx%2Fh0Ztl%2Bz8SiPI7wEWVxDlQQUTiJUIBiV5uNu5g%2F6%123123123%3D\" sentbyte=400 rcvdbyte=0 direction=\"outgoing\" msg=\"URL belongs to an allowed category in policy\" method=\"domain\" cat=50 catdesc=\"Information and Computer Security\"",
     "sekoiaio": {
       "intake": {
         "dialect": "Fortinet FortiGate",
@@ -9,7 +9,7 @@
     }
   },
   "expected": {
-    "message": "time=12:20:33 devname=\"testDev\" devid=\"FGVM2VTM21000062\" eventtime=1741260033527521837 tz=\"+0100\" logid=\"0317013312\" type=\"utm\" subtype=\"webfilter\" eventtype=\"ftgd_allow\" level=\"notice\" vd=\"root\" policyid=106 poluuid=\"test-pol-uuid\" policytype=\"policy\" sessionid=958259665 srcip=1.2.3.4 srcport=55377 srccountry=\"Reserved\" srcintf=\"T_testDev\" srcintfrole=\"undefined\" srcuuid=\"test-src-uuid\" dstip=3.4.5.6 dstport=80 dstcountry=\"France\" dstintf=\"port4\" dstintfrole=\"undefined\" dstuuid=\"test-dst-uuid\" proto=6 service=\"HTTP\" hostname=\"example.com\" profile=\"Filtrage_web_Avanc\u00e9\" action=\"passthrough\" reqtype=\"direct\" url=\"http://example.com/MFEwTzBNMEswSTAJBgUrDgMCGgUABBQ50otx%2Fh0Ztl%2Bz8SiPI7wEWVxDlQQUTiJUIBiV5uNu5g%2F6%123123123%3D\" sentbyte=400 rcvdbyte=0 direction=\"outgoing\" msg=\"URL belongs to an allowed category in policy\" method=\"domain\" cat=50 catdesc=\"Information and Computer Security\"",
+    "message": "time=12:20:33 devname=\"testDev\" devid=\"FGVM2VTM21000062\" eventtime=1741260033527521837 tz=\"+0100\" logid=\"0317013312\" type=\"utm\" subtype=\"webfilter\" eventtype=\"ftgd_allow\" level=\"notice\" vd=\"root\" policyid=106 poluuid=\"test-pol-uuid\" policytype=\"policy\" sessionid=958259665 srcip=198.51.100.4 srcport=55377 srccountry=\"Reserved\" srcintf=\"T_testDev\" srcintfrole=\"undefined\" srcuuid=\"test-src-uuid\" dstip=203.0.113.6 dstport=80 dstcountry=\"France\" dstintf=\"port4\" dstintfrole=\"undefined\" dstuuid=\"test-dst-uuid\" proto=6 service=\"HTTP\" hostname=\"example.com\" profile=\"Filtrage_web_Avanc\u00e9\" action=\"passthrough\" reqtype=\"direct\" url=\"http://example.com/MFEwTzBNMEswSTAJBgUrDgMCGgUABBQ50otx%2Fh0Ztl%2Bz8SiPI7wEWVxDlQQUTiJUIBiV5uNu5g%2F6%123123123%3D\" sentbyte=400 rcvdbyte=0 direction=\"outgoing\" msg=\"URL belongs to an allowed category in policy\" method=\"domain\" cat=50 catdesc=\"Information and Computer Security\"",
     "event": {
       "action": "passthrough",
       "category": "utm",
@@ -28,13 +28,13 @@
       "type": "webfilter"
     },
     "destination": {
-      "address": "3.4.5.6",
+      "address": "203.0.113.6",
       "bytes": 0,
       "domain": "example.com",
       "geo": {
         "country_name": "France"
       },
-      "ip": "3.4.5.6",
+      "ip": "203.0.113.6",
       "port": 80
     },
     "fortinet": {
@@ -81,8 +81,8 @@
         "testDev"
       ],
       "ip": [
-        "1.2.3.4",
-        "3.4.5.6"
+        "198.51.100.4",
+        "203.0.113.6"
       ]
     },
     "rule": {
@@ -90,9 +90,9 @@
       "ruleset": "policy"
     },
     "source": {
-      "address": "1.2.3.4",
+      "address": "198.51.100.4",
       "bytes": 400,
-      "ip": "1.2.3.4",
+      "ip": "198.51.100.4",
       "port": 55377
     },
     "url": {

--- a/Fortinet/fortigate/tests/webfilter.CEF.json
+++ b/Fortinet/fortigate/tests/webfilter.CEF.json
@@ -6,9 +6,9 @@
     "message": "CEF:0|Fortinet|Fortigate|v6.0.3|13056|utm:webfilter ftgd_blk blocked|4|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0316013056 cat=utm:webfilter FTNTFGTsubtype=webfilter FTNTFGTeventtype=ftgd_blk FTNTFGTlevel=warning FTNTFGTvd=vdom1 FTNTFGTeventtime=1545938629 FTNTFGTpolicyid=1 externalId=764 duser=example.com\\\\\\\\bob src=10.1.100.11 spt=59194 deviceInboundInterface=port12 FTNTFGTsrcintfrole=undefined dst=192.0.2.1 dpt=80 deviceOutboundInterface=port11 FTNTFGTdstintfrole=undefined proto=6 app=HTTP dhost=example.com FTNTFGTprofile=g-default act=blocked FTNTFGTreqtype=direct request=/bizsquads out=96 in=0 deviceDirection=1 msg=URL belongs to a denied category in policy FTNTFGTmethod=domain FTNTFGTcat=26 requestContext=Malicious Websites FTNTFGTcrscore=60 FTNTFGTcrlevel=high",
     "event": {
       "action": "blocked",
-      "category": "utm",
+      "category": "26",
       "code": "0316013056",
-      "dataset": "utm:webfilter",
+      "dataset": "26",
       "outcome": "success",
       "provider": "domain",
       "reason": "URL belongs to a denied category in policy"

--- a/Fortinet/fortigate/tests/webfilter.CEF.json
+++ b/Fortinet/fortigate/tests/webfilter.CEF.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|13056|utm:webfilter ftgd_blk blocked|4|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0316013056 cat=utm:webfilter FTNTFGTsubtype=webfilter FTNTFGTeventtype=ftgd_blk FTNTFGTlevel=warning FTNTFGTvd=vdom1 FTNTFGTeventtime=1545938629 FTNTFGTpolicyid=1 externalId=764 duser=example.com\\\\\\\\bob src=10.1.100.11 spt=59194 deviceInboundInterface=port12 FTNTFGTsrcintfrole=undefined dst=192.0.2.1 dpt=80 deviceOutboundInterface=port11 FTNTFGTdstintfrole=undefined proto=6 app=HTTP dhost=example.com FTNTFGTprofile=g-default act=blocked FTNTFGTreqtype=direct request=/bizsquads out=96 in=0 deviceDirection=1 msg=URL belongs to a denied category in policy FTNTFGTmethod=domain FTNTFGTcat=26 requestContext=Malicious Websites FTNTFGTcrscore=60 FTNTFGTcrlevel=high"
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|13056|utm:webfilter ftgd_blk blocked|4|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0316013056 cat=utm:webfilter FTNTFGTsubtype=webfilter FTNTFGTeventtype=ftgd_blk FTNTFGTlevel=warning FTNTFGTvd=vdom1 FTNTFGTeventtime=1545938629 FTNTFGTpolicyid=1 externalId=764 duser=example.com\\\\\\\\bob src=198.51.100.11 spt=59194 deviceInboundInterface=port12 FTNTFGTsrcintfrole=undefined dst=192.0.2.1 dpt=80 deviceOutboundInterface=port11 FTNTFGTdstintfrole=undefined proto=6 app=HTTP dhost=example.com FTNTFGTprofile=g-default act=blocked FTNTFGTreqtype=direct request=/bizsquads out=96 in=0 deviceDirection=1 msg=URL belongs to a denied category in policy FTNTFGTmethod=domain FTNTFGTcat=26 requestContext=Malicious Websites FTNTFGTcrscore=60 FTNTFGTcrlevel=high"
   },
   "expected": {
-    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|13056|utm:webfilter ftgd_blk blocked|4|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0316013056 cat=utm:webfilter FTNTFGTsubtype=webfilter FTNTFGTeventtype=ftgd_blk FTNTFGTlevel=warning FTNTFGTvd=vdom1 FTNTFGTeventtime=1545938629 FTNTFGTpolicyid=1 externalId=764 duser=example.com\\\\\\\\bob src=10.1.100.11 spt=59194 deviceInboundInterface=port12 FTNTFGTsrcintfrole=undefined dst=192.0.2.1 dpt=80 deviceOutboundInterface=port11 FTNTFGTdstintfrole=undefined proto=6 app=HTTP dhost=example.com FTNTFGTprofile=g-default act=blocked FTNTFGTreqtype=direct request=/bizsquads out=96 in=0 deviceDirection=1 msg=URL belongs to a denied category in policy FTNTFGTmethod=domain FTNTFGTcat=26 requestContext=Malicious Websites FTNTFGTcrscore=60 FTNTFGTcrlevel=high",
+    "message": "CEF:0|Fortinet|Fortigate|v6.0.3|13056|utm:webfilter ftgd_blk blocked|4|deviceExternalId=FGT5HD3915800610 FTNTFGTlogid=0316013056 cat=utm:webfilter FTNTFGTsubtype=webfilter FTNTFGTeventtype=ftgd_blk FTNTFGTlevel=warning FTNTFGTvd=vdom1 FTNTFGTeventtime=1545938629 FTNTFGTpolicyid=1 externalId=764 duser=example.com\\\\\\\\bob src=198.51.100.11 spt=59194 deviceInboundInterface=port12 FTNTFGTsrcintfrole=undefined dst=192.0.2.1 dpt=80 deviceOutboundInterface=port11 FTNTFGTdstintfrole=undefined proto=6 app=HTTP dhost=example.com FTNTFGTprofile=g-default act=blocked FTNTFGTreqtype=direct request=/bizsquads out=96 in=0 deviceDirection=1 msg=URL belongs to a denied category in policy FTNTFGTmethod=domain FTNTFGTcat=26 requestContext=Malicious Websites FTNTFGTcrscore=60 FTNTFGTcrlevel=high",
     "event": {
       "action": "blocked",
       "category": "26",
@@ -75,8 +75,8 @@
         "example.com"
       ],
       "ip": [
-        "10.1.100.11",
-        "192.0.2.1"
+        "192.0.2.1",
+        "198.51.100.11"
       ],
       "user": [
         "bob"
@@ -86,9 +86,9 @@
       "category": "Malicious Websites"
     },
     "source": {
-      "address": "10.1.100.11",
+      "address": "198.51.100.11",
       "bytes": 96,
-      "ip": "10.1.100.11",
+      "ip": "198.51.100.11",
       "port": 59194
     },
     "url": {


### PR DESCRIPTION
## Description

Relates to https://github.com/SekoiaLab/integration/issues/1793

### Fixed

- Anonymize all JSON test fixtures by replacing non-example email domains and non-reserved IP values with RFC 5737 test ranges, while preserving parsing-relevant value shapes

### Removed

- Remove parsing of credential-like password values from incident payloads to prevent high-risk exposure of raw secrets in normalized events
- Remove custom fields:
  - `fortinet.fortigate.password`

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] New intake format
- [ ] Update to existing intake format
- [x] Bug fix
- [ ] Documentation update
- [ ] Other (please describe):

## Affected Intake Formats

<!-- List the vendor/product formats affected by this PR -->

- Vendor/product: Fortinet/fortigate

## Checklist

<!-- Ensure all requirements are met before submitting -->

### 🔒 CRITICAL - Security Requirements (MUST BE VERIFIED FIRST)

- [ ] **No real email addresses** in test files (use: user@example.com, test@example.org)
- [ ] **No real passwords or API keys** (use: "P@ssw0rd!", "xxxxxxxxxxxx", "FAKE_TOKEN_123")
- [ ] **No real IP addresses** (use TEST-NET ranges: 192.0.2.x, 198.51.100.x, 203.0.113.x)
- [ ] **No real phone numbers** (use: +1-555-0100 or similar test numbers)
- [ ] **No real names or PII** (use: "John Doe", "Jane Smith", "User123")
- [ ] **No real company/organization names** in test data (unless public vendors)
- [ ] **No real usernames, hostnames, or domain names** (use: user1, host.example.com, test.corp)
- [ ] All test data has been anonymized and verified

### Required for All PRs

- [ ] Code has been linted
    - [ ] with the linter for manifest, smart-descriptions, and test files (`uv run python linter.py check --changes` in utils/)
    - [ ] with Prettier for the parser code files (`npx prettier --write <module>/<format>/ingest/parser.yml`)
- [ ] All CI/CD checks pass
- [ ] Changes follow the contribution guidelines in `CONTRIBUTING.md`

### Required for New/Updated Intake Formats

- [ ] Clear descriptions provided for modules and formats
- [ ] Logo files included for new modules/formats
- [ ] Parser test coverage is at least 75%
- [ ] At least one smart-description is provided
- [ ] README.md updated (if applicable)
- [ ] Taxonomy mappings are correct and documented
- [ ] Test cases cover edge cases and error handling

### Testing

- [ ] Local tests pass (`uv run pytest` in utils/)
- [ ] Sample data is representative and **completely anonymized**
- [ ] **No sensitive information** (PII, credentials, real IPs, real emails) in test files
- [ ] Test data uses example.com/example.org domains and TEST-NET IP ranges
- [ ] Parser handles malformed data gracefully

### Documentation

- [ ] Code changes are documented
- [ ] Smart-descriptions are clear and informative
- [ ] Field mappings are explained

## Additional Notes

<!-- Add any additional context, screenshots, or information that would help reviewers -->

## Related Issues

<!-- Link any related issues using #issue_number -->

Closes #

## Summary by Sourcery

Prevent credential exposure in Fortinet FortiGate events and sanitize the associated test fixtures.

Bug Fixes:
- Stop extracting password values from Fortinet FortiGate incident events to prevent raw credentials from reaching normalized events.

Enhancements:
- Remove the FortiGate password custom field from the normalized event schema.
- Sanitize FortiGate JSON test fixtures by replacing potentially sensitive email domains and IP addresses with safe example values while preserving parsing coverage.

## Summary by Sourcery

Prevent credential exposure in Fortinet FortiGate events and sanitize the associated test data.

Bug Fixes:
- Stop extracting password values from Fortinet FortiGate incident events to prevent credentials from reaching normalized events.

Enhancements:
- Remove the FortiGate password custom field from the normalized event schema.

Chores:
- Anonymize FortiGate JSON test fixtures with safe example email domains and reserved test IP ranges while preserving parsing coverage.