### PR TITLE
Fix: BeyondTrust Pra Sessions Fields (1919)

### DIFF
--- a/BeyondTrust/beyondtrust-pra-sessions/CHANGELOG.md
+++ b/BeyondTrust/beyondtrust-pra-sessions/CHANGELOG.md
@@ -6,3 +6,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## 2026-09-04
+
+### Added
+
+- Parse new ECS fields for participant identity and endpoint context in session events:
+  - `destination.ip`
+  - `destination.nat.ip`
+  - `destination.nat.port`
+  - `destination.user.full_name`
+  - `destination.user.id`
+  - `user.id`
+
+- Parse new custom fields for the session representative and the session counters:
+  - `beyondtrust.pra.destination_gsnumber`
+  - `beyondtrust.pra.file_delete_count`
+  - `beyondtrust.pra.file_move_count`
+  - `beyondtrust.pra.file_transfer_count`
+  - `beyondtrust.pra.primary_rep.gsnumber`
+  - `beyondtrust.pra.primary_rep.name`
+
+- Resolve the primary participants from the session-level `customer_list` and `rep_list` when the event references them by `gsnumber` only
+
+### Changed
+
+- Extend parsing of existing ECS fields for events carrying participant `public_ip`:
+  - `source.nat.ip`
+  - `source.nat.port`
+- Anchor the grok pattern extracting the NAT address and port, to reject partial matches
+- Filter the literal `Unknown` locally for `host.os.full`, instead of ignoring that value globally

--- a/BeyondTrust/beyondtrust-pra-sessions/_meta/fields.yml
+++ b/BeyondTrust/beyondtrust-pra-sessions/_meta/fields.yml
@@ -68,24 +68,9 @@ beyondtrust.pra.owner:
   name: beyondtrust.pra.owner
   type: keyword
 
-beyondtrust.pra.performed_by.gsnumber:
-  description: Identifier of the performer of the event inside the session
-  name: beyondtrust.pra.performed_by.gsnumber
-  type: keyword
-
 beyondtrust.pra.performed_by.type:
   description: ''
   name: beyondtrust.pra.performed_by.type
-  type: keyword
-
-beyondtrust.pra.primary_customer.gsnumber:
-  description: Identifier of the primary customer inside the session
-  name: beyondtrust.pra.primary_customer.gsnumber
-  type: keyword
-
-beyondtrust.pra.primary_customer.name:
-  description: Name of the primary customer of the session
-  name: beyondtrust.pra.primary_customer.name
   type: keyword
 
 beyondtrust.pra.primary_rep.gsnumber:

--- a/BeyondTrust/beyondtrust-pra-sessions/_meta/fields.yml
+++ b/BeyondTrust/beyondtrust-pra-sessions/_meta/fields.yml
@@ -13,6 +13,11 @@ beyondtrust.pra.approver_name:
   name: beyondtrust.pra.approver_name
   type: keyword
 
+beyondtrust.pra.destination_gsnumber:
+  description: Identifier of the destination of the event inside the session
+  name: beyondtrust.pra.destination_gsnumber
+  type: keyword
+
 beyondtrust.pra.destination_name:
   description: ''
   name: beyondtrust.pra.destination_name
@@ -22,6 +27,21 @@ beyondtrust.pra.destination_type:
   description: ''
   name: beyondtrust.pra.destination_type
   type: keyword
+
+beyondtrust.pra.file_delete_count:
+  description: Number of files deleted during the session
+  name: beyondtrust.pra.file_delete_count
+  type: long
+
+beyondtrust.pra.file_move_count:
+  description: Number of files moved during the session
+  name: beyondtrust.pra.file_move_count
+  type: long
+
+beyondtrust.pra.file_transfer_count:
+  description: Number of files transferred during the session
+  name: beyondtrust.pra.file_transfer_count
+  type: long
 
 beyondtrust.pra.jump_group.type:
   description: ''
@@ -48,9 +68,34 @@ beyondtrust.pra.owner:
   name: beyondtrust.pra.owner
   type: keyword
 
+beyondtrust.pra.performed_by.gsnumber:
+  description: Identifier of the performer of the event inside the session
+  name: beyondtrust.pra.performed_by.gsnumber
+  type: keyword
+
 beyondtrust.pra.performed_by.type:
   description: ''
   name: beyondtrust.pra.performed_by.type
+  type: keyword
+
+beyondtrust.pra.primary_customer.gsnumber:
+  description: Identifier of the primary customer inside the session
+  name: beyondtrust.pra.primary_customer.gsnumber
+  type: keyword
+
+beyondtrust.pra.primary_customer.name:
+  description: Name of the primary customer of the session
+  name: beyondtrust.pra.primary_customer.name
+  type: keyword
+
+beyondtrust.pra.primary_rep.gsnumber:
+  description: Identifier of the primary representative inside the session
+  name: beyondtrust.pra.primary_rep.gsnumber
+  type: keyword
+
+beyondtrust.pra.primary_rep.name:
+  description: Name of the primary representative of the session
+  name: beyondtrust.pra.primary_rep.name
   type: keyword
 
 beyondtrust.pra.push_agent_name:

--- a/BeyondTrust/beyondtrust-pra-sessions/_meta/smart-descriptions.json
+++ b/BeyondTrust/beyondtrust-pra-sessions/_meta/smart-descriptions.json
@@ -1,5 +1,30 @@
 [
   {
+    "value": "{beyondtrust.pra.session_id}: {event.code} rep={beyondtrust.pra.primary_rep.name}({beyondtrust.pra.primary_rep.gsnumber}) customer={destination.user.full_name}({destination.user.id})",
+    "conditions": [
+      {
+        "field": "event.code"
+      },
+      {
+        "field": "beyondtrust.pra.primary_rep.name"
+      },
+      {
+        "field": "destination.user.full_name"
+      }
+    ]
+  },
+  {
+    "value": "{beyondtrust.pra.session_id}: {event.code} transfers={beyondtrust.pra.file_transfer_count} moved={beyondtrust.pra.file_move_count} deleted={beyondtrust.pra.file_delete_count}",
+    "conditions": [
+      {
+        "field": "event.code"
+      },
+      {
+        "field": "beyondtrust.pra.file_transfer_count"
+      }
+    ]
+  },
+  {
     "value": "{beyondtrust.pra.session_id}: {event.code} by {user.name} from {source.ip}",
     "conditions": [
       {

--- a/BeyondTrust/beyondtrust-pra-sessions/ingest/parser.yml
+++ b/BeyondTrust/beyondtrust-pra-sessions/ingest/parser.yml
@@ -1,5 +1,5 @@
 name: beyondtrust-pra-sessions
-ignored_values: ["", "Unknown"]
+ignored_values: [""]
 pipeline:
   - name: parsed_event
     external:
@@ -15,7 +15,7 @@ pipeline:
       properties:
         input_field: "{{parsed_event.message.data.public_ip}}"
         output_field: message
-        pattern: '\[?%{IP:public_ip}\]?:%{INT:public_port}'
+        pattern: '^\[?%{IP:public_ip}\]?:%{INT:public_port}$'
 
   - name: parse_performed_by_public_ip
     filter: "{{parsed_event.message.get('performed_by', {}).get('public_ip') != None}}"
@@ -24,25 +24,43 @@ pipeline:
       properties:
         input_field: "{{parsed_event.message.performed_by.public_ip}}"
         output_field: message
-        pattern: '\[?%{IP:public_ip}\]?:%{INT:public_port}'
+        pattern: '^\[?%{IP:public_ip}\]?:%{INT:public_port}$'
+
+  # the session may carry its participants in session-level lists and reference the primary
+  # ones by gsnumber only: resolve them to get their addresses, hostname and operating system
+  - name: resolved_primary_customer
+    filter: "{{parsed_event.message.get('customer_list') != None and parsed_event.message.get('primary_customer', {}).get('gsnumber') != None}}"
+    external:
+      name: json.parse-json
+      properties:
+        output_field: message
+        input_field: "{{ '' ~ (parsed_event.message.customer_list | selectattr('gsnumber', 'equalto', parsed_event.message.primary_customer.gsnumber) | first | default({}, true) | tojson) }}"
+
+  - name: resolved_primary_rep
+    filter: "{{parsed_event.message.get('rep_list') != None and parsed_event.message.get('primary_rep', {}).get('gsnumber') != None}}"
+    external:
+      name: json.parse-json
+      properties:
+        output_field: message
+        input_field: "{{ '' ~ (parsed_event.message.rep_list | selectattr('gsnumber', 'equalto', parsed_event.message.primary_rep.gsnumber) | first | default({}, true) | tojson) }}"
 
   - name: parse_primary_customer_public_ip
-    filter: "{{parsed_event.message.get('primary_customer', {}).get('public_ip') != None}}"
+    filter: "{{(parsed_event.message.get('primary_customer', {}).get('public_ip') or resolved_primary_customer.message.public_ip) != None}}"
     external:
       name: grok.match
       properties:
-        input_field: "{{parsed_event.message.primary_customer.public_ip}}"
+        input_field: "{{parsed_event.message.primary_customer.public_ip or resolved_primary_customer.message.public_ip}}"
         output_field: message
-        pattern: '\[?%{IP:public_ip}\]?:%{INT:public_port}'
+        pattern: '^\[?%{IP:public_ip}\]?:%{INT:public_port}$'
 
   - name: parse_primary_rep_public_ip
-    filter: "{{parsed_event.message.get('primary_rep', {}).get('public_ip') != None}}"
+    filter: "{{(parsed_event.message.get('primary_rep', {}).get('public_ip') or resolved_primary_rep.message.public_ip) != None}}"
     external:
       name: grok.match
       properties:
-        input_field: "{{parsed_event.message.primary_rep.public_ip}}"
+        input_field: "{{parsed_event.message.primary_rep.public_ip or resolved_primary_rep.message.public_ip}}"
         output_field: message
-        pattern: '\[?%{IP:public_ip}\]?:%{INT:public_port}'
+        pattern: '^\[?%{IP:public_ip}\]?:%{INT:public_port}$'
 
   - name: parse_requesting_user
     filter: "{{parsed_event.message.get('data', {}).get('requesting_user') != None}}"
@@ -99,7 +117,7 @@ stages:
           source.nat.port: "{{parse_public_ip.message.public_port}}"
         filter: "{{parse_public_ip.message.public_ip | is_ipaddress}}"
 
-      # addresses of the performer, resolved from the participants of the session through its gsnumber
+      # addresses of the performer of the event
       - set:
           source.ip: "{{parsed_event.message.performed_by.private_ip}}"
         filter: "{{parsed_event.message.get('performed_by', {}).get('private_ip') | is_ipaddress}}"
@@ -111,12 +129,12 @@ stages:
 
       # Session Start and Session End have no performer: fall back to the representative running the session
       - set:
-          user.name: "{{parsed_event.message.primary_rep.name}}"
+          user.name: "{{parsed_event.message.primary_rep.name or resolved_primary_rep.message.name}}"
         filter: "{{parsed_event.message.get('performed_by') == None}}"
 
       - set:
-          source.ip: "{{parsed_event.message.primary_rep.private_ip}}"
-        filter: "{{parsed_event.message.get('performed_by') == None and parsed_event.message.get('primary_rep', {}).get('private_ip') | is_ipaddress}}"
+          source.ip: "{{parsed_event.message.primary_rep.private_ip or resolved_primary_rep.message.private_ip}}"
+        filter: "{{parsed_event.message.get('performed_by') == None and (parsed_event.message.primary_rep.private_ip or resolved_primary_rep.message.private_ip) | is_ipaddress}}"
 
       - set:
           source.nat.ip: "{{parse_primary_rep_public_ip.message.public_ip}}"
@@ -125,22 +143,30 @@ stages:
 
       # the endpoint of the customer is the machine reached through the session
       - set:
-          host.name: "{{parsed_event.message.primary_customer.hostname}}"
-          host.os.full: "{{parsed_event.message.primary_customer.os}}"
+          host.name: "{{parsed_event.message.primary_customer.hostname or resolved_primary_customer.message.hostname}}"
+
+      # BeyondTrust reports an unresolved operating system as the literal 'Unknown'
+      - set:
+          host.os.full: "{{parsed_event.message.primary_customer.os or resolved_primary_customer.message.os}}"
+        filter: "{{(parsed_event.message.primary_customer.os or resolved_primary_customer.message.os) != 'Unknown'}}"
 
       - set:
-          destination.ip: "{{parsed_event.message.primary_customer.private_ip}}"
-        filter: "{{parsed_event.message.get('primary_customer', {}).get('private_ip') | is_ipaddress}}"
+          destination.ip: "{{parsed_event.message.primary_customer.private_ip or resolved_primary_customer.message.private_ip}}"
+        filter: "{{(parsed_event.message.primary_customer.private_ip or resolved_primary_customer.message.private_ip) | is_ipaddress}}"
 
       - set:
           destination.nat.ip: "{{parse_primary_customer_public_ip.message.public_ip}}"
           destination.nat.port: "{{parse_primary_customer_public_ip.message.public_port}}"
         filter: "{{parse_primary_customer_public_ip.message.public_ip | is_ipaddress}}"
 
+      # the customer is the logical target of the event, distinct from the endpoint addresses above
+      - set:
+          destination.user.id: "{{parsed_event.message.primary_customer.gsnumber}}"
+          destination.user.full_name: "{{parsed_event.message.primary_customer.name or resolved_primary_customer.message.name}}"
+
       - set:
           event.reason: "{{parsed_event.message.body or parsed_event.message.data.failure_reason}}"
           host.name: "{{parsed_event.message.data.hostname}}"
-          host.os.full: "{{parsed_event.message.data.os}}"
           user.target.id: "{{parsed_event.message.data.user_id}}"
           user.target.name: "{{parsed_event.message.data.username}}"
           process.executable: "{{parsed_event.message.data.exeName}}"
@@ -155,6 +181,10 @@ stages:
           registry.value: "{{parsed_event.message.data.value_name}}"
 
       - set:
+          host.os.full: "{{parsed_event.message.data.os}}"
+        filter: "{{parsed_event.message.get('data', {}).get('os') not in (None, 'Unknown')}}"
+
+      - set:
           process.command_line: "{{parsed_event.message.data.text}}"
         filter: "{{parsed_event.message.event_type == 'Remote Shell Event'}}"
 
@@ -166,7 +196,7 @@ stages:
       - set:
           beyondtrust.pra.session_id: "{{parsed_event.message.session_id}}"
           beyondtrust.pra.performed_by.type: "{{parsed_event.message.performed_by.type}}"
-          beyondtrust.pra.performed_by.gsnumber: "{{parsed_event.message.performed_by.gsnumber}}"
+          user.id: "{{parsed_event.message.performed_by.gsnumber}}"
           beyondtrust.pra.jump_group.type: "{{parsed_event.message.jump_group.type}}"
           beyondtrust.pra.state: "{{parsed_event.message.data.state}}"
           beyondtrust.pra.owner: "{{parsed_event.message.data.owner}}"
@@ -175,9 +205,7 @@ stages:
           beyondtrust.pra.destination_gsnumber: "{{parsed_event.message.destination.gsnumber}}"
 
       - set:
-          beyondtrust.pra.primary_customer.name: "{{parsed_event.message.primary_customer.name}}"
-          beyondtrust.pra.primary_customer.gsnumber: "{{parsed_event.message.primary_customer.gsnumber}}"
-          beyondtrust.pra.primary_rep.name: "{{parsed_event.message.primary_rep.name}}"
+          beyondtrust.pra.primary_rep.name: "{{parsed_event.message.primary_rep.name or resolved_primary_rep.message.name}}"
           beyondtrust.pra.primary_rep.gsnumber: "{{parsed_event.message.primary_rep.gsnumber}}"
 
           beyondtrust.pra.file_transfer_count: "{{parsed_event.message.file_transfer_count}}"

--- a/BeyondTrust/beyondtrust-pra-sessions/ingest/parser.yml
+++ b/BeyondTrust/beyondtrust-pra-sessions/ingest/parser.yml
@@ -1,5 +1,5 @@
 name: beyondtrust-pra-sessions
-ignored_values: [""]
+ignored_values: ["", "Unknown"]
 pipeline:
   - name: parsed_event
     external:
@@ -14,6 +14,33 @@ pipeline:
       name: grok.match
       properties:
         input_field: "{{parsed_event.message.data.public_ip}}"
+        output_field: message
+        pattern: '\[?%{IP:public_ip}\]?:%{INT:public_port}'
+
+  - name: parse_performed_by_public_ip
+    filter: "{{parsed_event.message.get('performed_by', {}).get('public_ip') != None}}"
+    external:
+      name: grok.match
+      properties:
+        input_field: "{{parsed_event.message.performed_by.public_ip}}"
+        output_field: message
+        pattern: '\[?%{IP:public_ip}\]?:%{INT:public_port}'
+
+  - name: parse_primary_customer_public_ip
+    filter: "{{parsed_event.message.get('primary_customer', {}).get('public_ip') != None}}"
+    external:
+      name: grok.match
+      properties:
+        input_field: "{{parsed_event.message.primary_customer.public_ip}}"
+        output_field: message
+        pattern: '\[?%{IP:public_ip}\]?:%{INT:public_port}'
+
+  - name: parse_primary_rep_public_ip
+    filter: "{{parsed_event.message.get('primary_rep', {}).get('public_ip') != None}}"
+    external:
+      name: grok.match
+      properties:
+        input_field: "{{parsed_event.message.primary_rep.public_ip}}"
         output_field: message
         pattern: '\[?%{IP:public_ip}\]?:%{INT:public_port}'
 
@@ -72,6 +99,44 @@ stages:
           source.nat.port: "{{parse_public_ip.message.public_port}}"
         filter: "{{parse_public_ip.message.public_ip | is_ipaddress}}"
 
+      # addresses of the performer, resolved from the participants of the session through its gsnumber
+      - set:
+          source.ip: "{{parsed_event.message.performed_by.private_ip}}"
+        filter: "{{parsed_event.message.get('performed_by', {}).get('private_ip') | is_ipaddress}}"
+
+      - set:
+          source.nat.ip: "{{parse_performed_by_public_ip.message.public_ip}}"
+          source.nat.port: "{{parse_performed_by_public_ip.message.public_port}}"
+        filter: "{{parse_performed_by_public_ip.message.public_ip | is_ipaddress}}"
+
+      # Session Start and Session End have no performer: fall back to the representative running the session
+      - set:
+          user.name: "{{parsed_event.message.primary_rep.name}}"
+        filter: "{{parsed_event.message.get('performed_by') == None}}"
+
+      - set:
+          source.ip: "{{parsed_event.message.primary_rep.private_ip}}"
+        filter: "{{parsed_event.message.get('performed_by') == None and parsed_event.message.get('primary_rep', {}).get('private_ip') | is_ipaddress}}"
+
+      - set:
+          source.nat.ip: "{{parse_primary_rep_public_ip.message.public_ip}}"
+          source.nat.port: "{{parse_primary_rep_public_ip.message.public_port}}"
+        filter: "{{parsed_event.message.get('performed_by') == None and parse_primary_rep_public_ip.message.public_ip | is_ipaddress}}"
+
+      # the endpoint of the customer is the machine reached through the session
+      - set:
+          host.name: "{{parsed_event.message.primary_customer.hostname}}"
+          host.os.full: "{{parsed_event.message.primary_customer.os}}"
+
+      - set:
+          destination.ip: "{{parsed_event.message.primary_customer.private_ip}}"
+        filter: "{{parsed_event.message.get('primary_customer', {}).get('private_ip') | is_ipaddress}}"
+
+      - set:
+          destination.nat.ip: "{{parse_primary_customer_public_ip.message.public_ip}}"
+          destination.nat.port: "{{parse_primary_customer_public_ip.message.public_port}}"
+        filter: "{{parse_primary_customer_public_ip.message.public_ip | is_ipaddress}}"
+
       - set:
           event.reason: "{{parsed_event.message.body or parsed_event.message.data.failure_reason}}"
           host.name: "{{parsed_event.message.data.hostname}}"
@@ -101,11 +166,23 @@ stages:
       - set:
           beyondtrust.pra.session_id: "{{parsed_event.message.session_id}}"
           beyondtrust.pra.performed_by.type: "{{parsed_event.message.performed_by.type}}"
+          beyondtrust.pra.performed_by.gsnumber: "{{parsed_event.message.performed_by.gsnumber}}"
           beyondtrust.pra.jump_group.type: "{{parsed_event.message.jump_group.type}}"
           beyondtrust.pra.state: "{{parsed_event.message.data.state}}"
           beyondtrust.pra.owner: "{{parsed_event.message.data.owner}}"
           beyondtrust.pra.destination_type: "{{parsed_event.message.destination.type}}"
           beyondtrust.pra.destination_name: "{{parsed_event.message.destination.name}}"
+          beyondtrust.pra.destination_gsnumber: "{{parsed_event.message.destination.gsnumber}}"
+
+      - set:
+          beyondtrust.pra.primary_customer.name: "{{parsed_event.message.primary_customer.name}}"
+          beyondtrust.pra.primary_customer.gsnumber: "{{parsed_event.message.primary_customer.gsnumber}}"
+          beyondtrust.pra.primary_rep.name: "{{parsed_event.message.primary_rep.name}}"
+          beyondtrust.pra.primary_rep.gsnumber: "{{parsed_event.message.primary_rep.gsnumber}}"
+
+          beyondtrust.pra.file_transfer_count: "{{parsed_event.message.file_transfer_count}}"
+          beyondtrust.pra.file_move_count: "{{parsed_event.message.file_move_count}}"
+          beyondtrust.pra.file_delete_count: "{{parsed_event.message.file_delete_count}}"
 
       - set:
           beyondtrust.pra.request.id: "{{parsed_event.message.data.request_id}}"

--- a/BeyondTrust/beyondtrust-pra-sessions/tests/test_3.json
+++ b/BeyondTrust/beyondtrust-pra-sessions/tests/test_3.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "{\"timestamp\": \"1746516527\", \"event_type\": \"Jump Item Authorization Request Utilized\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"data\": {\"request_id\": \"789\", \"request_start_time\": \"2025-05-06 09:27:40 CEST\", \"request_duration\": \"4 hour(s)\", \"jump_policy_name\": \"Some policy\", \"jump_item_type\": \"Remote RDP Jump Shortcut\", \"jump_item_name\": \"1.2.3.4\", \"push_agent_name\": \"EXAMPLE_AGENT\", \"requesting_user\": \"John Doe (john.doe@example.com)\", \"requesting_user_id\": \"123\", \"approval_applies_to\": \"John Doe\", \"request_reason\": \"\", \"approver_name\": \"Site Admin\", \"request_approver\": \"jane.doe@example2.com\", \"approver_comments\": \"\"}, \"session_id\": \"21d6f40cfb511982e4424e0e250a9557\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}}"
+    "message": "{\"timestamp\": \"1746516527\", \"event_type\": \"Jump Item Authorization Request Utilized\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"data\": {\"request_id\": \"789\", \"request_start_time\": \"2025-05-06 09:27:40 CEST\", \"request_duration\": \"4 hour(s)\", \"jump_policy_name\": \"Some policy\", \"jump_item_type\": \"Remote RDP Jump Shortcut\", \"jump_item_name\": \"1.2.3.4\", \"push_agent_name\": \"EXAMPLE_AGENT\", \"requesting_user\": \"John Doe (john.doe@example.com)\", \"requesting_user_id\": \"1111\", \"approval_applies_to\": \"John Doe\", \"request_reason\": \"\", \"approver_name\": \"Site Admin\", \"request_approver\": \"jane.doe@example.org\", \"approver_comments\": \"\"}, \"session_id\": \"21d6f40cfb511982e4424e0e250a9557\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}}"
   },
   "expected": {
-    "message": "{\"timestamp\": \"1746516527\", \"event_type\": \"Jump Item Authorization Request Utilized\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"data\": {\"request_id\": \"789\", \"request_start_time\": \"2025-05-06 09:27:40 CEST\", \"request_duration\": \"4 hour(s)\", \"jump_policy_name\": \"Some policy\", \"jump_item_type\": \"Remote RDP Jump Shortcut\", \"jump_item_name\": \"1.2.3.4\", \"push_agent_name\": \"EXAMPLE_AGENT\", \"requesting_user\": \"John Doe (john.doe@example.com)\", \"requesting_user_id\": \"123\", \"approval_applies_to\": \"John Doe\", \"request_reason\": \"\", \"approver_name\": \"Site Admin\", \"request_approver\": \"jane.doe@example2.com\", \"approver_comments\": \"\"}, \"session_id\": \"21d6f40cfb511982e4424e0e250a9557\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}}",
+    "message": "{\"timestamp\": \"1746516527\", \"event_type\": \"Jump Item Authorization Request Utilized\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"data\": {\"request_id\": \"789\", \"request_start_time\": \"2025-05-06 09:27:40 CEST\", \"request_duration\": \"4 hour(s)\", \"jump_policy_name\": \"Some policy\", \"jump_item_type\": \"Remote RDP Jump Shortcut\", \"jump_item_name\": \"1.2.3.4\", \"push_agent_name\": \"EXAMPLE_AGENT\", \"requesting_user\": \"John Doe (john.doe@example.com)\", \"requesting_user_id\": \"1111\", \"approval_applies_to\": \"John Doe\", \"request_reason\": \"\", \"approver_name\": \"Site Admin\", \"request_approver\": \"jane.doe@example.org\", \"approver_comments\": \"\"}, \"session_id\": \"21d6f40cfb511982e4424e0e250a9557\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}}",
     "event": {
       "category": [
         "session"
@@ -34,7 +34,7 @@
           "id": "789",
           "start_time": "2025-05-06 09:27:40 CEST"
         },
-        "request_approver": "jane.doe@example2.com",
+        "request_approver": "jane.doe@example.org",
         "session_id": "21d6f40cfb511982e4424e0e250a9557"
       }
     },
@@ -53,7 +53,7 @@
     "source": {
       "user": {
         "email": "john.doe@example.com",
-        "id": "123",
+        "id": "1111",
         "name": "John Doe"
       }
     }

--- a/BeyondTrust/beyondtrust-pra-sessions/tests/test_3.json
+++ b/BeyondTrust/beyondtrust-pra-sessions/tests/test_3.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "{\"timestamp\": \"1746516527\", \"event_type\": \"Jump Item Authorization Request Utilized\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"data\": {\"request_id\": \"789\", \"request_start_time\": \"2025-05-06 09:27:40 CEST\", \"request_duration\": \"4 hour(s)\", \"jump_policy_name\": \"Some policy\", \"jump_item_type\": \"Remote RDP Jump Shortcut\", \"jump_item_name\": \"1.2.3.4\", \"push_agent_name\": \"EXAMPLE_AGENT\", \"requesting_user\": \"John Doe (john.doe@example.com)\", \"requesting_user_id\": \"1111\", \"approval_applies_to\": \"John Doe\", \"request_reason\": \"\", \"approver_name\": \"Site Admin\", \"request_approver\": \"jane.doe@example.org\", \"approver_comments\": \"\"}, \"session_id\": \"21d6f40cfb511982e4424e0e250a9557\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}}"
+    "message": "{\"timestamp\": \"1746516527\", \"event_type\": \"Jump Item Authorization Request Utilized\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"data\": {\"request_id\": \"789\", \"request_start_time\": \"2025-05-06 09:27:40 CEST\", \"request_duration\": \"4 hour(s)\", \"jump_policy_name\": \"Some policy\", \"jump_item_type\": \"Remote RDP Jump Shortcut\", \"jump_item_name\": \"192.0.2.10\", \"push_agent_name\": \"EXAMPLE_AGENT\", \"requesting_user\": \"John Doe (john.doe@example.com)\", \"requesting_user_id\": \"1111\", \"approval_applies_to\": \"John Doe\", \"request_reason\": \"\", \"approver_name\": \"Site Admin\", \"request_approver\": \"jane.doe@example.org\", \"approver_comments\": \"\"}, \"session_id\": \"21d6f40cfb511982e4424e0e250a9557\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}}"
   },
   "expected": {
-    "message": "{\"timestamp\": \"1746516527\", \"event_type\": \"Jump Item Authorization Request Utilized\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"data\": {\"request_id\": \"789\", \"request_start_time\": \"2025-05-06 09:27:40 CEST\", \"request_duration\": \"4 hour(s)\", \"jump_policy_name\": \"Some policy\", \"jump_item_type\": \"Remote RDP Jump Shortcut\", \"jump_item_name\": \"1.2.3.4\", \"push_agent_name\": \"EXAMPLE_AGENT\", \"requesting_user\": \"John Doe (john.doe@example.com)\", \"requesting_user_id\": \"1111\", \"approval_applies_to\": \"John Doe\", \"request_reason\": \"\", \"approver_name\": \"Site Admin\", \"request_approver\": \"jane.doe@example.org\", \"approver_comments\": \"\"}, \"session_id\": \"21d6f40cfb511982e4424e0e250a9557\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}}",
+    "message": "{\"timestamp\": \"1746516527\", \"event_type\": \"Jump Item Authorization Request Utilized\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"data\": {\"request_id\": \"789\", \"request_start_time\": \"2025-05-06 09:27:40 CEST\", \"request_duration\": \"4 hour(s)\", \"jump_policy_name\": \"Some policy\", \"jump_item_type\": \"Remote RDP Jump Shortcut\", \"jump_item_name\": \"192.0.2.10\", \"push_agent_name\": \"EXAMPLE_AGENT\", \"requesting_user\": \"John Doe (john.doe@example.com)\", \"requesting_user_id\": \"1111\", \"approval_applies_to\": \"John Doe\", \"request_reason\": \"\", \"approver_name\": \"Site Admin\", \"request_approver\": \"jane.doe@example.org\", \"approver_comments\": \"\"}, \"session_id\": \"21d6f40cfb511982e4424e0e250a9557\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}}",
     "event": {
       "category": [
         "session"
@@ -23,7 +23,7 @@
         "jump_group": {
           "type": "shared"
         },
-        "jump_item_name": "1.2.3.4",
+        "jump_item_name": "192.0.2.10",
         "jump_item_type": "Remote RDP Jump Shortcut",
         "jump_policy_name": "Some policy",
         "performed_by": {

--- a/BeyondTrust/beyondtrust-pra-sessions/tests/test_chat_message.json
+++ b/BeyondTrust/beyondtrust-pra-sessions/tests/test_chat_message.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "{\"timestamp\": \"1732809736\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"Chat Message\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"destination\": {\"type\": \"everyone\", \"name\": \"Everyone\"}, \"body\": \"Admin can now view and control the endpoint.\"}"
+    "message": "{\"timestamp\": \"1732809736\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Chat Message\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"destination\": {\"type\": \"everyone\", \"name\": \"Everyone\"}, \"body\": \"Admin can now view and control the endpoint.\"}"
   },
   "expected": {
-    "message": "{\"timestamp\": \"1732809736\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"Chat Message\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"destination\": {\"type\": \"everyone\", \"name\": \"Everyone\"}, \"body\": \"Admin can now view and control the endpoint.\"}",
+    "message": "{\"timestamp\": \"1732809736\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Chat Message\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"destination\": {\"type\": \"everyone\", \"name\": \"Everyone\"}, \"body\": \"Admin can now view and control the endpoint.\"}",
     "event": {
       "category": [
         "session"
@@ -30,7 +30,7 @@
       }
     },
     "group": {
-      "name": "Sekoia.io integration"
+      "name": "EXAMPLE_JUMP_GROUP"
     },
     "observer": {
       "product": "Privileged Remote Access",

--- a/BeyondTrust/beyondtrust-pra-sessions/tests/test_conference_member_added.json
+++ b/BeyondTrust/beyondtrust-pra-sessions/tests/test_conference_member_added.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "{\"timestamp\": \"1732809735\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"Conference Member Added\", \"performed_by\": {\"type\": \"customer\", \"name\": \"Sekoia.io integration\"}, \"data\": {\"name\": \"Sekoia.io integration\", \"private_ip\": \"1.2.3.4\", \"public_ip\": \"4.3.2.1:50677\", \"hostname\": \"Windows2022\", \"os\": \"Windows Server 2022 Datacenter Azure Edition (21H2)\"}}"
+    "message": "{\"timestamp\": \"1732809735\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Conference Member Added\", \"performed_by\": {\"type\": \"customer\", \"name\": \"John Doe\"}, \"data\": {\"name\": \"John Doe\", \"private_ip\": \"1.2.3.4\", \"public_ip\": \"4.3.2.1:50677\", \"hostname\": \"workstation.test.local\", \"os\": \"Windows Server 2022 Datacenter Azure Edition (21H2)\"}}"
   },
   "expected": {
-    "message": "{\"timestamp\": \"1732809735\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"Conference Member Added\", \"performed_by\": {\"type\": \"customer\", \"name\": \"Sekoia.io integration\"}, \"data\": {\"name\": \"Sekoia.io integration\", \"private_ip\": \"1.2.3.4\", \"public_ip\": \"4.3.2.1:50677\", \"hostname\": \"Windows2022\", \"os\": \"Windows Server 2022 Datacenter Azure Edition (21H2)\"}}",
+    "message": "{\"timestamp\": \"1732809735\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Conference Member Added\", \"performed_by\": {\"type\": \"customer\", \"name\": \"John Doe\"}, \"data\": {\"name\": \"John Doe\", \"private_ip\": \"1.2.3.4\", \"public_ip\": \"4.3.2.1:50677\", \"hostname\": \"workstation.test.local\", \"os\": \"Windows Server 2022 Datacenter Azure Edition (21H2)\"}}",
     "event": {
       "category": [
         "configuration"
@@ -27,10 +27,10 @@
       }
     },
     "group": {
-      "name": "Sekoia.io integration"
+      "name": "EXAMPLE_JUMP_GROUP"
     },
     "host": {
-      "name": "Windows2022",
+      "name": "workstation.test.local",
       "os": {
         "full": "Windows Server 2022 Datacenter Azure Edition (21H2)"
       }
@@ -45,7 +45,7 @@
         "4.3.2.1"
       ],
       "user": [
-        "Sekoia.io integration"
+        "John Doe"
       ]
     },
     "source": {
@@ -57,7 +57,7 @@
       }
     },
     "user": {
-      "name": "Sekoia.io integration"
+      "name": "John Doe"
     }
   }
 }

--- a/BeyondTrust/beyondtrust-pra-sessions/tests/test_conference_member_added.json
+++ b/BeyondTrust/beyondtrust-pra-sessions/tests/test_conference_member_added.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "{\"timestamp\": \"1732809735\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Conference Member Added\", \"performed_by\": {\"type\": \"customer\", \"name\": \"John Doe\"}, \"data\": {\"name\": \"John Doe\", \"private_ip\": \"1.2.3.4\", \"public_ip\": \"4.3.2.1:50677\", \"hostname\": \"workstation.test.local\", \"os\": \"Windows Server 2022 Datacenter Azure Edition (21H2)\"}}"
+    "message": "{\"timestamp\": \"1732809735\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Conference Member Added\", \"performed_by\": {\"type\": \"customer\", \"name\": \"John Doe\"}, \"data\": {\"name\": \"John Doe\", \"private_ip\": \"192.0.2.10\", \"public_ip\": \"203.0.113.20:50677\", \"hostname\": \"workstation.test.local\", \"os\": \"Windows Server 2022 Datacenter Azure Edition (21H2)\"}}"
   },
   "expected": {
-    "message": "{\"timestamp\": \"1732809735\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Conference Member Added\", \"performed_by\": {\"type\": \"customer\", \"name\": \"John Doe\"}, \"data\": {\"name\": \"John Doe\", \"private_ip\": \"1.2.3.4\", \"public_ip\": \"4.3.2.1:50677\", \"hostname\": \"workstation.test.local\", \"os\": \"Windows Server 2022 Datacenter Azure Edition (21H2)\"}}",
+    "message": "{\"timestamp\": \"1732809735\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Conference Member Added\", \"performed_by\": {\"type\": \"customer\", \"name\": \"John Doe\"}, \"data\": {\"name\": \"John Doe\", \"private_ip\": \"192.0.2.10\", \"public_ip\": \"203.0.113.20:50677\", \"hostname\": \"workstation.test.local\", \"os\": \"Windows Server 2022 Datacenter Azure Edition (21H2)\"}}",
     "event": {
       "category": [
         "configuration"
@@ -41,18 +41,18 @@
     },
     "related": {
       "ip": [
-        "1.2.3.4",
-        "4.3.2.1"
+        "192.0.2.10",
+        "203.0.113.20"
       ],
       "user": [
         "John Doe"
       ]
     },
     "source": {
-      "address": "1.2.3.4",
-      "ip": "1.2.3.4",
+      "address": "192.0.2.10",
+      "ip": "192.0.2.10",
       "nat": {
-        "ip": "4.3.2.1",
+        "ip": "203.0.113.20",
         "port": 50677
       }
     },

--- a/BeyondTrust/beyondtrust-pra-sessions/tests/test_conference_member_added_2.json
+++ b/BeyondTrust/beyondtrust-pra-sessions/tests/test_conference_member_added_2.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "{\"timestamp\": \"1733239566\", \"event_type\": \"Conference Member Added\", \"performed_by\": {\"type\": \"representative\", \"name\": \"Admin\"}, \"data\": {\"private_name\": \"Admin\", \"username\": \"admin\", \"private_ip\": \"Unknown\", \"public_ip\": \"[2a01:e34:ec57:b230:f188:56c5:7089:d987]:56722\", \"os\": \"Unknown\", \"user_id\": \"1\"}, \"session_id\": \"e9e99aeb9ad54fb381634498502c5a1b\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}}"
+    "message": "{\"timestamp\": \"1733239566\", \"event_type\": \"Conference Member Added\", \"performed_by\": {\"type\": \"representative\", \"name\": \"Admin\"}, \"data\": {\"private_name\": \"Admin\", \"username\": \"admin\", \"private_ip\": \"Unknown\", \"public_ip\": \"[2001:db8::1]:56722\", \"os\": \"Unknown\", \"user_id\": \"1\"}, \"session_id\": \"e9e99aeb9ad54fb381634498502c5a1b\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}}"
   },
   "expected": {
-    "message": "{\"timestamp\": \"1733239566\", \"event_type\": \"Conference Member Added\", \"performed_by\": {\"type\": \"representative\", \"name\": \"Admin\"}, \"data\": {\"private_name\": \"Admin\", \"username\": \"admin\", \"private_ip\": \"Unknown\", \"public_ip\": \"[2a01:e34:ec57:b230:f188:56c5:7089:d987]:56722\", \"os\": \"Unknown\", \"user_id\": \"1\"}, \"session_id\": \"e9e99aeb9ad54fb381634498502c5a1b\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}}",
+    "message": "{\"timestamp\": \"1733239566\", \"event_type\": \"Conference Member Added\", \"performed_by\": {\"type\": \"representative\", \"name\": \"Admin\"}, \"data\": {\"private_name\": \"Admin\", \"username\": \"admin\", \"private_ip\": \"Unknown\", \"public_ip\": \"[2001:db8::1]:56722\", \"os\": \"Unknown\", \"user_id\": \"1\"}, \"session_id\": \"e9e99aeb9ad54fb381634498502c5a1b\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}}",
     "event": {
       "category": [
         "configuration"
@@ -27,12 +27,7 @@
       }
     },
     "group": {
-      "name": "Sekoia.io integration"
-    },
-    "host": {
-      "os": {
-        "full": "Unknown"
-      }
+      "name": "EXAMPLE_JUMP_GROUP"
     },
     "observer": {
       "product": "Privileged Remote Access",
@@ -40,7 +35,7 @@
     },
     "related": {
       "ip": [
-        "2a01:e34:ec57:b230:f188:56c5:7089:d987"
+        "2001:db8::1"
       ],
       "user": [
         "Admin",
@@ -49,7 +44,7 @@
     },
     "source": {
       "nat": {
-        "ip": "2a01:e34:ec57:b230:f188:56c5:7089:d987",
+        "ip": "2001:db8::1",
         "port": 56722
       }
     },

--- a/BeyondTrust/beyondtrust-pra-sessions/tests/test_conference_member_departed.json
+++ b/BeyondTrust/beyondtrust-pra-sessions/tests/test_conference_member_departed.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "{\"timestamp\": \"1732810703\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"Conference Member Departed\", \"performed_by\": {\"type\": \"customer\", \"name\": \"Sekoia.io integration\"}}"
+    "message": "{\"timestamp\": \"1732810703\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Conference Member Departed\", \"performed_by\": {\"type\": \"customer\", \"name\": \"John Doe\"}}"
   },
   "expected": {
-    "message": "{\"timestamp\": \"1732810703\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"Conference Member Departed\", \"performed_by\": {\"type\": \"customer\", \"name\": \"Sekoia.io integration\"}}",
+    "message": "{\"timestamp\": \"1732810703\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Conference Member Departed\", \"performed_by\": {\"type\": \"customer\", \"name\": \"John Doe\"}}",
     "event": {
       "category": [
         "configuration"
@@ -27,7 +27,7 @@
       }
     },
     "group": {
-      "name": "Sekoia.io integration"
+      "name": "EXAMPLE_JUMP_GROUP"
     },
     "observer": {
       "product": "Privileged Remote Access",
@@ -35,11 +35,11 @@
     },
     "related": {
       "user": [
-        "Sekoia.io integration"
+        "John Doe"
       ]
     },
     "user": {
-      "name": "Sekoia.io integration"
+      "name": "John Doe"
     }
   }
 }

--- a/BeyondTrust/beyondtrust-pra-sessions/tests/test_conference_member_state_changed.json
+++ b/BeyondTrust/beyondtrust-pra-sessions/tests/test_conference_member_state_changed.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "{\"timestamp\": \"1732809735\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"Conference Member State Changed\", \"performed_by\": {\"type\": \"customer\", \"name\": \"Sekoia.io integration\"}, \"data\": {\"state\": \"connected\"}}"
+    "message": "{\"timestamp\": \"1732809735\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Conference Member State Changed\", \"performed_by\": {\"type\": \"customer\", \"name\": \"John Doe\"}, \"data\": {\"state\": \"connected\"}}"
   },
   "expected": {
-    "message": "{\"timestamp\": \"1732809735\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"Conference Member State Changed\", \"performed_by\": {\"type\": \"customer\", \"name\": \"Sekoia.io integration\"}, \"data\": {\"state\": \"connected\"}}",
+    "message": "{\"timestamp\": \"1732809735\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Conference Member State Changed\", \"performed_by\": {\"type\": \"customer\", \"name\": \"John Doe\"}, \"data\": {\"state\": \"connected\"}}",
     "event": {
       "category": [
         "configuration"
@@ -28,7 +28,7 @@
       }
     },
     "group": {
-      "name": "Sekoia.io integration"
+      "name": "EXAMPLE_JUMP_GROUP"
     },
     "observer": {
       "product": "Privileged Remote Access",
@@ -36,11 +36,11 @@
     },
     "related": {
       "user": [
-        "Sekoia.io integration"
+        "John Doe"
       ]
     },
     "user": {
-      "name": "Sekoia.io integration"
+      "name": "John Doe"
     }
   }
 }

--- a/BeyondTrust/beyondtrust-pra-sessions/tests/test_conference_member_state_changed_2.json
+++ b/BeyondTrust/beyondtrust-pra-sessions/tests/test_conference_member_state_changed_2.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "{\"timestamp\": \"1732809884\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"Conference Member State Changed\", \"performed_by\": {\"type\": \"customer\", \"name\": \"Sekoia.io integration\"}, \"data\": {\"state\": \"disconnected\"}}"
+    "message": "{\"timestamp\": \"1732809884\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Conference Member State Changed\", \"performed_by\": {\"type\": \"customer\", \"name\": \"John Doe\"}, \"data\": {\"state\": \"disconnected\"}}"
   },
   "expected": {
-    "message": "{\"timestamp\": \"1732809884\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"Conference Member State Changed\", \"performed_by\": {\"type\": \"customer\", \"name\": \"Sekoia.io integration\"}, \"data\": {\"state\": \"disconnected\"}}",
+    "message": "{\"timestamp\": \"1732809884\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Conference Member State Changed\", \"performed_by\": {\"type\": \"customer\", \"name\": \"John Doe\"}, \"data\": {\"state\": \"disconnected\"}}",
     "event": {
       "category": [
         "configuration"
@@ -28,7 +28,7 @@
       }
     },
     "group": {
-      "name": "Sekoia.io integration"
+      "name": "EXAMPLE_JUMP_GROUP"
     },
     "observer": {
       "product": "Privileged Remote Access",
@@ -36,11 +36,11 @@
     },
     "related": {
       "user": [
-        "Sekoia.io integration"
+        "John Doe"
       ]
     },
     "user": {
-      "name": "Sekoia.io integration"
+      "name": "John Doe"
     }
   }
 }

--- a/BeyondTrust/beyondtrust-pra-sessions/tests/test_conference_owner_changed.json
+++ b/BeyondTrust/beyondtrust-pra-sessions/tests/test_conference_owner_changed.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "{\"timestamp\": \"1732809735\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"Conference Owner Changed\", \"destination\": {\"type\": \"system\", \"name\": \"Pre-start Conference\"}, \"data\": {\"owner\": \"Pre-start Conference\"}}"
+    "message": "{\"timestamp\": \"1732809735\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Conference Owner Changed\", \"destination\": {\"type\": \"system\", \"name\": \"Pre-start Conference\"}, \"data\": {\"owner\": \"Pre-start Conference\"}}"
   },
   "expected": {
-    "message": "{\"timestamp\": \"1732809735\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"Conference Owner Changed\", \"destination\": {\"type\": \"system\", \"name\": \"Pre-start Conference\"}, \"data\": {\"owner\": \"Pre-start Conference\"}}",
+    "message": "{\"timestamp\": \"1732809735\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Conference Owner Changed\", \"destination\": {\"type\": \"system\", \"name\": \"Pre-start Conference\"}, \"data\": {\"owner\": \"Pre-start Conference\"}}",
     "event": {
       "category": [
         "configuration"
@@ -27,7 +27,7 @@
       }
     },
     "group": {
-      "name": "Sekoia.io integration"
+      "name": "EXAMPLE_JUMP_GROUP"
     },
     "observer": {
       "product": "Privileged Remote Access",

--- a/BeyondTrust/beyondtrust-pra-sessions/tests/test_conference_owner_changed_participants.json
+++ b/BeyondTrust/beyondtrust-pra-sessions/tests/test_conference_owner_changed_participants.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "message": "{\"timestamp\": \"1733239565\", \"event_type\": \"Conference Owner Changed\", \"performed_by\": {\"type\": \"representative\", \"name\": \"Admin\", \"gsnumber\": \"21\", \"public_ip\": \"[2001:db8::1]:56722\"}, \"data\": {\"owner\": \"Pre-start Conference\"}, \"destination\": {\"type\": \"system\", \"name\": \"Pre-start Conference\", \"gsnumber\": \"0\"}, \"session_id\": \"e9e99aeb9ad54fb381634498502c5a1b\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"primary_customer\": {\"name\": \"John Doe\", \"gsnumber\": \"22\", \"private_ip\": \"1.2.3.4\", \"public_ip\": \"4.3.2.1:61606\", \"hostname\": \"workstation.test.local\", \"os\": \"Windows Server 2022 Datacenter Azure Edition (21H2)\"}, \"primary_rep\": {\"name\": \"Admin\", \"gsnumber\": \"21\", \"public_ip\": \"[2001:db8::1]:56722\"}, \"file_transfer_count\": \"2\", \"file_move_count\": \"0\", \"file_delete_count\": \"1\"}",
+    "message": "{\"timestamp\": \"1733239565\", \"event_type\": \"Conference Owner Changed\", \"performed_by\": {\"type\": \"representative\", \"name\": \"Admin\", \"gsnumber\": \"21\", \"public_ip\": \"[2001:db8::1]:56722\"}, \"data\": {\"owner\": \"Pre-start Conference\"}, \"destination\": {\"type\": \"system\", \"name\": \"Pre-start Conference\", \"gsnumber\": \"0\"}, \"session_id\": \"e9e99aeb9ad54fb381634498502c5a1b\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"primary_customer\": {\"name\": \"John Doe\", \"gsnumber\": \"22\", \"private_ip\": \"192.0.2.10\", \"public_ip\": \"203.0.113.20:61606\", \"hostname\": \"workstation.test.local\", \"os\": \"Windows Server 2022 Datacenter Azure Edition (21H2)\"}, \"primary_rep\": {\"name\": \"Admin\", \"gsnumber\": \"21\", \"public_ip\": \"[2001:db8::1]:56722\"}, \"file_transfer_count\": \"2\", \"file_move_count\": \"0\", \"file_delete_count\": \"1\"}",
     "sekoiaio": {
       "intake": {
         "dialect": "BeyondTrust Privileged Remote Access Session",
@@ -9,7 +9,7 @@
     }
   },
   "expected": {
-    "message": "{\"timestamp\": \"1733239565\", \"event_type\": \"Conference Owner Changed\", \"performed_by\": {\"type\": \"representative\", \"name\": \"Admin\", \"gsnumber\": \"21\", \"public_ip\": \"[2001:db8::1]:56722\"}, \"data\": {\"owner\": \"Pre-start Conference\"}, \"destination\": {\"type\": \"system\", \"name\": \"Pre-start Conference\", \"gsnumber\": \"0\"}, \"session_id\": \"e9e99aeb9ad54fb381634498502c5a1b\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"primary_customer\": {\"name\": \"John Doe\", \"gsnumber\": \"22\", \"private_ip\": \"1.2.3.4\", \"public_ip\": \"4.3.2.1:61606\", \"hostname\": \"workstation.test.local\", \"os\": \"Windows Server 2022 Datacenter Azure Edition (21H2)\"}, \"primary_rep\": {\"name\": \"Admin\", \"gsnumber\": \"21\", \"public_ip\": \"[2001:db8::1]:56722\"}, \"file_transfer_count\": \"2\", \"file_move_count\": \"0\", \"file_delete_count\": \"1\"}",
+    "message": "{\"timestamp\": \"1733239565\", \"event_type\": \"Conference Owner Changed\", \"performed_by\": {\"type\": \"representative\", \"name\": \"Admin\", \"gsnumber\": \"21\", \"public_ip\": \"[2001:db8::1]:56722\"}, \"data\": {\"owner\": \"Pre-start Conference\"}, \"destination\": {\"type\": \"system\", \"name\": \"Pre-start Conference\", \"gsnumber\": \"0\"}, \"session_id\": \"e9e99aeb9ad54fb381634498502c5a1b\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"primary_customer\": {\"name\": \"John Doe\", \"gsnumber\": \"22\", \"private_ip\": \"192.0.2.10\", \"public_ip\": \"203.0.113.20:61606\", \"hostname\": \"workstation.test.local\", \"os\": \"Windows Server 2022 Datacenter Azure Edition (21H2)\"}, \"primary_rep\": {\"name\": \"Admin\", \"gsnumber\": \"21\", \"public_ip\": \"[2001:db8::1]:56722\"}, \"file_transfer_count\": \"2\", \"file_move_count\": \"0\", \"file_delete_count\": \"1\"}",
     "event": {
       "category": [
         "configuration"
@@ -34,12 +34,7 @@
         },
         "owner": "Pre-start Conference",
         "performed_by": {
-          "gsnumber": "21",
           "type": "representative"
-        },
-        "primary_customer": {
-          "gsnumber": "22",
-          "name": "John Doe"
         },
         "primary_rep": {
           "gsnumber": "21",
@@ -49,11 +44,15 @@
       }
     },
     "destination": {
-      "address": "1.2.3.4",
-      "ip": "1.2.3.4",
+      "address": "192.0.2.10",
+      "ip": "192.0.2.10",
       "nat": {
-        "ip": "4.3.2.1",
+        "ip": "203.0.113.20",
         "port": 61606
+      },
+      "user": {
+        "full_name": "John Doe",
+        "id": "22"
       }
     },
     "group": {
@@ -71,9 +70,9 @@
     },
     "related": {
       "ip": [
-        "1.2.3.4",
+        "192.0.2.10",
         "2001:db8::1",
-        "4.3.2.1"
+        "203.0.113.20"
       ],
       "user": [
         "Admin"
@@ -86,6 +85,7 @@
       }
     },
     "user": {
+      "id": "21",
       "name": "Admin"
     }
   }

--- a/BeyondTrust/beyondtrust-pra-sessions/tests/test_conference_owner_changed_participants.json
+++ b/BeyondTrust/beyondtrust-pra-sessions/tests/test_conference_owner_changed_participants.json
@@ -1,0 +1,92 @@
+{
+  "input": {
+    "message": "{\"timestamp\": \"1733239565\", \"event_type\": \"Conference Owner Changed\", \"performed_by\": {\"type\": \"representative\", \"name\": \"Admin\", \"gsnumber\": \"21\", \"public_ip\": \"[2001:db8::1]:56722\"}, \"data\": {\"owner\": \"Pre-start Conference\"}, \"destination\": {\"type\": \"system\", \"name\": \"Pre-start Conference\", \"gsnumber\": \"0\"}, \"session_id\": \"e9e99aeb9ad54fb381634498502c5a1b\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"primary_customer\": {\"name\": \"John Doe\", \"gsnumber\": \"22\", \"private_ip\": \"1.2.3.4\", \"public_ip\": \"4.3.2.1:61606\", \"hostname\": \"workstation.test.local\", \"os\": \"Windows Server 2022 Datacenter Azure Edition (21H2)\"}, \"primary_rep\": {\"name\": \"Admin\", \"gsnumber\": \"21\", \"public_ip\": \"[2001:db8::1]:56722\"}, \"file_transfer_count\": \"2\", \"file_move_count\": \"0\", \"file_delete_count\": \"1\"}",
+    "sekoiaio": {
+      "intake": {
+        "dialect": "BeyondTrust Privileged Remote Access Session",
+        "dialect_uuid": "f6cfddb4-543a-41fe-9802-c66b7c90366d"
+      }
+    }
+  },
+  "expected": {
+    "message": "{\"timestamp\": \"1733239565\", \"event_type\": \"Conference Owner Changed\", \"performed_by\": {\"type\": \"representative\", \"name\": \"Admin\", \"gsnumber\": \"21\", \"public_ip\": \"[2001:db8::1]:56722\"}, \"data\": {\"owner\": \"Pre-start Conference\"}, \"destination\": {\"type\": \"system\", \"name\": \"Pre-start Conference\", \"gsnumber\": \"0\"}, \"session_id\": \"e9e99aeb9ad54fb381634498502c5a1b\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"primary_customer\": {\"name\": \"John Doe\", \"gsnumber\": \"22\", \"private_ip\": \"1.2.3.4\", \"public_ip\": \"4.3.2.1:61606\", \"hostname\": \"workstation.test.local\", \"os\": \"Windows Server 2022 Datacenter Azure Edition (21H2)\"}, \"primary_rep\": {\"name\": \"Admin\", \"gsnumber\": \"21\", \"public_ip\": \"[2001:db8::1]:56722\"}, \"file_transfer_count\": \"2\", \"file_move_count\": \"0\", \"file_delete_count\": \"1\"}",
+    "event": {
+      "category": [
+        "configuration"
+      ],
+      "code": "Conference Owner Changed",
+      "dataset": "session",
+      "type": [
+        "change"
+      ]
+    },
+    "@timestamp": "2024-12-03T15:26:05Z",
+    "beyondtrust": {
+      "pra": {
+        "destination_gsnumber": "0",
+        "destination_name": "Pre-start Conference",
+        "destination_type": "system",
+        "file_delete_count": 1,
+        "file_move_count": 0,
+        "file_transfer_count": 2,
+        "jump_group": {
+          "type": "shared"
+        },
+        "owner": "Pre-start Conference",
+        "performed_by": {
+          "gsnumber": "21",
+          "type": "representative"
+        },
+        "primary_customer": {
+          "gsnumber": "22",
+          "name": "John Doe"
+        },
+        "primary_rep": {
+          "gsnumber": "21",
+          "name": "Admin"
+        },
+        "session_id": "e9e99aeb9ad54fb381634498502c5a1b"
+      }
+    },
+    "destination": {
+      "address": "1.2.3.4",
+      "ip": "1.2.3.4",
+      "nat": {
+        "ip": "4.3.2.1",
+        "port": 61606
+      }
+    },
+    "group": {
+      "name": "EXAMPLE_JUMP_GROUP"
+    },
+    "host": {
+      "name": "workstation.test.local",
+      "os": {
+        "full": "Windows Server 2022 Datacenter Azure Edition (21H2)"
+      }
+    },
+    "observer": {
+      "product": "Privileged Remote Access",
+      "vendor": "BeyondTrust"
+    },
+    "related": {
+      "ip": [
+        "1.2.3.4",
+        "2001:db8::1",
+        "4.3.2.1"
+      ],
+      "user": [
+        "Admin"
+      ]
+    },
+    "source": {
+      "nat": {
+        "ip": "2001:db8::1",
+        "port": 56722
+      }
+    },
+    "user": {
+      "name": "Admin"
+    }
+  }
+}

--- a/BeyondTrust/beyondtrust-pra-sessions/tests/test_directory_created.json
+++ b/BeyondTrust/beyondtrust-pra-sessions/tests/test_directory_created.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "{\"timestamp\": \"1733239957\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"Directory Created\", \"performed_by\": {\"type\": \"representative\", \"name\": \"Admin\"}, \"destination\": {\"type\": \"customer\", \"name\": \"Sekoia.io integration\"}, \"data\": {\"path\": \"C:\\\\Users\\\\jdoe\\\\Downloads\\\\mydirectory\"}}"
+    "message": "{\"timestamp\": \"1733239957\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Directory Created\", \"performed_by\": {\"type\": \"representative\", \"name\": \"Admin\"}, \"destination\": {\"type\": \"customer\", \"name\": \"John Doe\"}, \"data\": {\"path\": \"C:\\\\Users\\\\jdoe\\\\Downloads\\\\mydirectory\"}}"
   },
   "expected": {
-    "message": "{\"timestamp\": \"1733239957\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"Directory Created\", \"performed_by\": {\"type\": \"representative\", \"name\": \"Admin\"}, \"destination\": {\"type\": \"customer\", \"name\": \"Sekoia.io integration\"}, \"data\": {\"path\": \"C:\\\\Users\\\\jdoe\\\\Downloads\\\\mydirectory\"}}",
+    "message": "{\"timestamp\": \"1733239957\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Directory Created\", \"performed_by\": {\"type\": \"representative\", \"name\": \"Admin\"}, \"destination\": {\"type\": \"customer\", \"name\": \"John Doe\"}, \"data\": {\"path\": \"C:\\\\Users\\\\jdoe\\\\Downloads\\\\mydirectory\"}}",
     "event": {
       "category": [
         "file"
@@ -17,7 +17,7 @@
     "@timestamp": "2024-12-03T15:32:37Z",
     "beyondtrust": {
       "pra": {
-        "destination_name": "Sekoia.io integration",
+        "destination_name": "John Doe",
         "destination_type": "customer",
         "jump_group": {
           "type": "shared"
@@ -34,7 +34,7 @@
       "path": "C:\\Users\\jdoe\\Downloads\\mydirectory"
     },
     "group": {
-      "name": "Sekoia.io integration"
+      "name": "EXAMPLE_JUMP_GROUP"
     },
     "observer": {
       "product": "Privileged Remote Access",

--- a/BeyondTrust/beyondtrust-pra-sessions/tests/test_file_deleted.json
+++ b/BeyondTrust/beyondtrust-pra-sessions/tests/test_file_deleted.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "{\"timestamp\": \"1733239990\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"File Deleted\", \"performed_by\": {\"type\": \"representative\", \"name\": \"Admin\"}, \"destination\": {\"type\": \"customer\", \"name\": \"Sekoia.io integration\"}, \"data\": {\"filename\": \"C:\\\\Users\\\\jdoe\\\\Downloads\\\\image.png\", \"filesize\": \"1296708\"}}"
+    "message": "{\"timestamp\": \"1733239990\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"File Deleted\", \"performed_by\": {\"type\": \"representative\", \"name\": \"Admin\"}, \"destination\": {\"type\": \"customer\", \"name\": \"John Doe\"}, \"data\": {\"filename\": \"C:\\\\Users\\\\jdoe\\\\Downloads\\\\image.png\", \"filesize\": \"1296708\"}}"
   },
   "expected": {
-    "message": "{\"timestamp\": \"1733239990\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"File Deleted\", \"performed_by\": {\"type\": \"representative\", \"name\": \"Admin\"}, \"destination\": {\"type\": \"customer\", \"name\": \"Sekoia.io integration\"}, \"data\": {\"filename\": \"C:\\\\Users\\\\jdoe\\\\Downloads\\\\image.png\", \"filesize\": \"1296708\"}}",
+    "message": "{\"timestamp\": \"1733239990\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"File Deleted\", \"performed_by\": {\"type\": \"representative\", \"name\": \"Admin\"}, \"destination\": {\"type\": \"customer\", \"name\": \"John Doe\"}, \"data\": {\"filename\": \"C:\\\\Users\\\\jdoe\\\\Downloads\\\\image.png\", \"filesize\": \"1296708\"}}",
     "event": {
       "category": [
         "file"
@@ -17,7 +17,7 @@
     "@timestamp": "2024-12-03T15:33:10Z",
     "beyondtrust": {
       "pra": {
-        "destination_name": "Sekoia.io integration",
+        "destination_name": "John Doe",
         "destination_type": "customer",
         "jump_group": {
           "type": "shared"
@@ -33,7 +33,7 @@
       "size": 1296708
     },
     "group": {
-      "name": "Sekoia.io integration"
+      "name": "EXAMPLE_JUMP_GROUP"
     },
     "observer": {
       "product": "Privileged Remote Access",

--- a/BeyondTrust/beyondtrust-pra-sessions/tests/test_file_download.json
+++ b/BeyondTrust/beyondtrust-pra-sessions/tests/test_file_download.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "{\"timestamp\": \"1733239745\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"File Download\", \"performed_by\": {\"type\": \"customer\", \"name\": \"Sekoia.io integration\"}, \"destination\": {\"type\": \"representative\", \"name\": \"Admin\"}, \"data\": {\"filename\": \"C:\\\\Users\\\\jdoe\\\\Downloads\\\\nxlog-reference-manual.pdf\", \"filesize\": \"3229469\"}}"
+    "message": "{\"timestamp\": \"1733239745\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"File Download\", \"performed_by\": {\"type\": \"customer\", \"name\": \"John Doe\"}, \"destination\": {\"type\": \"representative\", \"name\": \"Admin\"}, \"data\": {\"filename\": \"C:\\\\Users\\\\jdoe\\\\Downloads\\\\nxlog-reference-manual.pdf\", \"filesize\": \"3229469\"}}"
   },
   "expected": {
-    "message": "{\"timestamp\": \"1733239745\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"File Download\", \"performed_by\": {\"type\": \"customer\", \"name\": \"Sekoia.io integration\"}, \"destination\": {\"type\": \"representative\", \"name\": \"Admin\"}, \"data\": {\"filename\": \"C:\\\\Users\\\\jdoe\\\\Downloads\\\\nxlog-reference-manual.pdf\", \"filesize\": \"3229469\"}}",
+    "message": "{\"timestamp\": \"1733239745\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"File Download\", \"performed_by\": {\"type\": \"customer\", \"name\": \"John Doe\"}, \"destination\": {\"type\": \"representative\", \"name\": \"Admin\"}, \"data\": {\"filename\": \"C:\\\\Users\\\\jdoe\\\\Downloads\\\\nxlog-reference-manual.pdf\", \"filesize\": \"3229469\"}}",
     "event": {
       "category": [
         "file"
@@ -33,7 +33,7 @@
       "size": 3229469
     },
     "group": {
-      "name": "Sekoia.io integration"
+      "name": "EXAMPLE_JUMP_GROUP"
     },
     "observer": {
       "product": "Privileged Remote Access",
@@ -41,11 +41,11 @@
     },
     "related": {
       "user": [
-        "Sekoia.io integration"
+        "John Doe"
       ]
     },
     "user": {
-      "name": "Sekoia.io integration"
+      "name": "John Doe"
     }
   }
 }

--- a/BeyondTrust/beyondtrust-pra-sessions/tests/test_file_upload.json
+++ b/BeyondTrust/beyondtrust-pra-sessions/tests/test_file_upload.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "{\"timestamp\": \"1733239944\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"File Upload\", \"performed_by\": {\"type\": \"representative\", \"name\": \"Admin\"}, \"destination\": {\"type\": \"customer\", \"name\": \"Sekoia.io integration\"}, \"data\": {\"filename\": \"C:\\\\Users\\\\jdoe\\\\Downloads\\\\image.png\", \"filesize\": \"1296708\"}}"
+    "message": "{\"timestamp\": \"1733239944\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"File Upload\", \"performed_by\": {\"type\": \"representative\", \"name\": \"Admin\"}, \"destination\": {\"type\": \"customer\", \"name\": \"John Doe\"}, \"data\": {\"filename\": \"C:\\\\Users\\\\jdoe\\\\Downloads\\\\image.png\", \"filesize\": \"1296708\"}}"
   },
   "expected": {
-    "message": "{\"timestamp\": \"1733239944\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"File Upload\", \"performed_by\": {\"type\": \"representative\", \"name\": \"Admin\"}, \"destination\": {\"type\": \"customer\", \"name\": \"Sekoia.io integration\"}, \"data\": {\"filename\": \"C:\\\\Users\\\\jdoe\\\\Downloads\\\\image.png\", \"filesize\": \"1296708\"}}",
+    "message": "{\"timestamp\": \"1733239944\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"File Upload\", \"performed_by\": {\"type\": \"representative\", \"name\": \"Admin\"}, \"destination\": {\"type\": \"customer\", \"name\": \"John Doe\"}, \"data\": {\"filename\": \"C:\\\\Users\\\\jdoe\\\\Downloads\\\\image.png\", \"filesize\": \"1296708\"}}",
     "event": {
       "category": [
         "file"
@@ -17,7 +17,7 @@
     "@timestamp": "2024-12-03T15:32:24Z",
     "beyondtrust": {
       "pra": {
-        "destination_name": "Sekoia.io integration",
+        "destination_name": "John Doe",
         "destination_type": "customer",
         "jump_group": {
           "type": "shared"
@@ -33,7 +33,7 @@
       "size": 1296708
     },
     "group": {
-      "name": "Sekoia.io integration"
+      "name": "EXAMPLE_JUMP_GROUP"
     },
     "observer": {
       "product": "Privileged Remote Access",

--- a/BeyondTrust/beyondtrust-pra-sessions/tests/test_session_end.json
+++ b/BeyondTrust/beyondtrust-pra-sessions/tests/test_session_end.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "{\"timestamp\": \"1732810703\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"Session End\"}"
+    "message": "{\"timestamp\": \"1732810703\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Session End\"}"
   },
   "expected": {
-    "message": "{\"timestamp\": \"1732810703\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"Session End\"}",
+    "message": "{\"timestamp\": \"1732810703\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Session End\"}",
     "event": {
       "category": [
         "session"
@@ -24,7 +24,7 @@
       }
     },
     "group": {
-      "name": "Sekoia.io integration"
+      "name": "EXAMPLE_JUMP_GROUP"
     },
     "observer": {
       "product": "Privileged Remote Access",

--- a/BeyondTrust/beyondtrust-pra-sessions/tests/test_session_foreground_window_changed.json
+++ b/BeyondTrust/beyondtrust-pra-sessions/tests/test_session_foreground_window_changed.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "{\"timestamp\": \"1732810070\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"Session Foreground Window Changed\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"data\": {\"exeName\": \"C:\\\\Program Files (x86)\\\\Microsoft\\\\Edge\\\\Application\\\\msedge.exe\", \"windowName\": \"BeyondTrust Integration Middleware Administration Tool - Profile 1 - Microsoft\\u200b Edge\"}}"
+    "message": "{\"timestamp\": \"1732810070\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Session Foreground Window Changed\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"data\": {\"exeName\": \"C:\\\\Program Files (x86)\\\\Microsoft\\\\Edge\\\\Application\\\\msedge.exe\", \"windowName\": \"BeyondTrust Integration Middleware Administration Tool - Profile 1 - Microsoft\\u200b Edge\"}}"
   },
   "expected": {
-    "message": "{\"timestamp\": \"1732810070\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"Session Foreground Window Changed\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"data\": {\"exeName\": \"C:\\\\Program Files (x86)\\\\Microsoft\\\\Edge\\\\Application\\\\msedge.exe\", \"windowName\": \"BeyondTrust Integration Middleware Administration Tool - Profile 1 - Microsoft\\u200b Edge\"}}",
+    "message": "{\"timestamp\": \"1732810070\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Session Foreground Window Changed\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"data\": {\"exeName\": \"C:\\\\Program Files (x86)\\\\Microsoft\\\\Edge\\\\Application\\\\msedge.exe\", \"windowName\": \"BeyondTrust Integration Middleware Administration Tool - Profile 1 - Microsoft\\u200b Edge\"}}",
     "event": {
       "category": [
         "session"
@@ -27,7 +27,7 @@
       }
     },
     "group": {
-      "name": "Sekoia.io integration"
+      "name": "EXAMPLE_JUMP_GROUP"
     },
     "observer": {
       "product": "Privileged Remote Access",

--- a/BeyondTrust/beyondtrust-pra-sessions/tests/test_session_mouse_left_clicked.json
+++ b/BeyondTrust/beyondtrust-pra-sessions/tests/test_session_mouse_left_clicked.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "{\"timestamp\": \"1732809895\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"Session Mouse Left Clicked\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"data\": {\"exeName\": \"C:\\\\Program Files (x86)\\\\Microsoft\\\\Edge\\\\Application\\\\msedge.exe\", \"windowName\": \"BeyondTrust Integration Middleware Administration Tool - Profile 1 - Microsoft\\u200b Edge\"}}"
+    "message": "{\"timestamp\": \"1732809895\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Session Mouse Left Clicked\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"data\": {\"exeName\": \"C:\\\\Program Files (x86)\\\\Microsoft\\\\Edge\\\\Application\\\\msedge.exe\", \"windowName\": \"BeyondTrust Integration Middleware Administration Tool - Profile 1 - Microsoft\\u200b Edge\"}}"
   },
   "expected": {
-    "message": "{\"timestamp\": \"1732809895\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"Session Mouse Left Clicked\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"data\": {\"exeName\": \"C:\\\\Program Files (x86)\\\\Microsoft\\\\Edge\\\\Application\\\\msedge.exe\", \"windowName\": \"BeyondTrust Integration Middleware Administration Tool - Profile 1 - Microsoft\\u200b Edge\"}}",
+    "message": "{\"timestamp\": \"1732809895\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Session Mouse Left Clicked\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"data\": {\"exeName\": \"C:\\\\Program Files (x86)\\\\Microsoft\\\\Edge\\\\Application\\\\msedge.exe\", \"windowName\": \"BeyondTrust Integration Middleware Administration Tool - Profile 1 - Microsoft\\u200b Edge\"}}",
     "event": {
       "category": [
         "session"
@@ -27,7 +27,7 @@
       }
     },
     "group": {
-      "name": "Sekoia.io integration"
+      "name": "EXAMPLE_JUMP_GROUP"
     },
     "observer": {
       "product": "Privileged Remote Access",

--- a/BeyondTrust/beyondtrust-pra-sessions/tests/test_session_mouse_left_clicked_2.json
+++ b/BeyondTrust/beyondtrust-pra-sessions/tests/test_session_mouse_left_clicked_2.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "{\"timestamp\": \"1733240092\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"Session Mouse Left Clicked\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"data\": {\"targetName\": \"MyValue\", \"targetType\": \"list item\", \"exeName\": \"C:\\\\Windows\\\\regedit.exe\", \"windowName\": \"Registry Editor\"}}"
+    "message": "{\"timestamp\": \"1733240092\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Session Mouse Left Clicked\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"data\": {\"targetName\": \"MyValue\", \"targetType\": \"list item\", \"exeName\": \"C:\\\\Windows\\\\regedit.exe\", \"windowName\": \"Registry Editor\"}}"
   },
   "expected": {
-    "message": "{\"timestamp\": \"1733240092\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"Session Mouse Left Clicked\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"data\": {\"targetName\": \"MyValue\", \"targetType\": \"list item\", \"exeName\": \"C:\\\\Windows\\\\regedit.exe\", \"windowName\": \"Registry Editor\"}}",
+    "message": "{\"timestamp\": \"1733240092\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Session Mouse Left Clicked\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"data\": {\"targetName\": \"MyValue\", \"targetType\": \"list item\", \"exeName\": \"C:\\\\Windows\\\\regedit.exe\", \"windowName\": \"Registry Editor\"}}",
     "event": {
       "category": [
         "session"
@@ -27,7 +27,7 @@
       }
     },
     "group": {
-      "name": "Sekoia.io integration"
+      "name": "EXAMPLE_JUMP_GROUP"
     },
     "observer": {
       "product": "Privileged Remote Access",

--- a/BeyondTrust/beyondtrust-pra-sessions/tests/test_session_start.json
+++ b/BeyondTrust/beyondtrust-pra-sessions/tests/test_session_start.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "{\"timestamp\": \"1732809735\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"Session Start\"}"
+    "message": "{\"timestamp\": \"1732809735\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Session Start\"}"
   },
   "expected": {
-    "message": "{\"timestamp\": \"1732809735\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"Session Start\"}",
+    "message": "{\"timestamp\": \"1732809735\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Session Start\"}",
     "event": {
       "category": [
         "session"
@@ -24,7 +24,7 @@
       }
     },
     "group": {
-      "name": "Sekoia.io integration"
+      "name": "EXAMPLE_JUMP_GROUP"
     },
     "observer": {
       "product": "Privileged Remote Access",

--- a/BeyondTrust/beyondtrust-pra-sessions/tests/test_session_start_participants.json
+++ b/BeyondTrust/beyondtrust-pra-sessions/tests/test_session_start_participants.json
@@ -1,0 +1,84 @@
+{
+  "input": {
+    "message": "{\"timestamp\": \"1733239565\", \"event_type\": \"Session Start\", \"session_id\": \"e9e99aeb9ad54fb381634498502c5a1b\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"primary_customer\": {\"name\": \"John Doe\", \"gsnumber\": \"22\", \"private_ip\": \"1.2.3.4\", \"public_ip\": \"4.3.2.1:61606\", \"hostname\": \"workstation.test.local\", \"os\": \"Windows Server 2022 Datacenter Azure Edition (21H2)\"}, \"primary_rep\": {\"name\": \"Admin\", \"gsnumber\": \"21\", \"public_ip\": \"[2001:db8::1]:56722\"}, \"file_transfer_count\": \"2\", \"file_move_count\": \"0\", \"file_delete_count\": \"1\"}",
+    "sekoiaio": {
+      "intake": {
+        "dialect": "BeyondTrust Privileged Remote Access Session",
+        "dialect_uuid": "f6cfddb4-543a-41fe-9802-c66b7c90366d"
+      }
+    }
+  },
+  "expected": {
+    "message": "{\"timestamp\": \"1733239565\", \"event_type\": \"Session Start\", \"session_id\": \"e9e99aeb9ad54fb381634498502c5a1b\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"primary_customer\": {\"name\": \"John Doe\", \"gsnumber\": \"22\", \"private_ip\": \"1.2.3.4\", \"public_ip\": \"4.3.2.1:61606\", \"hostname\": \"workstation.test.local\", \"os\": \"Windows Server 2022 Datacenter Azure Edition (21H2)\"}, \"primary_rep\": {\"name\": \"Admin\", \"gsnumber\": \"21\", \"public_ip\": \"[2001:db8::1]:56722\"}, \"file_transfer_count\": \"2\", \"file_move_count\": \"0\", \"file_delete_count\": \"1\"}",
+    "event": {
+      "category": [
+        "session"
+      ],
+      "code": "Session Start",
+      "dataset": "session",
+      "type": [
+        "start"
+      ]
+    },
+    "@timestamp": "2024-12-03T15:26:05Z",
+    "beyondtrust": {
+      "pra": {
+        "file_delete_count": 1,
+        "file_move_count": 0,
+        "file_transfer_count": 2,
+        "jump_group": {
+          "type": "shared"
+        },
+        "primary_customer": {
+          "gsnumber": "22",
+          "name": "John Doe"
+        },
+        "primary_rep": {
+          "gsnumber": "21",
+          "name": "Admin"
+        },
+        "session_id": "e9e99aeb9ad54fb381634498502c5a1b"
+      }
+    },
+    "destination": {
+      "address": "1.2.3.4",
+      "ip": "1.2.3.4",
+      "nat": {
+        "ip": "4.3.2.1",
+        "port": 61606
+      }
+    },
+    "group": {
+      "name": "EXAMPLE_JUMP_GROUP"
+    },
+    "host": {
+      "name": "workstation.test.local",
+      "os": {
+        "full": "Windows Server 2022 Datacenter Azure Edition (21H2)"
+      }
+    },
+    "observer": {
+      "product": "Privileged Remote Access",
+      "vendor": "BeyondTrust"
+    },
+    "related": {
+      "ip": [
+        "1.2.3.4",
+        "2001:db8::1",
+        "4.3.2.1"
+      ],
+      "user": [
+        "Admin"
+      ]
+    },
+    "source": {
+      "nat": {
+        "ip": "2001:db8::1",
+        "port": 56722
+      }
+    },
+    "user": {
+      "name": "Admin"
+    }
+  }
+}

--- a/BeyondTrust/beyondtrust-pra-sessions/tests/test_session_start_participants.json
+++ b/BeyondTrust/beyondtrust-pra-sessions/tests/test_session_start_participants.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "message": "{\"timestamp\": \"1733239565\", \"event_type\": \"Session Start\", \"session_id\": \"e9e99aeb9ad54fb381634498502c5a1b\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"primary_customer\": {\"name\": \"John Doe\", \"gsnumber\": \"22\", \"private_ip\": \"1.2.3.4\", \"public_ip\": \"4.3.2.1:61606\", \"hostname\": \"workstation.test.local\", \"os\": \"Windows Server 2022 Datacenter Azure Edition (21H2)\"}, \"primary_rep\": {\"name\": \"Admin\", \"gsnumber\": \"21\", \"public_ip\": \"[2001:db8::1]:56722\"}, \"file_transfer_count\": \"2\", \"file_move_count\": \"0\", \"file_delete_count\": \"1\"}",
+    "message": "{\"timestamp\": \"1733239565\", \"event_type\": \"Session Start\", \"session_id\": \"e9e99aeb9ad54fb381634498502c5a1b\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"primary_customer\": {\"name\": \"John Doe\", \"gsnumber\": \"22\", \"private_ip\": \"192.0.2.10\", \"public_ip\": \"203.0.113.20:61606\", \"hostname\": \"workstation.test.local\", \"os\": \"Windows Server 2022 Datacenter Azure Edition (21H2)\"}, \"primary_rep\": {\"name\": \"Admin\", \"gsnumber\": \"21\", \"public_ip\": \"[2001:db8::1]:56722\"}, \"file_transfer_count\": \"2\", \"file_move_count\": \"0\", \"file_delete_count\": \"1\"}",
     "sekoiaio": {
       "intake": {
         "dialect": "BeyondTrust Privileged Remote Access Session",
@@ -9,7 +9,7 @@
     }
   },
   "expected": {
-    "message": "{\"timestamp\": \"1733239565\", \"event_type\": \"Session Start\", \"session_id\": \"e9e99aeb9ad54fb381634498502c5a1b\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"primary_customer\": {\"name\": \"John Doe\", \"gsnumber\": \"22\", \"private_ip\": \"1.2.3.4\", \"public_ip\": \"4.3.2.1:61606\", \"hostname\": \"workstation.test.local\", \"os\": \"Windows Server 2022 Datacenter Azure Edition (21H2)\"}, \"primary_rep\": {\"name\": \"Admin\", \"gsnumber\": \"21\", \"public_ip\": \"[2001:db8::1]:56722\"}, \"file_transfer_count\": \"2\", \"file_move_count\": \"0\", \"file_delete_count\": \"1\"}",
+    "message": "{\"timestamp\": \"1733239565\", \"event_type\": \"Session Start\", \"session_id\": \"e9e99aeb9ad54fb381634498502c5a1b\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"primary_customer\": {\"name\": \"John Doe\", \"gsnumber\": \"22\", \"private_ip\": \"192.0.2.10\", \"public_ip\": \"203.0.113.20:61606\", \"hostname\": \"workstation.test.local\", \"os\": \"Windows Server 2022 Datacenter Azure Edition (21H2)\"}, \"primary_rep\": {\"name\": \"Admin\", \"gsnumber\": \"21\", \"public_ip\": \"[2001:db8::1]:56722\"}, \"file_transfer_count\": \"2\", \"file_move_count\": \"0\", \"file_delete_count\": \"1\"}",
     "event": {
       "category": [
         "session"
@@ -29,10 +29,6 @@
         "jump_group": {
           "type": "shared"
         },
-        "primary_customer": {
-          "gsnumber": "22",
-          "name": "John Doe"
-        },
         "primary_rep": {
           "gsnumber": "21",
           "name": "Admin"
@@ -41,11 +37,15 @@
       }
     },
     "destination": {
-      "address": "1.2.3.4",
-      "ip": "1.2.3.4",
+      "address": "192.0.2.10",
+      "ip": "192.0.2.10",
       "nat": {
-        "ip": "4.3.2.1",
+        "ip": "203.0.113.20",
         "port": 61606
+      },
+      "user": {
+        "full_name": "John Doe",
+        "id": "22"
       }
     },
     "group": {
@@ -63,9 +63,9 @@
     },
     "related": {
       "ip": [
-        "1.2.3.4",
+        "192.0.2.10",
         "2001:db8::1",
-        "4.3.2.1"
+        "203.0.113.20"
       ],
       "user": [
         "Admin"

--- a/BeyondTrust/beyondtrust-pra-sessions/tests/test_session_start_participants_list.json
+++ b/BeyondTrust/beyondtrust-pra-sessions/tests/test_session_start_participants_list.json
@@ -1,0 +1,84 @@
+{
+  "input": {
+    "message": "{\"timestamp\": \"1733239565\", \"event_type\": \"Session Start\", \"session_id\": \"e9e99aeb9ad54fb381634498502c5a1b\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"customer_list\": [{\"gsnumber\": \"23\", \"name\": \"Jane Doe\", \"private_ip\": \"192.0.2.11\", \"public_ip\": \"203.0.113.21:61607\", \"hostname\": \"laptop.test.local\", \"os\": \"Unknown\"}, {\"gsnumber\": \"22\", \"name\": \"John Doe\", \"private_ip\": \"192.0.2.10\", \"public_ip\": \"203.0.113.20:61606\", \"hostname\": \"workstation.test.local\", \"os\": \"Windows Server 2022 Datacenter Azure Edition (21H2)\"}], \"rep_list\": [{\"gsnumber\": \"20\", \"name\": \"Other Rep\", \"public_ip\": \"203.0.113.30:56721\"}, {\"gsnumber\": \"21\", \"name\": \"Admin\", \"public_ip\": \"[2001:db8::1]:56722\"}], \"primary_customer\": {\"gsnumber\": \"22\"}, \"primary_rep\": {\"gsnumber\": \"21\"}, \"file_transfer_count\": \"2\", \"file_move_count\": \"0\", \"file_delete_count\": \"1\"}",
+    "sekoiaio": {
+      "intake": {
+        "dialect": "BeyondTrust Privileged Remote Access Session",
+        "dialect_uuid": "f6cfddb4-543a-41fe-9802-c66b7c90366d"
+      }
+    }
+  },
+  "expected": {
+    "message": "{\"timestamp\": \"1733239565\", \"event_type\": \"Session Start\", \"session_id\": \"e9e99aeb9ad54fb381634498502c5a1b\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"customer_list\": [{\"gsnumber\": \"23\", \"name\": \"Jane Doe\", \"private_ip\": \"192.0.2.11\", \"public_ip\": \"203.0.113.21:61607\", \"hostname\": \"laptop.test.local\", \"os\": \"Unknown\"}, {\"gsnumber\": \"22\", \"name\": \"John Doe\", \"private_ip\": \"192.0.2.10\", \"public_ip\": \"203.0.113.20:61606\", \"hostname\": \"workstation.test.local\", \"os\": \"Windows Server 2022 Datacenter Azure Edition (21H2)\"}], \"rep_list\": [{\"gsnumber\": \"20\", \"name\": \"Other Rep\", \"public_ip\": \"203.0.113.30:56721\"}, {\"gsnumber\": \"21\", \"name\": \"Admin\", \"public_ip\": \"[2001:db8::1]:56722\"}], \"primary_customer\": {\"gsnumber\": \"22\"}, \"primary_rep\": {\"gsnumber\": \"21\"}, \"file_transfer_count\": \"2\", \"file_move_count\": \"0\", \"file_delete_count\": \"1\"}",
+    "event": {
+      "category": [
+        "session"
+      ],
+      "code": "Session Start",
+      "dataset": "session",
+      "type": [
+        "start"
+      ]
+    },
+    "@timestamp": "2024-12-03T15:26:05Z",
+    "beyondtrust": {
+      "pra": {
+        "file_delete_count": 1,
+        "file_move_count": 0,
+        "file_transfer_count": 2,
+        "jump_group": {
+          "type": "shared"
+        },
+        "primary_rep": {
+          "gsnumber": "21",
+          "name": "Admin"
+        },
+        "session_id": "e9e99aeb9ad54fb381634498502c5a1b"
+      }
+    },
+    "destination": {
+      "address": "192.0.2.10",
+      "ip": "192.0.2.10",
+      "nat": {
+        "ip": "203.0.113.20",
+        "port": 61606
+      },
+      "user": {
+        "full_name": "John Doe",
+        "id": "22"
+      }
+    },
+    "group": {
+      "name": "EXAMPLE_JUMP_GROUP"
+    },
+    "host": {
+      "name": "workstation.test.local",
+      "os": {
+        "full": "Windows Server 2022 Datacenter Azure Edition (21H2)"
+      }
+    },
+    "observer": {
+      "product": "Privileged Remote Access",
+      "vendor": "BeyondTrust"
+    },
+    "related": {
+      "ip": [
+        "192.0.2.10",
+        "2001:db8::1",
+        "203.0.113.20"
+      ],
+      "user": [
+        "Admin"
+      ]
+    },
+    "source": {
+      "nat": {
+        "ip": "2001:db8::1",
+        "port": 56722
+      }
+    },
+    "user": {
+      "name": "Admin"
+    }
+  }
+}

--- a/BeyondTrust/beyondtrust-pra-sessions/tests/test_session_window_closed.json
+++ b/BeyondTrust/beyondtrust-pra-sessions/tests/test_session_window_closed.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "{\"timestamp\": \"1733239748\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"Session Window Closed\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"data\": {\"exeName\": \"C:\\\\Windows\\\\SystemApps\\\\ShellExperienceHost_cw5n1h2txyewy\\\\ShellExperienceHost.exe\", \"windowName\": \"New notification\"}}"
+    "message": "{\"timestamp\": \"1733239748\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Session Window Closed\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"data\": {\"exeName\": \"C:\\\\Windows\\\\SystemApps\\\\ShellExperienceHost_cw5n1h2txyewy\\\\ShellExperienceHost.exe\", \"windowName\": \"New notification\"}}"
   },
   "expected": {
-    "message": "{\"timestamp\": \"1733239748\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"Session Window Closed\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"data\": {\"exeName\": \"C:\\\\Windows\\\\SystemApps\\\\ShellExperienceHost_cw5n1h2txyewy\\\\ShellExperienceHost.exe\", \"windowName\": \"New notification\"}}",
+    "message": "{\"timestamp\": \"1733239748\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Session Window Closed\", \"performed_by\": {\"type\": \"system\", \"name\": \"Privileged Remote Access\"}, \"data\": {\"exeName\": \"C:\\\\Windows\\\\SystemApps\\\\ShellExperienceHost_cw5n1h2txyewy\\\\ShellExperienceHost.exe\", \"windowName\": \"New notification\"}}",
     "event": {
       "category": [
         "session"
@@ -27,7 +27,7 @@
       }
     },
     "group": {
-      "name": "Sekoia.io integration"
+      "name": "EXAMPLE_JUMP_GROUP"
     },
     "observer": {
       "product": "Privileged Remote Access",

--- a/BeyondTrust/beyondtrust-pra-sessions/tests/test_special_action_executed.json
+++ b/BeyondTrust/beyondtrust-pra-sessions/tests/test_special_action_executed.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "message": "{\"timestamp\": \"1732810080\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"Special Action Executed\", \"performed_by\": {\"type\": \"representative\", \"name\": \"Admin\"}, \"data\": {\"action_name\": \"S\\u00e9curit\\u00e9 Windows (Ctrl-Alt-Suppr)\"}}"
+    "message": "{\"timestamp\": \"1732810080\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Special Action Executed\", \"performed_by\": {\"type\": \"representative\", \"name\": \"Admin\"}, \"data\": {\"action_name\": \"S\\u00e9curit\\u00e9 Windows (Ctrl-Alt-Suppr)\"}}"
   },
   "expected": {
-    "message": "{\"timestamp\": \"1732810080\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"Sekoia.io integration\", \"type\": \"shared\"}, \"event_type\": \"Special Action Executed\", \"performed_by\": {\"type\": \"representative\", \"name\": \"Admin\"}, \"data\": {\"action_name\": \"S\\u00e9curit\\u00e9 Windows (Ctrl-Alt-Suppr)\"}}",
+    "message": "{\"timestamp\": \"1732810080\", \"session_id\": \"1f344f8a38d14d1597b1c4188e0b6a55\", \"jump_group\": {\"name\": \"EXAMPLE_JUMP_GROUP\", \"type\": \"shared\"}, \"event_type\": \"Special Action Executed\", \"performed_by\": {\"type\": \"representative\", \"name\": \"Admin\"}, \"data\": {\"action_name\": \"S\\u00e9curit\\u00e9 Windows (Ctrl-Alt-Suppr)\"}}",
     "event": {
       "action": "S\u00e9curit\u00e9 Windows (Ctrl-Alt-Suppr)",
       "category": [
@@ -28,7 +28,7 @@
       }
     },
     "group": {
-      "name": "Sekoia.io integration"
+      "name": "EXAMPLE_JUMP_GROUP"
     },
     "observer": {
       "product": "Privileged Remote Access",


### PR DESCRIPTION
## Description

Relates to  https://github.com/SekoiaLab/integration/issues/1919

### Added

- Parse new ECS fields for participant identity and endpoint context in session events:
  - `destination.ip`
  - `destination.nat.ip`
  - `destination.nat.port`
  - `destination.user.full_name`
  - `destination.user.id`
  - `user.id`

- Parse new custom fields for the session representative and the session counters:
  - `beyondtrust.pra.destination_gsnumber`
  - `beyondtrust.pra.file_delete_count`
  - `beyondtrust.pra.file_move_count`
  - `beyondtrust.pra.file_transfer_count`
  - `beyondtrust.pra.primary_rep.gsnumber`
  - `beyondtrust.pra.primary_rep.name`

- Resolve the primary participants from the session-level `customer_list` and `rep_list` when the event references them by `gsnumber` only

### Changed

- Extend parsing of existing ECS fields for events carrying participant `public_ip`:
  - `source.nat.ip`
  - `source.nat.port`
- Anchor the grok pattern extracting the NAT address and port, to reject partial matches
- Filter the literal `Unknown` locally for `host.os.full`, instead of ignoring that value globally

## Summary by Sourcery

Enhance BeyondTrust PRA session parsing with complete participant context and session activity metadata.

New Features:
- Add ECS and BeyondTrust fields for session participants, endpoints, representative identity, and file operation counters.
- Resolve primary customer and representative details from session participant lists when events provide only their identifiers.

Bug Fixes:
- Improve BeyondTrust PRA session event parsing for participant network context and unresolved operating-system values.

Enhancements:
- Strengthen public IP and port parsing to accept only complete valid values and preserve event-specific host operating-system data.

Tests:
- Update existing parser fixtures and add coverage for participant-based session start and conference events.